### PR TITLE
Compile glog without gflags

### DIFF
--- a/backports/glog/APKBUILD
+++ b/backports/glog/APKBUILD
@@ -1,13 +1,13 @@
 # Contributor: Florent Ferreri <florent@seqsense.com>
 pkgname=glog
 pkgver=0.4.0
-pkgrel=0
+pkgrel=1
 pkgdesc="C++ implementation of the Google logging module"
 url="https://github.com/google/glog"
 arch="all"
 license="BSD-3-Clause"
 options=""
-makedepends="cmake gflags-dev"
+makedepends="cmake"
 subpackages="$pkgname-dev $pkgname-doc"
 source="$pkgname-$pkgver.tar.gz::https://github.com/google/$pkgname/archive/refs/tags/v${pkgver}.tar.gz"
 builddir="$srcdir/$pkgname-$pkgver"
@@ -15,7 +15,7 @@ builddir="$srcdir/$pkgname-$pkgver"
 build() {
     mkdir build
     cd build
-    cmake -S .. -G "Unix Makefiles" -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=none
+    cmake -S .. -G "Unix Makefiles" -DWITH_GFLAGS=OFF -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=none
     cd ..
     cmake --build build
 }


### PR DESCRIPTION
This PR provides a solution to error such as the following when linking with `glog`
```
../libifm3d_tools/libifm3d_tools.so.0.18.0: undefined reference to `google::FlagRegisterer::FlagRegisterer<int>(char const*, char const*, char const*, int*, int*)'
../libifm3d_tools/libifm3d_tools.so.0.18.0: undefined reference to `google::FlagRegisterer::FlagRegisterer<bool>(char const*, char const*, char const*, bool*, bool*)'
../libifm3d_tools/libifm3d_tools.so.0.18.0: undefined reference to `google::FlagRegisterer::FlagRegisterer<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >(char const*, char const*, char const*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >*)'
collect2: error: ld returned 1 exit status
```

Example build log: https://s3-ap-northeast-1.amazonaws.com/alpine-ros-experimental.dev-sq.work/build_logs/91f708fc-6716-42fa-98ca-84b2056bb825