### PR TITLE
Fix noetic tf2 0.7.5.patch

### DIFF
--- a/ros/noetic/tf2/00-allow-tf-repeated.patch
+++ b/ros/noetic/tf2/00-allow-tf-repeated.patch
@@ -1,12 +1,43 @@
+diff --git a/include/tf2/transform_storage.h b/include/tf2/transform_storage.h
+index 7856bb8..b611a02 100644
+--- a/include/tf2/transform_storage.h
++++ b/include/tf2/transform_storage.h
+@@ -73,11 +73,26 @@ public:
+     return *this;
+   }
+ 
++  static bool allow_tf_repeated()
++  {
++    static bool allow_tf_repeated_checked = false;
++    if (!allow_tf_repeated_checked)
++    {
++      const char* env_var = std::getenv("ALLOW_TF_REPEATED");
++      allow_tf_repeated_ = env_var ? std::string(env_var) == "true" : false;
++      allow_tf_repeated_checked = true;
++    }
++    return allow_tf_repeated_;
++  }
++
+   tf2::Quaternion rotation_;
+   tf2::Vector3 translation_;
+   ros::Time stamp_;
+   CompactFrameID frame_id_;
+   CompactFrameID child_frame_id_;
++
++private:
++  static bool allow_tf_repeated_;
+ };
+ 
+ }
 diff --git a/src/cache.cpp b/src/cache.cpp
-index f9614c7..3994ab2 100644
+index f9614c7..ea3c28f 100644
 --- a/src/cache.cpp
 +++ b/src/cache.cpp
 @@ -40,6 +40,8 @@
-
+ 
  namespace tf2 {
-
-+const static bool ALLOW_TF_REAPEATED = std::getenv("ALLOW_TF_REPEATED") == "true";
+ 
++bool TransformStorage::allow_tf_repeated_;
 +
  TransformStorage::TransformStorage()
  {
@@ -16,7 +47,7 @@ index f9614c7..3994ab2 100644
      storage_it++;
    }
 -  if (storage_it != storage_.end() && storage_it->stamp_ == new_data.stamp_)
-+  if (ALLOW_TF_REAPEATED)
++  if (TransformStorage::allow_tf_repeated())
    {
 -    if (error_str)
 -    {
@@ -41,5 +72,5 @@ index f9614c7..3994ab2 100644
 +      storage_.insert(storage_it, new_data);
 +    }
    }
-
+ 
    pruneList();

--- a/ros/noetic/tf2/00-allow-tf-repeated.patch
+++ b/ros/noetic/tf2/00-allow-tf-repeated.patch
@@ -1,43 +1,12 @@
-diff --git a/include/tf2/transform_storage.h b/include/tf2/transform_storage.h
-index 7856bb8..b611a02 100644
---- a/include/tf2/transform_storage.h
-+++ b/include/tf2/transform_storage.h
-@@ -73,11 +73,26 @@ public:
-     return *this;
-   }
- 
-+  static bool allow_tf_repeated()
-+  {
-+    static bool allow_tf_repeated_checked = false;
-+    if (!allow_tf_repeated_checked)
-+    {
-+      const char* env_var = std::getenv("ALLOW_TF_REPEATED");
-+      allow_tf_repeated_ = env_var ? std::string(env_var) == "true" : false;
-+      allow_tf_repeated_checked = true;
-+    }
-+    return allow_tf_repeated_;
-+  }
-+
-   tf2::Quaternion rotation_;
-   tf2::Vector3 translation_;
-   ros::Time stamp_;
-   CompactFrameID frame_id_;
-   CompactFrameID child_frame_id_;
-+
-+private:
-+  static bool allow_tf_repeated_;
- };
- 
- }
 diff --git a/src/cache.cpp b/src/cache.cpp
-index f9614c7..ea3c28f 100644
+index f9614c7..117aece 100644
 --- a/src/cache.cpp
 +++ b/src/cache.cpp
 @@ -40,6 +40,8 @@
  
  namespace tf2 {
  
-+bool TransformStorage::allow_tf_repeated_;
++const static bool ALLOW_TF_REPEATED = std::getenv("ALLOW_TF_REPEATED") ? std::string(std::getenv("ALLOW_TF_REPEATED")) == "true" : false;
 +
  TransformStorage::TransformStorage()
  {
@@ -47,7 +16,7 @@ index f9614c7..ea3c28f 100644
      storage_it++;
    }
 -  if (storage_it != storage_.end() && storage_it->stamp_ == new_data.stamp_)
-+  if (TransformStorage::allow_tf_repeated())
++  if (ALLOW_TF_REPEATED)
    {
 -    if (error_str)
 -    {

--- a/ros/noetic/tf2/APKBUILD
+++ b/ros/noetic/tf2/APKBUILD
@@ -1,7 +1,7 @@
 pkgname=ros-noetic-tf2
 _pkgname=tf2
 pkgver=0.7.5
-pkgrel=1
+pkgrel=2
 pkgdesc="$_pkgname package for ROS noetic"
 url="http://www.ros.org/wiki/tf2"
 arch="all"


### PR DESCRIPTION
~~The previous patch does not allow the user to toggle the desired behavior at runtime. It requires compiling the `tf2` package again. This one does. One potential downside is allowing to have nodes using different implementation of the `insertData` method in `tf2` e.g. start one node using `tf2` with `ALLOW_TF_REPEATED` set to `true` then `export ALLOW_TF_REPEATED=false` before starting another node using `tf2` as well.~~

The patch was just not working as intended. See comment below.