### PR TITLE
backports/py-opengl: fix py-opengl pkgname

### DIFF
--- a/backports/py-opengl/APKBUILD
+++ b/backports/py-opengl/APKBUILD
@@ -1,9 +1,9 @@
 # Contributor: Francesco Colista <fcolista@alpinelinux.org>
 # Maintainer: Francesco Colista <fcolista@alpinelinux.org>
-pkgname=py-opengl
+pkgname=py2-opengl
 _pkgname=PyOpenGL
 pkgver=3.1.1a1
-pkgrel=3
+pkgrel=4
 pkgdesc="Standard OpenGL bindings for Python"
 url="http://pyopengl.sourceforge.net"
 arch="noarch"
@@ -14,6 +14,9 @@ makedepends="$depends_dev python2-dev py-setuptools freeglut-dev"
 install=""
 subpackages=""
 source="https://files.pythonhosted.org/packages/source/P/PyOpenGL/$_pkgname-$pkgver.tar.gz"
+
+replaces="py-opengl" # Backwards compatibility
+provides="py-opengl=$pkgver-r$pkgrel" # Backwards compatibility
 
 builddir="$srcdir"/$_pkgname-$pkgver
 build() {


### PR DESCRIPTION
To make package name consistent between python versions.