### PR TITLE
backports/py3-rosdep: add dependency to setuptools

### DIFF
--- a/backports/py3-rosdep/APKBUILD
+++ b/backports/py3-rosdep/APKBUILD
@@ -3,13 +3,13 @@
 pkgname=py3-rosdep
 _pkgname=rosdep
 pkgver=0.19.0
-pkgrel=1
+pkgrel=2
 pkgdesc="rosdep package manager abstraction tool for ROS"
 url="https://pypi.python.org/pypi/rosdep/"
 arch="noarch"
 license="BSD-3-Clause"
-depends="py3-catkin-pkg>=0.4.0 py3-rospkg>=1.1.10 py3-rosdistro>=0.7.5 py3-yaml>=3.1"
-makedepends="python3-dev py3-setuptools git"
+depends="py3-catkin-pkg>=0.4.0 py3-rospkg>=1.1.10 py3-rosdistro>=0.7.5 py3-yaml>=3.1 py3-setuptools"
+makedepends="python3-dev git"
 subpackages="$pkgname-doc"
 source="https://files.pythonhosted.org/packages/source/${_pkgname:0:1}/$_pkgname/$_pkgname-$pkgver.tar.gz
 	LICENSE"


### PR DESCRIPTION
Fix https://github.com/alpine-ros/alpine-ros/pull/15/checks?check_run_id=2880238004#step:3:88
```
Traceback (most recent call last):
  File "/usr/bin/rosdep", line 33, in <module>
    sys.exit(load_entry_point('rosdep==0.19.0', 'console_scripts', 'rosdep')())
  File "/usr/bin/rosdep", line 25, in importlib_load_entry_point
    return next(matches).load()
  File "/usr/lib/python3.9/importlib/metadata.py", line 77, in load
    module = import_module(match.group('module'))
  File "/usr/lib/python3.9/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
  File "<frozen importlib._bootstrap>", line 972, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
  File "<frozen importlib._bootstrap>", line 986, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 680, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 855, in exec_module
  File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
  File "/usr/lib/python3.9/site-packages/rosdep2/__init__.py", line 45, in <module>
    from .lookup import RosdepDefinition, RosdepView, RosdepLookup, \
  File "/usr/lib/python3.9/site-packages/rosdep2/lookup.py", line 44, in <module>
    from .sources_list import SourcesListLoader
  File "/usr/lib/python3.9/site-packages/rosdep2/sources_list.py", line 48, in <module>
    from .gbpdistro_support import get_gbprepo_as_rosdep_data, download_gbpdistro_as_rosdep_data
  File "/usr/lib/python3.9/site-packages/rosdep2/gbpdistro_support.py", line 18, in <module>
    from .platforms.debian import APT_INSTALLER
  File "/usr/lib/python3.9/site-packages/rosdep2/platforms/debian.py", line 36, in <module>
    from .pip import PIP_INSTALLER
  File "/usr/lib/python3.9/site-packages/rosdep2/platforms/pip.py", line 33, in <module>
    import pkg_resources
ModuleNotFoundError: No module named 'pkg_resources'
The command '/bin/sh -c apk add --no-cache py3-rosdep   && rosdep init   && sed -i -e 's/ros\/rosdistro\/master/alpine-ros\/rosdistro\/alpine-custom-apk/' /etc/ros/rosdep/sources.list.d/20-default.list' returned a non-zero code: 1
```