### PR TITLE
Add patch to allow inserting TF with same timestamp

### DIFF
--- a/ros/noetic/tf2/00-allow-tf-repeated.patch
+++ b/ros/noetic/tf2/00-allow-tf-repeated.patch
@@ -1,0 +1,45 @@
+diff --git a/tf2/src/cache.cpp b/tf2/src/cache.cpp
+index f9614c7..3994ab2 100644
+--- a/tf2/src/cache.cpp
++++ b/tf2/src/cache.cpp
+@@ -40,6 +40,8 @@
+ 
+ namespace tf2 {
+ 
++const static bool ALLOW_TF_REAPEATED = std::getenv("ALLOW_TF_REPEATED") == "true";
++
+ TransformStorage::TransformStorage()
+ {
+ }
+@@ -273,17 +275,24 @@ bool TimeCache::insertData(const TransformStorage& new_data, std::string* error_
+       break;
+     storage_it++;
+   }
+-  if (storage_it != storage_.end() && storage_it->stamp_ == new_data.stamp_)
++  if (ALLOW_TF_REAPEATED)
+   {
+-    if (error_str)
+-    {
+-      *error_str = "TF_REPEATED_DATA ignoring data with redundant timestamp";
+-    }
+-    return false;
++    storage_.insert(storage_it, new_data);
+   }
+   else
+   {
+-    storage_.insert(storage_it, new_data);
++    if (storage_it != storage_.end() && storage_it->stamp_ == new_data.stamp_)
++    {
++      if (error_str)
++      {
++        *error_str = "TF_REPEATED_DATA ignoring data with redundant timestamp";
++      }
++      return false;
++    }
++    else
++    {
++      storage_.insert(storage_it, new_data);
++    }
+   }
+ 
+   pruneList();

--- a/ros/noetic/tf2/00-allow-tf-repeated.patch
+++ b/ros/noetic/tf2/00-allow-tf-repeated.patch
@@ -1,11 +1,11 @@
-diff --git a/tf2/src/cache.cpp b/tf2/src/cache.cpp
+diff --git a/src/cache.cpp b/src/cache.cpp
 index f9614c7..3994ab2 100644
---- a/tf2/src/cache.cpp
-+++ b/tf2/src/cache.cpp
+--- a/src/cache.cpp
++++ b/src/cache.cpp
 @@ -40,6 +40,8 @@
- 
+
  namespace tf2 {
- 
+
 +const static bool ALLOW_TF_REAPEATED = std::getenv("ALLOW_TF_REPEATED") == "true";
 +
  TransformStorage::TransformStorage()
@@ -41,5 +41,5 @@ index f9614c7..3994ab2 100644
 +      storage_.insert(storage_it, new_data);
 +    }
    }
- 
+
    pruneList();

--- a/ros/noetic/tf2/APKBUILD
+++ b/ros/noetic/tf2/APKBUILD
@@ -1,7 +1,7 @@
 pkgname=ros-noetic-tf2
 _pkgname=tf2
 pkgver=0.7.5
-pkgrel=0
+pkgrel=1
 pkgdesc="$_pkgname package for ROS noetic"
 url="http://www.ros.org/wiki/tf2"
 arch="all"


### PR DESCRIPTION
This PR adds a short term patch to the ongoing issue in `tf2`: https://github.com/ros/geometry2/issues/467
It enables the user to use TF with the behavior before this commit https://github.com/ros/geometry2/commit/eefb50935bfd28223c87b3d708e916f7bcc4b4ca.

It can be turned on by setting `ALLOW_TF_REPEATED` to `true`.