### PR TITLE
Purge obsolete packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ $(REPOSITORY):
 		-v `pwd`/packages/v$(ALPINE_VERSION):/home/builder/packages \
 		$(PRIVATE_KEY_OPT) \
 		-e JOBS=${JOBS} \
+		-e PURGE_OBSOLETE=yes \
 		$(BUILDER_NAME):$(ALPINE_VERSION) $@
 
 .PHONY: s3-pull
@@ -33,7 +34,8 @@ s3-pull:
 
 .PHONY: s3-push
 s3-push:
-	aws s3 sync --acl=public-read packages/v$(ALPINE_VERSION) $(S3_APK_REPO_BUCKET_URI)/v$(ALPINE_VERSION)
+	aws s3 sync --acl=public-read --delete packages/v$(ALPINE_VERSION) $(S3_APK_REPO_BUCKET_URI)/v$(ALPINE_VERSION)
+	aws s3 sync --acl=public-read packages/v$(ALPINE_VERSION) $(S3_APK_REPO_BUCKET_URI)/archives/v$(ALPINE_VERSION)
 
 .PHONY: all
 all:

--- a/build-repo.sh
+++ b/build-repo.sh
@@ -8,6 +8,12 @@ repodir_base=${REPODIR}
 repo=${1:-backports}
 
 
+BUILD_REPO_OPTIONS=
+case "${PURGE_OBSOLETE:-no}" in
+  "y" | "yes" | "Yes" | "on" | "ON" ) BUILD_REPO_OPTIONS="-p";;
+esac
+
+
 # Disable stack protection to improve performance
 
 CFLAGS="-fno-stack-protector -fomit-frame-pointer -march=x86-64 -mtune=generic -Os"
@@ -87,7 +93,7 @@ sudo apk update
 
 (cd ${basedir} && \
   set -o pipefail && \
-  buildrepo ${repo} -d ${REPODIR} -a ${APORTSDIR} 2>&1 | \
+  buildrepo ${repo} -d ${REPODIR} -a ${APORTSDIR} ${BUILD_REPO_OPTIONS} 2>&1 | \
     grep --line-buffered \
       -v -e "([0-9]*/[0-9]*) Purging " \
       -v -e "([0-9]*/[0-9]*) Installing " \


### PR DESCRIPTION
All old packages are indexed at now. It makes build and sync slower.