### PR TITLE
backports/py-parameterized: backport

### DIFF
--- a/backports/py-parameterized/APKBUILD
+++ b/backports/py-parameterized/APKBUILD
@@ -1,0 +1,52 @@
+# Contributor: Stuart Cardall <developer@it-offshore.co.uk>
+# Maintainer: Stuart Cardall <developer@it-offshore.co.uk>
+pkgname=py-parameterized
+_pkgname=parameterized
+pkgver=0.7.0
+pkgrel=0
+pkgdesc="Parameterized testing with any Python test framework"
+url="https://pypi.python.org/pypi/parameterized"
+arch="noarch"
+license="BSD"
+depends=""
+makedepends="python2-dev python3-dev py-setuptools"
+checkdepends="py-nose py2-nose py-mock py2-mock"
+subpackages="py2-${pkgname#py-}:_py2 py3-${pkgname#py-}:_py3"
+source="$pkgname-$pkgver.tar.gz::https://files.pythonhosted.org/packages/source/p/parameterized/parameterized-$pkgver.tar.gz"
+builddir="$srcdir/"$_pkgname-$pkgver
+
+build() {
+	cd "$builddir"
+	python2 setup.py build
+	python3 setup.py build
+}
+
+check() {
+	cd "$builddir"
+	nosetests
+	nosetests-2.7
+}
+
+package() {
+	mkdir -p "$pkgdir"
+}
+
+_py2() {
+	_py python2
+}
+
+_py3() {
+	_py python3
+}
+
+_py() {
+	local python="$1"
+	pkgdesc="$pkgdesc (for $python)"
+	depends="$depends $python"
+	install_if="$pkgname=$pkgver-r$pkgrel $python"
+
+	cd "$builddir"
+	$python setup.py install --prefix=/usr --root="$subpkgdir"
+}
+
+sha512sums="b76e18a7eee62fcab4385fd5d053253c096d4c3fc3a6300e8539afc4d8decc995e533085297c52f8a26411d2591a326033a740cc30a250d510aa1c11ee904246  py-parameterized-0.7.0.tar.gz"


### PR DESCRIPTION
This file is the same one https://github.com/alpinelinux/aports/blob/master/testing/py-parameterized/APKBUILD

`parameterized` is used for test purpose.