### PR TITLE
backports/py-rospkg: upgrade to 1.1.10

### DIFF
--- a/backports/py-rospkg/APKBUILD
+++ b/backports/py-rospkg/APKBUILD
@@ -2,8 +2,8 @@
 # Maintainer:
 pkgname=py-rospkg
 _pkgname=rospkg
-pkgver=1.1.9
-pkgrel=1
+pkgver=1.1.10
+pkgrel=0
 pkgdesc="Standalone Python library for the ROS package system"
 url="https://pypi.python.org/pypi/rospkg/"
 arch="all"
@@ -49,4 +49,4 @@ _py() {
 	cd "$builddir"
 	$python setup.py install --prefix=/usr --root="$subpkgdir"
 }
-sha512sums="180006da6893c90cd1225437428c77aa5ae8456b4bd1ef6e70b72e40c264458b648c24b40886c3025ef56d06970b87ef1d17529b4333db7d837288c06c1937e1  rospkg-1.1.9.tar.gz"
+sha512sums="4bc43a32434cb192d275ea3397e54c5829e11e0c67dda55b3fe80981f9037d3fa2bf1232443e34c9d67f49eb37ec5318408c7a819e31e8a0da214881e9371745  rospkg-1.1.10.tar.gz"


### PR DESCRIPTION
for #110 