### PR TITLE
Revert rviz to previous version (1.14.8 noetic, 1.13.8 melodic)

### DIFF
--- a/ros/melodic/ros-melodic-rviz/APKBUILD
+++ b/ros/melodic/ros-melodic-rviz/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-melodic-rviz
 _pkgname=rviz
-pkgver=1.13.19
+pkgver=1.13.18
 pkgrel=0
 pkgdesc="$_pkgname package for ROS melodic"
 url="http://wiki.ros.org/rviz"
@@ -25,7 +25,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
 fi
 
 export ROS_PYTHON_VERSION=2
-rosinstall="- git: {local-name: rviz, uri: 'https://github.com/ros-gbp/rviz-release.git', version: release/melodic/rviz/1.13.19-1}
+rosinstall="- git: {local-name: rviz, uri: 'https://github.com/ros-gbp/rviz-release.git', version: release/melodic/rviz/1.13.18-1}
 "
 
 prepare() {

--- a/ros/noetic.v3.14/ros-noetic-rviz/APKBUILD
+++ b/ros/noetic.v3.14/ros-noetic-rviz/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-noetic-rviz
 _pkgname=rviz
-pkgver=1.14.9
+pkgver=1.14.8
 pkgrel=0
 pkgdesc="$_pkgname package for ROS noetic"
 url="http://wiki.ros.org/rviz"
@@ -28,7 +28,7 @@ export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: rviz
     uri: https://github.com/ros-gbp/rviz-release.git
-    version: release/noetic/rviz/1.14.9-2
+    version: release/noetic/rviz/1.14.8-1
 "
 
 prepare() {

--- a/ros/noetic/ros-noetic-rviz/APKBUILD
+++ b/ros/noetic/ros-noetic-rviz/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-noetic-rviz
 _pkgname=rviz
-pkgver=1.14.9
+pkgver=1.14.8
 pkgrel=0
 pkgdesc="$_pkgname package for ROS noetic"
 url="http://wiki.ros.org/rviz"
@@ -28,7 +28,7 @@ export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: rviz
     uri: https://github.com/ros-gbp/rviz-release.git
-    version: release/noetic/rviz/1.14.9-2
+    version: release/noetic/rviz/1.14.8-1
 "
 
 prepare() {


### PR DESCRIPTION
The latest version of `rviz` (`1.14.9`) has a bug when visualizing `PointCloud2` messages (https://github.com/ros-visualization/rviz/issues/1666). I think it is better to revert to the previous version for now (`1.14.8`). An alternative would be to patch the current version with the suggested fix from the issue.