### PR TITLE
Use 0.4.23 version of py-catkin-pkg

### DIFF
--- a/backports/py-catkin-pkg/APKBUILD
+++ b/backports/py-catkin-pkg/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer:
 pkgname=py-catkin-pkg
 _pkgname=catkin_pkg
-pkgver=0.4.16
+pkgver=0.4.23
 pkgrel=0
 pkgdesc="Library for retrieving information about catkin packages"
 url="https://pypi.python.org/pypi/catkin_pkg/"
@@ -54,5 +54,5 @@ _py() {
 	$python setup.py install --prefix=/usr --root="$subpkgdir"
 }
 
-sha512sums="e4589b22823688561af2ef6e583d14280705e5fcc6e397d6e329e83f2cf4626fef538428e234590cf4522a90cecfc18184bec43ff1c19deafed60feba33bf683  catkin_pkg-0.4.16.tar.gz
+sha512sums="6f0bec590ad85a74781a445bf5d5923acb8f45fd446decfa69eec5d6136dd90c3e95f1fef89bb6e1ed5613e04ced132d7bc3d48e072cd83ca07ec745ec9ed369  catkin_pkg-0.4.23.tar.gz
 0f08e51d22524882cb68829364ccbd4632633107b23096f4bc6c7fd31b8c9f9f1ae64d2bb3fa02f84f52c38c08eb35a58d10b28001c7d26b4c39e7250b9b6913  LICENSE"


### PR DESCRIPTION
Update `pkgver` and `sha512sums` to use `0.4.23`.