### PR TITLE
gflags: build shared library

### DIFF
--- a/backports/gflags.v3.8/APKBUILD
+++ b/backports/gflags.v3.8/APKBUILD
@@ -6,7 +6,6 @@ pkgdesc="The gflags package contains a C++ library that implements commandline f
 url="https://github.com/gflags/gflags"
 arch="all"
 license="BSD-3-Clause"
-options="!check" # Tests #17 and #18 (helpon=gflags) fail when running make test
 makedepends="cmake"
 subpackages="$pkgname-dev $pkgname-doc"
 source="$pkgname-$pkgver.tar.gz::https://github.com/gflags/$pkgname/archive/refs/tags/v${pkgver}.tar.gz"
@@ -22,6 +21,11 @@ build() {
       -DCMAKE_BUILD_TYPE=none \
       -DREGISTER_INSTALL_PREFIX=OFF
     make
+}
+
+check() {
+  cd "$builddir"/build
+  make test
 }
 
 package() {

--- a/backports/gflags.v3.8/APKBUILD
+++ b/backports/gflags.v3.8/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Florent Ferreri <florent@seqsense.com>
 pkgname=gflags
 pkgver=2.2.2
-pkgrel=0
+pkgrel=1
 pkgdesc="The gflags package contains a C++ library that implements commandline flags processing."
 url="https://github.com/gflags/gflags"
 arch="all"
@@ -13,9 +13,14 @@ source="$pkgname-$pkgver.tar.gz::https://github.com/gflags/$pkgname/archive/refs
 builddir="$srcdir/$pkgname-$pkgver"
 
 build() {
-    mkdir build
-    cd build
-    cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=none ..
+    mkdir build && cd build
+    cmake .. \
+      -DBUILD_STATIC_LIBS=ON \
+      -DBUILD_SHARED_LIBS=ON \
+      -DBUILD_TESTING=ON \
+      -DCMAKE_INSTALL_PREFIX=/usr \
+      -DCMAKE_BUILD_TYPE=none \
+      -DREGISTER_INSTALL_PREFIX=OFF
     make
 }
 

--- a/backports/gflags.v3.8/APKBUILD
+++ b/backports/gflags.v3.8/APKBUILD
@@ -6,6 +6,7 @@ pkgdesc="The gflags package contains a C++ library that implements commandline f
 url="https://github.com/gflags/gflags"
 arch="all"
 license="BSD-3-Clause"
+options="!check" # Tests #17 and #18 (helpon=gflags) fail when running make test
 makedepends="cmake"
 subpackages="$pkgname-dev $pkgname-doc"
 source="$pkgname-$pkgver.tar.gz::https://github.com/gflags/$pkgname/archive/refs/tags/v${pkgver}.tar.gz"
@@ -21,11 +22,6 @@ build() {
       -DCMAKE_BUILD_TYPE=none \
       -DREGISTER_INSTALL_PREFIX=OFF
     make
-}
-
-check() {
-  cd "$builddir"/build
-  make test
 }
 
 package() {

--- a/backports/gflags.v3.8/APKBUILD
+++ b/backports/gflags.v3.8/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Florent Ferreri <florent@seqsense.com>
 pkgname=gflags
 pkgver=2.2.2
-pkgrel=1
+pkgrel=2
 pkgdesc="The gflags package contains a C++ library that implements commandline flags processing."
 url="https://github.com/gflags/gflags"
 arch="all"


### PR DESCRIPTION
This PR fixes the `gflags` backport on alpine 3.8. to also build the shared library. This seems to be necessary to fix the issue encountered in https://github.com/seqsense/aports-ros-experimental/runs/6226227388