### PR TITLE
noetic-3.14: automatic update on 20221031-083524

### DIFF
--- a/ros/noetic.v3.14/ros-noetic-camera-calibration/APKBUILD
+++ b/ros/noetic.v3.14/ros-noetic-camera-calibration/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-noetic-camera-calibration
 _pkgname=camera_calibration
-pkgver=1.16.0
+pkgver=1.17.0
 pkgrel=0
 pkgdesc="$_pkgname package for ROS noetic"
 url="http://www.ros.org/wiki/camera_calibration"
@@ -28,7 +28,7 @@ export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: camera_calibration
     uri: https://github.com/ros-gbp/image_pipeline-release.git
-    version: release/noetic/camera_calibration/1.16.0-1
+    version: release/noetic/camera_calibration/1.17.0-1
 "
 
 prepare() {

--- a/ros/noetic.v3.14/ros-noetic-combined-robot-hw/APKBUILD
+++ b/ros/noetic.v3.14/ros-noetic-combined-robot-hw/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-noetic-combined-robot-hw
 _pkgname=combined_robot_hw
-pkgver=0.19.5
+pkgver=0.19.6
 pkgrel=0
 pkgdesc="$_pkgname package for ROS noetic"
 url="https://github.com/ros-controls/ros_control/wiki"
@@ -28,7 +28,7 @@ export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: combined_robot_hw
     uri: https://github.com/ros-gbp/ros_control-release.git
-    version: release/noetic/combined_robot_hw/0.19.5-1
+    version: release/noetic/combined_robot_hw/0.19.6-1
 "
 
 prepare() {

--- a/ros/noetic.v3.14/ros-noetic-controller-interface/APKBUILD
+++ b/ros/noetic.v3.14/ros-noetic-controller-interface/APKBUILD
@@ -1,7 +1,7 @@
 pkgname=ros-noetic-controller-interface
 _pkgname=controller_interface
-pkgver=0.19.5
-pkgrel=2
+pkgver=0.19.6
+pkgrel=0
 pkgdesc="$_pkgname package for ROS noetic"
 url="https://github.com/ros-controls/ros_control/wiki"
 arch="all"
@@ -28,7 +28,7 @@ export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: controller_interface
     uri: https://github.com/ros-gbp/ros_control-release.git
-    version: release/noetic/controller_interface/0.19.5-1
+    version: release/noetic/controller_interface/0.19.6-1
 "
 
 prepare() {

--- a/ros/noetic.v3.14/ros-noetic-controller-manager-msgs/APKBUILD
+++ b/ros/noetic.v3.14/ros-noetic-controller-manager-msgs/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-noetic-controller-manager-msgs
 _pkgname=controller_manager_msgs
-pkgver=0.19.5
+pkgver=0.19.6
 pkgrel=0
 pkgdesc="$_pkgname package for ROS noetic"
 url="https://github.com/ros-controls/ros_control/wiki"
@@ -28,7 +28,7 @@ export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: controller_manager_msgs
     uri: https://github.com/ros-gbp/ros_control-release.git
-    version: release/noetic/controller_manager_msgs/0.19.5-1
+    version: release/noetic/controller_manager_msgs/0.19.6-1
 "
 
 prepare() {

--- a/ros/noetic.v3.14/ros-noetic-controller-manager/APKBUILD
+++ b/ros/noetic.v3.14/ros-noetic-controller-manager/APKBUILD
@@ -1,7 +1,7 @@
 pkgname=ros-noetic-controller-manager
 _pkgname=controller_manager
-pkgver=0.19.5
-pkgrel=2
+pkgver=0.19.6
+pkgrel=0
 pkgdesc="$_pkgname package for ROS noetic"
 url="https://github.com/ros-controls/ros_control/wiki"
 arch="all"
@@ -28,7 +28,7 @@ export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: controller_manager
     uri: https://github.com/ros-gbp/ros_control-release.git
-    version: release/noetic/controller_manager/0.19.5-1
+    version: release/noetic/controller_manager/0.19.6-1
 "
 
 prepare() {

--- a/ros/noetic.v3.14/ros-noetic-depth-image-proc/APKBUILD
+++ b/ros/noetic.v3.14/ros-noetic-depth-image-proc/APKBUILD
@@ -1,13 +1,13 @@
 pkgname=ros-noetic-depth-image-proc
 _pkgname=depth_image_proc
-pkgver=1.16.0
+pkgver=1.17.0
 pkgrel=0
 pkgdesc="$_pkgname package for ROS noetic"
 url="http://ros.org/wiki/depth_image_proc"
 arch="all"
 license="BSD"
 
-depends="boost-dev ros-noetic-cv-bridge ros-noetic-eigen-conversions ros-noetic-image-geometry ros-noetic-image-transport ros-noetic-nodelet ros-noetic-tf2 ros-noetic-tf2-ros boost-dev ros-noetic-cv-bridge ros-noetic-eigen-conversions ros-noetic-image-geometry ros-noetic-image-transport ros-noetic-nodelet ros-noetic-tf2 ros-noetic-tf2-ros"
+depends="boost-dev ros-noetic-cv-bridge ros-noetic-eigen-conversions ros-noetic-image-geometry ros-noetic-image-transport ros-noetic-nodelet ros-noetic-sensor-msgs ros-noetic-tf2 ros-noetic-tf2-ros boost-dev ros-noetic-cv-bridge ros-noetic-eigen-conversions ros-noetic-image-geometry ros-noetic-image-transport ros-noetic-nodelet ros-noetic-sensor-msgs ros-noetic-tf2 ros-noetic-tf2-ros"
 makedepends="py3-setuptools py3-rosdep py3-rosinstall py3-rosinstall-generator py3-vcstool chrpath boost-dev ros-noetic-catkin ros-noetic-cmake-modules ros-noetic-cv-bridge ros-noetic-eigen-conversions ros-noetic-image-geometry ros-noetic-image-transport ros-noetic-message-filters ros-noetic-nodelet ros-noetic-rostest ros-noetic-sensor-msgs ros-noetic-stereo-msgs ros-noetic-tf2 ros-noetic-tf2-ros"
 
 subpackages="$pkgname-dbg $pkgname-doc"
@@ -28,7 +28,7 @@ export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: depth_image_proc
     uri: https://github.com/ros-gbp/image_pipeline-release.git
-    version: release/noetic/depth_image_proc/1.16.0-1
+    version: release/noetic/depth_image_proc/1.17.0-1
 "
 
 prepare() {

--- a/ros/noetic.v3.14/ros-noetic-hardware-interface/APKBUILD
+++ b/ros/noetic.v3.14/ros-noetic-hardware-interface/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-noetic-hardware-interface
 _pkgname=hardware_interface
-pkgver=0.19.5
+pkgver=0.19.6
 pkgrel=0
 pkgdesc="$_pkgname package for ROS noetic"
 url="https://github.com/ros-controls/ros_control/wiki"
@@ -28,7 +28,7 @@ export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: hardware_interface
     uri: https://github.com/ros-gbp/ros_control-release.git
-    version: release/noetic/hardware_interface/0.19.5-1
+    version: release/noetic/hardware_interface/0.19.6-1
 "
 
 prepare() {

--- a/ros/noetic.v3.14/ros-noetic-image-pipeline/APKBUILD
+++ b/ros/noetic.v3.14/ros-noetic-image-pipeline/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-noetic-image-pipeline
 _pkgname=image_pipeline
-pkgver=1.16.0
+pkgver=1.17.0
 pkgrel=0
 pkgdesc="$_pkgname package for ROS noetic"
 url="http://www.ros.org/wiki/image_pipeline"
@@ -28,7 +28,7 @@ export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: image_pipeline
     uri: https://github.com/ros-gbp/image_pipeline-release.git
-    version: release/noetic/image_pipeline/1.16.0-1
+    version: release/noetic/image_pipeline/1.17.0-1
 "
 
 prepare() {

--- a/ros/noetic.v3.14/ros-noetic-image-proc/APKBUILD
+++ b/ros/noetic.v3.14/ros-noetic-image-proc/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-noetic-image-proc
 _pkgname=image_proc
-pkgver=1.16.0
+pkgver=1.17.0
 pkgrel=0
 pkgdesc="$_pkgname package for ROS noetic"
 url="http://www.ros.org/wiki/image_proc"
@@ -28,7 +28,7 @@ export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: image_proc
     uri: https://github.com/ros-gbp/image_pipeline-release.git
-    version: release/noetic/image_proc/1.16.0-1
+    version: release/noetic/image_proc/1.17.0-1
 "
 
 prepare() {

--- a/ros/noetic.v3.14/ros-noetic-image-publisher/APKBUILD
+++ b/ros/noetic.v3.14/ros-noetic-image-publisher/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-noetic-image-publisher
 _pkgname=image_publisher
-pkgver=1.16.0
+pkgver=1.17.0
 pkgrel=0
 pkgdesc="$_pkgname package for ROS noetic"
 url="http://ros.org/wiki/image_publisher"
@@ -28,7 +28,7 @@ export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: image_publisher
     uri: https://github.com/ros-gbp/image_pipeline-release.git
-    version: release/noetic/image_publisher/1.16.0-1
+    version: release/noetic/image_publisher/1.17.0-1
 "
 
 prepare() {

--- a/ros/noetic.v3.14/ros-noetic-image-rotate/APKBUILD
+++ b/ros/noetic.v3.14/ros-noetic-image-rotate/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-noetic-image-rotate
 _pkgname=image_rotate
-pkgver=1.16.0
+pkgver=1.17.0
 pkgrel=0
 pkgdesc="$_pkgname package for ROS noetic"
 url="http://ros.org/wiki/image_rotate"
@@ -28,7 +28,7 @@ export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: image_rotate
     uri: https://github.com/ros-gbp/image_pipeline-release.git
-    version: release/noetic/image_rotate/1.16.0-1
+    version: release/noetic/image_rotate/1.17.0-1
 "
 
 prepare() {

--- a/ros/noetic.v3.14/ros-noetic-image-view/APKBUILD
+++ b/ros/noetic.v3.14/ros-noetic-image-view/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-noetic-image-view
 _pkgname=image_view
-pkgver=1.16.0
+pkgver=1.17.0
 pkgrel=0
 pkgdesc="$_pkgname package for ROS noetic"
 url="http://www.ros.org/wiki/image_view"
@@ -28,7 +28,7 @@ export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: image_view
     uri: https://github.com/ros-gbp/image_pipeline-release.git
-    version: release/noetic/image_view/1.16.0-1
+    version: release/noetic/image_view/1.17.0-1
 "
 
 prepare() {

--- a/ros/noetic.v3.14/ros-noetic-joint-limits-interface/APKBUILD
+++ b/ros/noetic.v3.14/ros-noetic-joint-limits-interface/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-noetic-joint-limits-interface
 _pkgname=joint_limits_interface
-pkgver=0.19.5
+pkgver=0.19.6
 pkgrel=0
 pkgdesc="$_pkgname package for ROS noetic"
 url="https://github.com/ros-controls/ros_control/wiki"
@@ -28,7 +28,7 @@ export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: joint_limits_interface
     uri: https://github.com/ros-gbp/ros_control-release.git
-    version: release/noetic/joint_limits_interface/0.19.5-1
+    version: release/noetic/joint_limits_interface/0.19.6-1
 "
 
 prepare() {

--- a/ros/noetic.v3.14/ros-noetic-ros-control/APKBUILD
+++ b/ros/noetic.v3.14/ros-noetic-ros-control/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-noetic-ros-control
 _pkgname=ros_control
-pkgver=0.19.5
+pkgver=0.19.6
 pkgrel=0
 pkgdesc="$_pkgname package for ROS noetic"
 url="http://ros.org/wiki/ros_control"
@@ -28,7 +28,7 @@ export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: ros_control
     uri: https://github.com/ros-gbp/ros_control-release.git
-    version: release/noetic/ros_control/0.19.5-1
+    version: release/noetic/ros_control/0.19.6-1
 "
 
 prepare() {

--- a/ros/noetic.v3.14/ros-noetic-rosapi/APKBUILD
+++ b/ros/noetic.v3.14/ros-noetic-rosapi/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-noetic-rosapi
 _pkgname=rosapi
-pkgver=0.11.15
+pkgver=0.11.16
 pkgrel=0
 pkgdesc="$_pkgname package for ROS noetic"
 url="http://ros.org/wiki/rosapi"
@@ -28,7 +28,7 @@ export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: rosapi
     uri: https://github.com/RobotWebTools-release/rosbridge_suite-release.git
-    version: release/noetic/rosapi/0.11.15-1
+    version: release/noetic/rosapi/0.11.16-1
 "
 
 prepare() {

--- a/ros/noetic.v3.14/ros-noetic-rosbridge-library/APKBUILD
+++ b/ros/noetic.v3.14/ros-noetic-rosbridge-library/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-noetic-rosbridge-library
 _pkgname=rosbridge_library
-pkgver=0.11.15
+pkgver=0.11.16
 pkgrel=0
 pkgdesc="$_pkgname package for ROS noetic"
 url="http://ros.org/wiki/rosbridge_library"
@@ -28,7 +28,7 @@ export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: rosbridge_library
     uri: https://github.com/RobotWebTools-release/rosbridge_suite-release.git
-    version: release/noetic/rosbridge_library/0.11.15-1
+    version: release/noetic/rosbridge_library/0.11.16-1
 "
 
 prepare() {

--- a/ros/noetic.v3.14/ros-noetic-rosbridge-msgs/APKBUILD
+++ b/ros/noetic.v3.14/ros-noetic-rosbridge-msgs/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-noetic-rosbridge-msgs
 _pkgname=rosbridge_msgs
-pkgver=0.11.15
+pkgver=0.11.16
 pkgrel=0
 pkgdesc="$_pkgname package for ROS noetic"
 url="http://wiki.ros.org/$_pkgname"
@@ -28,7 +28,7 @@ export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: rosbridge_msgs
     uri: https://github.com/RobotWebTools-release/rosbridge_suite-release.git
-    version: release/noetic/rosbridge_msgs/0.11.15-1
+    version: release/noetic/rosbridge_msgs/0.11.16-1
 "
 
 prepare() {

--- a/ros/noetic.v3.14/ros-noetic-rosbridge-server/APKBUILD
+++ b/ros/noetic.v3.14/ros-noetic-rosbridge-server/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-noetic-rosbridge-server
 _pkgname=rosbridge_server
-pkgver=0.11.15
+pkgver=0.11.16
 pkgrel=0
 pkgdesc="$_pkgname package for ROS noetic"
 url="http://ros.org/wiki/rosbridge_server"
@@ -28,7 +28,7 @@ export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: rosbridge_server
     uri: https://github.com/RobotWebTools-release/rosbridge_suite-release.git
-    version: release/noetic/rosbridge_server/0.11.15-1
+    version: release/noetic/rosbridge_server/0.11.16-1
 "
 
 prepare() {

--- a/ros/noetic.v3.14/ros-noetic-rosbridge-suite/APKBUILD
+++ b/ros/noetic.v3.14/ros-noetic-rosbridge-suite/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-noetic-rosbridge-suite
 _pkgname=rosbridge_suite
-pkgver=0.11.15
+pkgver=0.11.16
 pkgrel=0
 pkgdesc="$_pkgname package for ROS noetic"
 url="http://ros.org/wiki/rosbridge_suite"
@@ -28,7 +28,7 @@ export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: rosbridge_suite
     uri: https://github.com/RobotWebTools-release/rosbridge_suite-release.git
-    version: release/noetic/rosbridge_suite/0.11.15-1
+    version: release/noetic/rosbridge_suite/0.11.16-1
 "
 
 prepare() {

--- a/ros/noetic.v3.14/ros-noetic-stereo-image-proc/APKBUILD
+++ b/ros/noetic.v3.14/ros-noetic-stereo-image-proc/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-noetic-stereo-image-proc
 _pkgname=stereo_image_proc
-pkgver=1.16.0
+pkgver=1.17.0
 pkgrel=0
 pkgdesc="$_pkgname package for ROS noetic"
 url="http://www.ros.org/wiki/stereo_image_proc"
@@ -28,7 +28,7 @@ export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: stereo_image_proc
     uri: https://github.com/ros-gbp/image_pipeline-release.git
-    version: release/noetic/stereo_image_proc/1.16.0-1
+    version: release/noetic/stereo_image_proc/1.17.0-1
 "
 
 prepare() {

--- a/ros/noetic.v3.14/ros-noetic-tf2-eigen/APKBUILD
+++ b/ros/noetic.v3.14/ros-noetic-tf2-eigen/APKBUILD
@@ -1,7 +1,7 @@
 pkgname=ros-noetic-tf2-eigen
 _pkgname=tf2_eigen
-pkgver=0.7.5
-pkgrel=1
+pkgver=0.7.6
+pkgrel=0
 pkgdesc="$_pkgname package for ROS noetic"
 url="http://wiki.ros.org/$_pkgname"
 arch="all"
@@ -28,7 +28,7 @@ export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: tf2_eigen
     uri: https://github.com/ros-gbp/geometry2-release.git
-    version: release/noetic/tf2_eigen/0.7.5-1
+    version: release/noetic/tf2_eigen/0.7.6-1
 "
 
 prepare() {

--- a/ros/noetic.v3.14/ros-noetic-tf2-geometry-msgs/APKBUILD
+++ b/ros/noetic.v3.14/ros-noetic-tf2-geometry-msgs/APKBUILD
@@ -1,7 +1,7 @@
 pkgname=ros-noetic-tf2-geometry-msgs
 _pkgname=tf2_geometry_msgs
-pkgver=0.7.5
-pkgrel=1
+pkgver=0.7.6
+pkgrel=0
 pkgdesc="$_pkgname package for ROS noetic"
 url="http://www.ros.org/wiki/tf2_ros"
 arch="all"
@@ -28,7 +28,7 @@ export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: tf2_geometry_msgs
     uri: https://github.com/ros-gbp/geometry2-release.git
-    version: release/noetic/tf2_geometry_msgs/0.7.5-1
+    version: release/noetic/tf2_geometry_msgs/0.7.6-1
 "
 
 prepare() {

--- a/ros/noetic.v3.14/ros-noetic-tf2-kdl/APKBUILD
+++ b/ros/noetic.v3.14/ros-noetic-tf2-kdl/APKBUILD
@@ -1,7 +1,7 @@
 pkgname=ros-noetic-tf2-kdl
 _pkgname=tf2_kdl
-pkgver=0.7.5
-pkgrel=1
+pkgver=0.7.6
+pkgrel=0
 pkgdesc="$_pkgname package for ROS noetic"
 url="http://ros.org/wiki/tf2"
 arch="all"
@@ -28,7 +28,7 @@ export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: tf2_kdl
     uri: https://github.com/ros-gbp/geometry2-release.git
-    version: release/noetic/tf2_kdl/0.7.5-1
+    version: release/noetic/tf2_kdl/0.7.6-1
 "
 
 prepare() {

--- a/ros/noetic.v3.14/ros-noetic-tf2-msgs/APKBUILD
+++ b/ros/noetic.v3.14/ros-noetic-tf2-msgs/APKBUILD
@@ -1,7 +1,7 @@
 pkgname=ros-noetic-tf2-msgs
 _pkgname=tf2_msgs
-pkgver=0.7.5
-pkgrel=1
+pkgver=0.7.6
+pkgrel=0
 pkgdesc="$_pkgname package for ROS noetic"
 url="http://www.ros.org/wiki/tf2_msgs"
 arch="all"
@@ -28,7 +28,7 @@ export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: tf2_msgs
     uri: https://github.com/ros-gbp/geometry2-release.git
-    version: release/noetic/tf2_msgs/0.7.5-1
+    version: release/noetic/tf2_msgs/0.7.6-1
 "
 
 prepare() {

--- a/ros/noetic.v3.14/ros-noetic-tf2-py/APKBUILD
+++ b/ros/noetic.v3.14/ros-noetic-tf2-py/APKBUILD
@@ -1,7 +1,7 @@
 pkgname=ros-noetic-tf2-py
 _pkgname=tf2_py
-pkgver=0.7.5
-pkgrel=1
+pkgver=0.7.6
+pkgrel=0
 pkgdesc="$_pkgname package for ROS noetic"
 url="http://ros.org/wiki/tf2_py"
 arch="all"
@@ -28,7 +28,7 @@ export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: tf2_py
     uri: https://github.com/ros-gbp/geometry2-release.git
-    version: release/noetic/tf2_py/0.7.5-1
+    version: release/noetic/tf2_py/0.7.6-1
 "
 
 prepare() {

--- a/ros/noetic.v3.14/ros-noetic-tf2-ros/APKBUILD
+++ b/ros/noetic.v3.14/ros-noetic-tf2-ros/APKBUILD
@@ -1,7 +1,7 @@
 pkgname=ros-noetic-tf2-ros
 _pkgname=tf2_ros
-pkgver=0.7.5
-pkgrel=3
+pkgver=0.7.6
+pkgrel=0
 pkgdesc="$_pkgname package for ROS noetic"
 url="http://www.ros.org/wiki/tf2_ros"
 arch="all"
@@ -28,7 +28,7 @@ export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: tf2_ros
     uri: https://github.com/ros-gbp/geometry2-release.git
-    version: release/noetic/tf2_ros/0.7.5-1
+    version: release/noetic/tf2_ros/0.7.6-1
 "
 
 prepare() {

--- a/ros/noetic.v3.14/ros-noetic-tf2-sensor-msgs/APKBUILD
+++ b/ros/noetic.v3.14/ros-noetic-tf2-sensor-msgs/APKBUILD
@@ -1,7 +1,7 @@
 pkgname=ros-noetic-tf2-sensor-msgs
 _pkgname=tf2_sensor_msgs
-pkgver=0.7.5
-pkgrel=1
+pkgver=0.7.6
+pkgrel=0
 pkgdesc="$_pkgname package for ROS noetic"
 url="http://www.ros.org/wiki/tf2_ros"
 arch="all"
@@ -28,7 +28,7 @@ export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: tf2_sensor_msgs
     uri: https://github.com/ros-gbp/geometry2-release.git
-    version: release/noetic/tf2_sensor_msgs/0.7.5-1
+    version: release/noetic/tf2_sensor_msgs/0.7.6-1
 "
 
 prepare() {

--- a/ros/noetic.v3.14/ros-noetic-tf2/APKBUILD
+++ b/ros/noetic.v3.14/ros-noetic-tf2/APKBUILD
@@ -1,7 +1,7 @@
 pkgname=ros-noetic-tf2
 _pkgname=tf2
-pkgver=0.7.5
-pkgrel=4
+pkgver=0.7.6
+pkgrel=0
 pkgdesc="$_pkgname package for ROS noetic"
 url="http://www.ros.org/wiki/tf2"
 arch="all"
@@ -28,7 +28,7 @@ export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: tf2
     uri: https://github.com/ros-gbp/geometry2-release.git
-    version: release/noetic/tf2/0.7.5-1
+    version: release/noetic/tf2/0.7.6-1
 "
 
 prepare() {

--- a/ros/noetic.v3.14/ros-noetic-transmission-interface/APKBUILD
+++ b/ros/noetic.v3.14/ros-noetic-transmission-interface/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-noetic-transmission-interface
 _pkgname=transmission_interface
-pkgver=0.19.5
+pkgver=0.19.6
 pkgrel=0
 pkgdesc="$_pkgname package for ROS noetic"
 url="https://github.com/ros-controls/ros_control/wiki"
@@ -28,7 +28,7 @@ export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: transmission_interface
     uri: https://github.com/ros-gbp/ros_control-release.git
-    version: release/noetic/transmission_interface/0.19.5-1
+    version: release/noetic/transmission_interface/0.19.6-1
 "
 
 prepare() {

--- a/ros/noetic.v3.14/ros-noetic-xacro/APKBUILD
+++ b/ros/noetic.v3.14/ros-noetic-xacro/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-noetic-xacro
 _pkgname=xacro
-pkgver=1.14.13
+pkgver=1.14.14
 pkgrel=0
 pkgdesc="$_pkgname package for ROS noetic"
 url="http://ros.org/wiki/xacro"
@@ -28,7 +28,7 @@ export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: xacro
     uri: https://github.com/ros-gbp/xacro-release.git
-    version: release/noetic/xacro/1.14.13-1
+    version: release/noetic/xacro/1.14.14-1
 "
 
 prepare() {


### PR DESCRIPTION
Updates found in rosdistro
- ros/noetic.v3.14/ros-noetic-camera-calibration [diff](https://github.com/ros-gbp/image_pipeline-release/compare/release/noetic/camera_calibration/1.16.0-1...release/noetic/camera_calibration/1.17.0-1)
- ros/noetic.v3.14/ros-noetic-combined-robot-hw [diff](https://github.com/ros-gbp/ros_control-release/compare/release/noetic/combined_robot_hw/0.19.5-1...release/noetic/combined_robot_hw/0.19.6-1)
- ros/noetic.v3.14/ros-noetic-controller-interface [diff](https://github.com/ros-gbp/ros_control-release/compare/release/noetic/controller_interface/0.19.5-1...release/noetic/controller_interface/0.19.6-1)
- ros/noetic.v3.14/ros-noetic-controller-manager-msgs [diff](https://github.com/ros-gbp/ros_control-release/compare/release/noetic/controller_manager_msgs/0.19.5-1...release/noetic/controller_manager_msgs/0.19.6-1)
- ros/noetic.v3.14/ros-noetic-controller-manager [diff](https://github.com/ros-gbp/ros_control-release/compare/release/noetic/controller_manager/0.19.5-1...release/noetic/controller_manager/0.19.6-1)
- ros/noetic.v3.14/ros-noetic-depth-image-proc [diff](https://github.com/ros-gbp/image_pipeline-release/compare/release/noetic/depth_image_proc/1.16.0-1...release/noetic/depth_image_proc/1.17.0-1)
- ros/noetic.v3.14/ros-noetic-hardware-interface [diff](https://github.com/ros-gbp/ros_control-release/compare/release/noetic/hardware_interface/0.19.5-1...release/noetic/hardware_interface/0.19.6-1)
- ros/noetic.v3.14/ros-noetic-image-pipeline [diff](https://github.com/ros-gbp/image_pipeline-release/compare/release/noetic/image_pipeline/1.16.0-1...release/noetic/image_pipeline/1.17.0-1)
- ros/noetic.v3.14/ros-noetic-image-proc [diff](https://github.com/ros-gbp/image_pipeline-release/compare/release/noetic/image_proc/1.16.0-1...release/noetic/image_proc/1.17.0-1)
- ros/noetic.v3.14/ros-noetic-image-publisher [diff](https://github.com/ros-gbp/image_pipeline-release/compare/release/noetic/image_publisher/1.16.0-1...release/noetic/image_publisher/1.17.0-1)
- ros/noetic.v3.14/ros-noetic-image-rotate [diff](https://github.com/ros-gbp/image_pipeline-release/compare/release/noetic/image_rotate/1.16.0-1...release/noetic/image_rotate/1.17.0-1)
- ros/noetic.v3.14/ros-noetic-image-view [diff](https://github.com/ros-gbp/image_pipeline-release/compare/release/noetic/image_view/1.16.0-1...release/noetic/image_view/1.17.0-1)
- ros/noetic.v3.14/ros-noetic-joint-limits-interface [diff](https://github.com/ros-gbp/ros_control-release/compare/release/noetic/joint_limits_interface/0.19.5-1...release/noetic/joint_limits_interface/0.19.6-1)
- ros/noetic.v3.14/ros-noetic-ros-control [diff](https://github.com/ros-gbp/ros_control-release/compare/release/noetic/ros_control/0.19.5-1...release/noetic/ros_control/0.19.6-1)
- ros/noetic.v3.14/ros-noetic-rosapi [diff](https://github.com/RobotWebTools-release/rosbridge_suite-release/compare/release/noetic/rosapi/0.11.15-1...release/noetic/rosapi/0.11.16-1)
- ros/noetic.v3.14/ros-noetic-rosbridge-library [diff](https://github.com/RobotWebTools-release/rosbridge_suite-release/compare/release/noetic/rosbridge_library/0.11.15-1...release/noetic/rosbridge_library/0.11.16-1)
- ros/noetic.v3.14/ros-noetic-rosbridge-msgs [diff](https://github.com/RobotWebTools-release/rosbridge_suite-release/compare/release/noetic/rosbridge_msgs/0.11.15-1...release/noetic/rosbridge_msgs/0.11.16-1)
- ros/noetic.v3.14/ros-noetic-rosbridge-server [diff](https://github.com/RobotWebTools-release/rosbridge_suite-release/compare/release/noetic/rosbridge_server/0.11.15-1...release/noetic/rosbridge_server/0.11.16-1)
- ros/noetic.v3.14/ros-noetic-rosbridge-suite [diff](https://github.com/RobotWebTools-release/rosbridge_suite-release/compare/release/noetic/rosbridge_suite/0.11.15-1...release/noetic/rosbridge_suite/0.11.16-1)
- ros/noetic.v3.14/ros-noetic-stereo-image-proc [diff](https://github.com/ros-gbp/image_pipeline-release/compare/release/noetic/stereo_image_proc/1.16.0-1...release/noetic/stereo_image_proc/1.17.0-1)
- ros/noetic.v3.14/ros-noetic-tf2-eigen [diff](https://github.com/ros-gbp/geometry2-release/compare/release/noetic/tf2_eigen/0.7.5-1...release/noetic/tf2_eigen/0.7.6-1)
- ros/noetic.v3.14/ros-noetic-tf2-geometry-msgs [diff](https://github.com/ros-gbp/geometry2-release/compare/release/noetic/tf2_geometry_msgs/0.7.5-1...release/noetic/tf2_geometry_msgs/0.7.6-1)
- ros/noetic.v3.14/ros-noetic-tf2-kdl [diff](https://github.com/ros-gbp/geometry2-release/compare/release/noetic/tf2_kdl/0.7.5-1...release/noetic/tf2_kdl/0.7.6-1)
- ros/noetic.v3.14/ros-noetic-tf2-msgs [diff](https://github.com/ros-gbp/geometry2-release/compare/release/noetic/tf2_msgs/0.7.5-1...release/noetic/tf2_msgs/0.7.6-1)
- ros/noetic.v3.14/ros-noetic-tf2-py [diff](https://github.com/ros-gbp/geometry2-release/compare/release/noetic/tf2_py/0.7.5-1...release/noetic/tf2_py/0.7.6-1)
- ros/noetic.v3.14/ros-noetic-tf2-ros [diff](https://github.com/ros-gbp/geometry2-release/compare/release/noetic/tf2_ros/0.7.5-1...release/noetic/tf2_ros/0.7.6-1)
- ros/noetic.v3.14/ros-noetic-tf2-sensor-msgs [diff](https://github.com/ros-gbp/geometry2-release/compare/release/noetic/tf2_sensor_msgs/0.7.5-1...release/noetic/tf2_sensor_msgs/0.7.6-1)
- ros/noetic.v3.14/ros-noetic-tf2 [diff](https://github.com/ros-gbp/geometry2-release/compare/release/noetic/tf2/0.7.5-1...release/noetic/tf2/0.7.6-1)
- ros/noetic.v3.14/ros-noetic-transmission-interface [diff](https://github.com/ros-gbp/ros_control-release/compare/release/noetic/transmission_interface/0.19.5-1...release/noetic/transmission_interface/0.19.6-1)
- ros/noetic.v3.14/ros-noetic-xacro [diff](https://github.com/ros-gbp/xacro-release/compare/release/noetic/xacro/1.14.13-1...release/noetic/xacro/1.14.14-1)
