### PR TITLE
backports/py-(autobahn|txaio|trollius): new aports

### DIFF
--- a/backports/py-autobahn/APKBUILD
+++ b/backports/py-autobahn/APKBUILD
@@ -1,0 +1,53 @@
+# Contributor: Atsushi Watanabe<atsushi.w@ieee.org>
+# Maintainer:
+pkgname=py-autobahn
+_pkgname=autobahn
+pkgver=17.10.1
+pkgrel=0
+pkgdesc="WebSocket client & server library, WAMP real-time framework"
+url="https://crossbar.io/autobahn"
+arch="all"
+license="MIT"
+depends="py-six>=1.10.0 py-txaio>=2.7.0"
+makedepends="python2-dev python3-dev py-setuptools"
+subpackages="py2-${pkgname#py-}:_py2 py3-${pkgname#py-}:_py3"
+source="https://files.pythonhosted.org/packages/source/${_pkgname:0:1}/$_pkgname/$_pkgname-$pkgver.tar.gz"
+builddir="$srcdir/$_pkgname-$pkgver"
+
+build() {
+	cd "$builddir"
+	python2 setup.py build
+	python3 setup.py build
+}
+
+check() {
+	cd "$builddir"
+	python2 setup.py check
+	python3 setup.py check
+}
+
+package() {
+	mkdir -p "$pkgdir"
+}
+
+_py2() {
+	depends="${depends//py-/py2-}"
+	_py python2
+}
+
+_py3() {
+	depends="${depends//py-/py3-}"
+	_py python3
+}
+
+_py() {
+	local python="$1"
+	pkgdesc="$pkgdesc (for $python)"
+	depends="$depends $python"
+	install_if="$pkgname=$pkgver-r$pkgrel $python"
+
+	cd "$builddir"
+	$python setup.py install --prefix=/usr --root="$subpkgdir"
+}
+
+sha512sums="f26c1c88bea325136f640420ada0fc70e82397ed660056c18f68a2193f069c5fb5771ac620db1583f8c7938e804726d8885d237c925c4bd38d1a613a6aabc219  autobahn-17.10.1.tar.gz"

--- a/backports/py-trollius/APKBUILD
+++ b/backports/py-trollius/APKBUILD
@@ -1,0 +1,54 @@
+# Contributor: Atsushi Watanabe<atsushi.w@ieee.org>
+# Maintainer:
+pkgname=py-trollius
+_pkgname=trollius
+pkgver=2.2
+_pkgver=2.2.post1
+pkgrel=0
+pkgdesc="Deprecated, unmaintained port of the asyncio module (PEP 3156) on Python 2"
+url="https://pypi.org/project/trollius/"
+arch="all"
+license="Apache-2.0"
+depends="py-six"
+makedepends="python2-dev python3-dev py-setuptools"
+subpackages="py2-${pkgname#py-}:_py2 py3-${pkgname#py-}:_py3"
+source="https://files.pythonhosted.org/packages/source/${_pkgname:0:1}/$_pkgname/$_pkgname-$_pkgver.tar.gz"
+builddir="$srcdir/$_pkgname-$_pkgver"
+
+build() {
+	cd "$builddir"
+	python2 setup.py build
+	python3 setup.py build
+}
+
+check() {
+	cd "$builddir"
+	python2 setup.py check
+	python3 setup.py check
+}
+
+package() {
+	mkdir -p "$pkgdir"
+}
+
+_py2() {
+	depends="${depends//py-/py2-} py2-futures"
+	_py python2
+}
+
+_py3() {
+	depends="${depends//py-/py3-}"
+	_py python3
+}
+
+_py() {
+	local python="$1"
+	pkgdesc="$pkgdesc (for $python)"
+	depends="$depends $python"
+	install_if="$pkgname=$_pkgver-r$pkgrel $python"
+
+	cd "$builddir"
+	$python setup.py install --prefix=/usr --root="$subpkgdir"
+}
+
+sha512sums="6c4657abdcbcb5b31dfa740848c32d68dbfe691c1e6b6400bccf18047c0d00be604d6d0536ab99973ed24805a7bd8c17fe04c3d504570351dface3f0162e6d09  trollius-2.2.post1.tar.gz"

--- a/backports/py-txaio/APKBUILD
+++ b/backports/py-txaio/APKBUILD
@@ -1,0 +1,53 @@
+# Contributor: Atsushi Watanabe<atsushi.w@ieee.org>
+# Maintainer:
+pkgname=py-txaio
+_pkgname=txaio
+pkgver=2.7.1
+pkgrel=0
+pkgdesc="Compatibility API between asyncio/Twisted/Trollius"
+url="https://crossbar.io/txaio"
+arch="all"
+license="MIT"
+depends="py-six"
+makedepends="python2-dev python3-dev py-setuptools"
+subpackages="py2-${pkgname#py-}:_py2 py3-${pkgname#py-}:_py3"
+source="https://files.pythonhosted.org/packages/source/${_pkgname:0:1}/$_pkgname/$_pkgname-$pkgver.tar.gz"
+builddir="$srcdir/$_pkgname-$pkgver"
+
+build() {
+	cd "$builddir"
+	python2 setup.py build
+	python3 setup.py build
+}
+
+check() {
+	cd "$builddir"
+	python2 setup.py check
+	python3 setup.py check
+}
+
+package() {
+	mkdir -p "$pkgdir"
+}
+
+_py2() {
+	depends="${depends//py-/py2-} py2-futures>=3.0.4 py2-trollius>=2.0"
+	_py python2
+}
+
+_py3() {
+	depends="${depends//py-/py3-}"
+	_py python3
+}
+
+_py() {
+	local python="$1"
+	pkgdesc="$pkgdesc (for $python)"
+	depends="$depends $python"
+	install_if="$pkgname=$pkgver-r$pkgrel $python"
+
+	cd "$builddir"
+	$python setup.py install --prefix=/usr --root="$subpkgdir"
+}
+
+sha512sums="d77a8b5e8fc21be0bef43f2a6795229456a351abc1a5eb6d2b7de0da0a58e67a228cb06d1a7962efcc760099ef5df94e9421875ea5628985260911efc7deb85e  txaio-2.7.1.tar.gz"


### PR DESCRIPTION
required by the latest rosbridge.

fix #163