### PR TITLE
Update the sha512sum for the patch file in ifm3d

### DIFF
--- a/backports/ifm3d/APKBUILD
+++ b/backports/ifm3d/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Florent Ferreri <florent@seqsense.com>
 pkgname=ifm3d
 pkgver=0.18.0
-pkgrel=0
+pkgrel=1
 pkgdesc="Library and Utilities for working with ifm pmd-based 3D ToF Cameras"
 url="https://github.com/ifm/ifm3d"
 arch="all"
@@ -36,4 +36,4 @@ package() {
 }
 
 sha512sums="6882065e7eefc509c59467fe341ef4dccdc2e7db9525f9036ac19887d369576925b66adf2dc974aaabac72f6ffd0028ae0dac1902c0319f85e2b27ac33a2063a  ifm3d-0.18.0.tar.gz
-50fb79d73ccd3b2f8c8a2bedbb40f2d3435337fafb3823e8e386e15c9d37b3ddcdcf469aa2c4aebd3a82a04c15e4d9fef6f39d750fcfa7fcf9748111665aa729  endianness-check-fix.patch"
+68bbcd63a7c175c8159fdab07f23518741fd93515034ccf27008205ff70ab9dbf438a89590c111f70ad742bef6a51f53719b91886dc9d602bf0f4cfccfe8fb2e  endianness-check-fix.patch"


### PR DESCRIPTION
I forgot to update the `sha512sum` corresponding to the patch file after changing it in https://github.com/seqsense/aports-ros-experimental/pull/480