### PR TITLE
backports/py-rospkg: fix runtime dependency to py_setuptools

### DIFF
--- a/backports/py-rospkg/APKBUILD
+++ b/backports/py-rospkg/APKBUILD
@@ -3,13 +3,13 @@
 pkgname=py-rospkg
 _pkgname=rospkg
 pkgver=1.1.7
-pkgrel=1
+pkgrel=2
 pkgdesc="Standalone Python library for the ROS package system"
 url="https://pypi.python.org/pypi/rospkg/"
 arch="all"
 license="BSD-3-Clause"
-depends="py-catkin-pkg py-yaml"
-makedepends="python2-dev python3-dev py-setuptools"
+depends="py-catkin-pkg py-yaml py-setuptools"
+makedepends="python2-dev python3-dev"
 subpackages="py2-${pkgname#py-}:_py2 py3-${pkgname#py-}:_py3"
 source="https://files.pythonhosted.org/packages/source/${_pkgname:0:1}/$_pkgname/$_pkgname-$pkgver.tar.gz"
 builddir="$srcdir/$_pkgname-$pkgver"


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/usr/bin/rosversion", line 6, in <module>
    from pkg_resources import load_entry_point
ImportError: No module named pkg_resources
Invalid <param> tag: Cannot load command parameter [rosversion]: command [rosversion roslaunch] returned with code [1]. 

Param xml is <param command="rosversion roslaunch" name="rosversion"/>
The traceback for the exception was written to the log file
```