### PR TITLE
noetic-3.17: automatic update on 20221228-042548

### DIFF
--- a/ros/noetic.v3.17/ros-noetic-actionlib-msgs/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-actionlib-msgs/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: actionlib_msgs
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-actionlib/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-actionlib/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: actionlib
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-amcl/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-amcl/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: amcl
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-angles/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-angles/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: angles
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-aruco-msgs/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-aruco-msgs/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: aruco_msgs
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-aruco-ros/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-aruco-ros/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: aruco_ros
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-aruco/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-aruco/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: aruco
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-audio-capture/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-audio-capture/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: audio_capture
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-audio-common-msgs/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-audio-common-msgs/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: audio_common_msgs
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-audio-common/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-audio-common/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: audio_common
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-audio-play/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-audio-play/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: audio_play
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-base-local-planner/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-base-local-planner/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: base_local_planner
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-bond-core/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-bond-core/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: bond_core
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-bond/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-bond/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: bond
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-bondcpp/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-bondcpp/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: bondcpp
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-bondpy/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-bondpy/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: bondpy
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-camera-calibration-parsers/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-camera-calibration-parsers/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: camera_calibration_parsers
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-camera-calibration/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-camera-calibration/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: camera_calibration
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-camera-info-manager/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-camera-info-manager/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: camera_info_manager
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-carrot-planner/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-carrot-planner/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: carrot_planner
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-catkin/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-catkin/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: catkin

--- a/ros/noetic.v3.17/ros-noetic-class-loader/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-class-loader/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: class_loader
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-clear-costmap-recovery/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-clear-costmap-recovery/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: clear_costmap_recovery
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-cmake-modules/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-cmake-modules/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: cmake_modules
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-combined-robot-hw/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-combined-robot-hw/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: combined_robot_hw
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-common-msgs/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-common-msgs/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: common_msgs
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-compressed-depth-image-transport/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-compressed-depth-image-transport/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: compressed_depth_image_transport
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-compressed-image-transport/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-compressed-image-transport/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: compressed_image_transport
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-control-msgs/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-control-msgs/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: control_msgs
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-controller-interface/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-controller-interface/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: controller_interface
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-controller-manager-msgs/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-controller-manager-msgs/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: controller_manager_msgs
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-controller-manager/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-controller-manager/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: controller_manager
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-costmap-2d/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-costmap-2d/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: costmap_2d
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-costmap-cspace-msgs/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-costmap-cspace-msgs/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: costmap_cspace_msgs
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-costmap-cspace/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-costmap-cspace/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: costmap_cspace
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-cpp-common/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-cpp-common/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: cpp_common
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-cv-bridge/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-cv-bridge/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: cv_bridge
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-depth-image-proc/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-depth-image-proc/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: depth_image_proc
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-diagnostic-aggregator/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-diagnostic-aggregator/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: diagnostic_aggregator
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-diagnostic-analysis/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-diagnostic-analysis/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: diagnostic_analysis
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-diagnostic-common-diagnostics/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-diagnostic-common-diagnostics/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: diagnostic_common_diagnostics
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-diagnostic-msgs/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-diagnostic-msgs/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: diagnostic_msgs
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-diagnostic-updater/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-diagnostic-updater/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: diagnostic_updater
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-diagnostics/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-diagnostics/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: diagnostics
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-dwa-local-planner/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-dwa-local-planner/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: dwa_local_planner
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-dynamic-reconfigure/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-dynamic-reconfigure/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: dynamic_reconfigure
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-eigen-conversions/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-eigen-conversions/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: eigen_conversions
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-executive-smach-visualization/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-executive-smach-visualization/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: executive_smach_visualization
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-executive-smach/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-executive-smach/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: executive_smach
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-fake-localization/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-fake-localization/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: fake_localization
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-filters/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-filters/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: filters
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-gencpp/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-gencpp/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: gencpp
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-geneus/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-geneus/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: geneus
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-genlisp/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-genlisp/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: genlisp
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-genmsg/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-genmsg/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: genmsg
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-gennodejs/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-gennodejs/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: gennodejs
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-genpy/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-genpy/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: genpy
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-geographic-msgs/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-geographic-msgs/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: geographic_msgs
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-geometry-msgs/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-geometry-msgs/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: geometry_msgs
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-geometry/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-geometry/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: geometry
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-gl-dependency/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-gl-dependency/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: gl_dependency
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-global-planner/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-global-planner/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: global_planner
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-grid-map-core/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-grid-map-core/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: grid_map_core
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-grid-map-cv/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-grid-map-cv/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: grid_map_cv
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-grid-map-msgs/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-grid-map-msgs/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: grid_map_msgs
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-grid-map-ros/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-grid-map-ros/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: grid_map_ros
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-grid-map-rviz-plugin/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-grid-map-rviz-plugin/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: grid_map_rviz_plugin
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-hardware-interface/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-hardware-interface/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: hardware_interface
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-ifm3d-core/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-ifm3d-core/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: ifm3d_core

--- a/ros/noetic.v3.17/ros-noetic-ifm3d/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-ifm3d/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: ifm3d
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-image-common/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-image-common/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: image_common
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-image-geometry/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-image-geometry/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: image_geometry
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-image-pipeline/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-image-pipeline/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: image_pipeline
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-image-proc/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-image-proc/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: image_proc
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-image-publisher/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-image-publisher/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: image_publisher
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-image-rotate/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-image-rotate/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: image_rotate
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-image-transport-plugins/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-image-transport-plugins/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: image_transport_plugins
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-image-transport/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-image-transport/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: image_transport
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-image-view/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-image-view/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: image_view
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-imu-complementary-filter/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-imu-complementary-filter/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: imu_complementary_filter
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-imu-filter-madgwick/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-imu-filter-madgwick/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: imu_filter_madgwick
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-imu-tools/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-imu-tools/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: imu_tools
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-interactive-markers/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-interactive-markers/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: interactive_markers
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-joint-limits-interface/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-joint-limits-interface/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: joint_limits_interface
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-joint-state-publisher-gui/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-joint-state-publisher-gui/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: joint_state_publisher_gui
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-joint-state-publisher/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-joint-state-publisher/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: joint_state_publisher
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-joy/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-joy/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: joy
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-joystick-interrupt/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-joystick-interrupt/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: joystick_interrupt
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-kdl-conversions/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-kdl-conversions/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: kdl_conversions
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-kdl-parser/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-kdl-parser/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: kdl_parser
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-laser-assembler/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-laser-assembler/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: laser_assembler
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-laser-filters/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-laser-filters/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: laser_filters
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-laser-geometry/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-laser-geometry/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: laser_geometry
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-laser-pipeline/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-laser-pipeline/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: laser_pipeline
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-laser-proc/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-laser-proc/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: laser_proc
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-map-msgs/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-map-msgs/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: map_msgs
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-map-organizer-msgs/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-map-organizer-msgs/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: map_organizer_msgs
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-map-organizer/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-map-organizer/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: map_organizer
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-map-server/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-map-server/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: map_server
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-mcl-3dl-msgs/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-mcl-3dl-msgs/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: mcl_3dl_msgs
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-mcl-3dl/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-mcl-3dl/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: mcl_3dl
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-media-export/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-media-export/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: media_export
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-message-filters/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-message-filters/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: message_filters
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-message-generation/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-message-generation/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: message_generation
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-message-runtime/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-message-runtime/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: message_runtime
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-mk/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-mk/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: mk
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-move-base-msgs/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-move-base-msgs/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: move_base_msgs
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-move-base/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-move-base/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: move_base
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-move-slow-and-clear/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-move-slow-and-clear/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: move_slow_and_clear
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-nav-core/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-nav-core/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: nav_core
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-nav-msgs/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-nav-msgs/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: nav_msgs
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-navfn/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-navfn/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: navfn
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-navigation/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-navigation/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: navigation
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-neonavigation-common/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-neonavigation-common/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: neonavigation_common
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-neonavigation-launch/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-neonavigation-launch/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: neonavigation_launch
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-neonavigation-msgs/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-neonavigation-msgs/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: neonavigation_msgs
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-neonavigation-rviz-plugins/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-neonavigation-rviz-plugins/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: neonavigation_rviz_plugins
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-neonavigation/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-neonavigation/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: neonavigation
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-nodelet-core/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-nodelet-core/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: nodelet_core
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-nodelet-topic-tools/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-nodelet-topic-tools/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: nodelet_topic_tools
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-nodelet/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-nodelet/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: nodelet
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-obj-to-pointcloud/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-obj-to-pointcloud/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: obj_to_pointcloud
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-octomap-msgs/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-octomap-msgs/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: octomap_msgs
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-octomap-ros/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-octomap-ros/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: octomap_ros
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-octomap/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-octomap/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: octomap

--- a/ros/noetic.v3.17/ros-noetic-pcl-conversions/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-pcl-conversions/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: pcl_conversions
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-pcl-msgs/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-pcl-msgs/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: pcl_msgs
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-pcl-ros/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-pcl-ros/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: pcl_ros
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-perception-pcl/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-perception-pcl/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: perception_pcl
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-perception/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-perception/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: perception
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-planner-cspace-msgs/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-planner-cspace-msgs/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: planner_cspace_msgs
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-planner-cspace/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-planner-cspace/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: planner_cspace
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-pluginlib/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-pluginlib/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: pluginlib
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-polled-camera/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-polled-camera/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: polled_camera
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-python-qt-binding/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-python-qt-binding/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: python_qt_binding
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-qt-dotgraph/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-qt-dotgraph/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: qt_dotgraph
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-qt-gui-cpp/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-qt-gui-cpp/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: qt_gui_cpp
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-qt-gui-py-common/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-qt-gui-py-common/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: qt_gui_py_common
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-qt-gui/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-qt-gui/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: qt_gui
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-qwt-dependency/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-qwt-dependency/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: qwt_dependency
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-realtime-tools/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-realtime-tools/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: realtime_tools
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-resource-retriever/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-resource-retriever/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: resource_retriever
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-robot-state-publisher/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-robot-state-publisher/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: robot_state_publisher
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-robot/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-robot/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: robot
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-ros-base/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-ros-base/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: ros_base
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-ros-comm/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-ros-comm/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: ros_comm
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-ros-control/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-ros-control/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: ros_control
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-ros-core/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-ros-core/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: ros_core
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-ros-environment/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-ros-environment/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: ros_environment
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-ros-tutorials/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-ros-tutorials/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: ros_tutorials
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-ros/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-ros/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: ros
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-rosapi/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-rosapi/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: rosapi
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-rosauth/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-rosauth/APKBUILD
@@ -8,7 +8,7 @@ arch="all"
 license="BSD"
 
 depends="ros-noetic-message-runtime ros-noetic-roscpp"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall py3-rosinstall-generator py3-vcstool chrpath libressl-dev ros-noetic-catkin ros-noetic-message-generation ros-noetic-roscpp ros-noetic-rostest"
+makedepends="py3-setuptools py3-rosdep py3-rosinstall py3-rosinstall-generator py3-vcstool chrpath openssl-dev ros-noetic-catkin ros-noetic-message-generation ros-noetic-roscpp ros-noetic-rostest"
 
 subpackages="$pkgname-dbg $pkgname-doc"
 
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: rosauth
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-rosbag-migration-rule/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-rosbag-migration-rule/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: rosbag_migration_rule
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-rosbag-storage/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-rosbag-storage/APKBUILD
@@ -7,8 +7,8 @@ url="http://wiki.ros.org/$_pkgname"
 arch="all"
 license="BSD"
 
-depends="boost-dev bzip2-dev console_bridge-dev gpgme-dev libressl-dev ros-noetic-cpp-common>=0.3.17 ros-noetic-pluginlib ros-noetic-roscpp-serialization ros-noetic-roscpp-traits>=0.3.17 ros-noetic-roslz4 ros-noetic-rostime boost-dev bzip2-dev console_bridge-dev gpgme-dev libressl-dev ros-noetic-cpp-common>=0.3.17 ros-noetic-pluginlib ros-noetic-roscpp-serialization ros-noetic-roscpp-traits>=0.3.17 ros-noetic-roslz4 ros-noetic-rostime"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall py3-rosinstall-generator py3-vcstool chrpath boost-dev bzip2-dev console_bridge-dev gpgme-dev libressl-dev ros-noetic-catkin ros-noetic-cpp-common>=0.3.17 ros-noetic-pluginlib ros-noetic-roscpp-serialization ros-noetic-roscpp-traits>=0.3.17 ros-noetic-roslz4 ros-noetic-rostest ros-noetic-rostime ros-noetic-std-msgs"
+depends="boost-dev bzip2-dev console_bridge-dev gpgme-dev openssl-dev ros-noetic-cpp-common>=0.3.17 ros-noetic-pluginlib ros-noetic-roscpp-serialization ros-noetic-roscpp-traits>=0.3.17 ros-noetic-roslz4 ros-noetic-rostime boost-dev bzip2-dev console_bridge-dev gpgme-dev openssl-dev ros-noetic-cpp-common>=0.3.17 ros-noetic-pluginlib ros-noetic-roscpp-serialization ros-noetic-roscpp-traits>=0.3.17 ros-noetic-roslz4 ros-noetic-rostime"
+makedepends="py3-setuptools py3-rosdep py3-rosinstall py3-rosinstall-generator py3-vcstool chrpath boost-dev bzip2-dev console_bridge-dev gpgme-dev openssl-dev ros-noetic-catkin ros-noetic-cpp-common>=0.3.17 ros-noetic-pluginlib ros-noetic-roscpp-serialization ros-noetic-roscpp-traits>=0.3.17 ros-noetic-roslz4 ros-noetic-rostest ros-noetic-rostime ros-noetic-std-msgs"
 
 subpackages="$pkgname-dbg $pkgname-doc"
 
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: rosbag_storage
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-rosbag/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-rosbag/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: rosbag
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-rosbash/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-rosbash/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: rosbash
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-rosboost-cfg/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-rosboost-cfg/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: rosboost_cfg
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-rosbridge-library/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-rosbridge-library/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: rosbridge_library
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-rosbridge-msgs/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-rosbridge-msgs/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: rosbridge_msgs
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-rosbridge-server/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-rosbridge-server/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: rosbridge_server
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-rosbridge-suite/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-rosbridge-suite/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: rosbridge_suite
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-rosbuild/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-rosbuild/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: rosbuild
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-rosclean/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-rosclean/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: rosclean
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-rosconsole-bridge/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-rosconsole-bridge/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: rosconsole_bridge
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-rosconsole/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-rosconsole/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: rosconsole
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-roscpp-core/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-roscpp-core/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: roscpp_core
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-roscpp-serialization/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-roscpp-serialization/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: roscpp_serialization
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-roscpp-traits/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-roscpp-traits/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: roscpp_traits
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-roscpp-tutorials/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-roscpp-tutorials/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: roscpp_tutorials
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-roscpp/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-roscpp/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: roscpp
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-roscreate/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-roscreate/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: roscreate
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-rosgraph-msgs/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-rosgraph-msgs/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: rosgraph_msgs
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-rosgraph/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-rosgraph/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: rosgraph
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-roslang/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-roslang/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: roslang
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-roslaunch/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-roslaunch/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: roslaunch
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-roslib/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-roslib/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: roslib
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-roslint/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-roslint/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: roslint
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-roslisp/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-roslisp/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: roslisp
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-roslz4/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-roslz4/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: roslz4
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-rosmake/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-rosmake/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: rosmake
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-rosmaster/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-rosmaster/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: rosmaster
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-rosmsg/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-rosmsg/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: rosmsg
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-rosnode/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-rosnode/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: rosnode
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-rosout/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-rosout/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: rosout
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-rospack/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-rospack/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: rospack
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-rosparam/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-rosparam/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: rosparam
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-rospy-tutorials/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-rospy-tutorials/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: rospy_tutorials
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-rospy/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-rospy/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: rospy
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-rosserial-client/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-rosserial-client/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: rosserial_client
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-rosserial-msgs/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-rosserial-msgs/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: rosserial_msgs
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-rosserial-python/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-rosserial-python/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: rosserial_python
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-rosserial/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-rosserial/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: rosserial
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-rosservice/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-rosservice/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: rosservice
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-rostest/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-rostest/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: rostest
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-rostime/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-rostime/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: rostime
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-rostopic/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-rostopic/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: rostopic
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-rosunit/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-rosunit/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: rosunit
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-roswtf/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-roswtf/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: roswtf
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-rotate-recovery/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-rotate-recovery/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: rotate_recovery
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-rqt-action/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-rqt-action/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: rqt_action
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-rqt-bag-plugins/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-rqt-bag-plugins/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: rqt_bag_plugins
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-rqt-bag/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-rqt-bag/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: rqt_bag
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-rqt-common-plugins/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-rqt-common-plugins/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: rqt_common_plugins
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-rqt-console/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-rqt-console/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: rqt_console
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-rqt-dep/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-rqt-dep/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: rqt_dep
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-rqt-graph/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-rqt-graph/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: rqt_graph
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-rqt-gui-cpp/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-rqt-gui-cpp/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: rqt_gui_cpp
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-rqt-gui-py/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-rqt-gui-py/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: rqt_gui_py
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-rqt-gui/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-rqt-gui/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: rqt_gui
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-rqt-image-view/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-rqt-image-view/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: rqt_image_view
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-rqt-launch/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-rqt-launch/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: rqt_launch
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-rqt-logger-level/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-rqt-logger-level/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: rqt_logger_level
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-rqt-moveit/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-rqt-moveit/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: rqt_moveit
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-rqt-msg/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-rqt-msg/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: rqt_msg
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-rqt-nav-view/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-rqt-nav-view/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: rqt_nav_view
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-rqt-plot/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-rqt-plot/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: rqt_plot
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-rqt-pose-view/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-rqt-pose-view/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: rqt_pose_view
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-rqt-publisher/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-rqt-publisher/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: rqt_publisher
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-rqt-py-common/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-rqt-py-common/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: rqt_py_common
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-rqt-py-console/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-rqt-py-console/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: rqt_py_console
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-rqt-reconfigure/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-rqt-reconfigure/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: rqt_reconfigure
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-rqt-robot-dashboard/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-rqt-robot-dashboard/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: rqt_robot_dashboard
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-rqt-robot-monitor/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-rqt-robot-monitor/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: rqt_robot_monitor
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-rqt-robot-plugins/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-rqt-robot-plugins/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: rqt_robot_plugins
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-rqt-robot-steering/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-rqt-robot-steering/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: rqt_robot_steering
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-rqt-runtime-monitor/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-rqt-runtime-monitor/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: rqt_runtime_monitor
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-rqt-rviz/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-rqt-rviz/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: rqt_rviz
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-rqt-service-caller/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-rqt-service-caller/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: rqt_service_caller
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-rqt-shell/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-rqt-shell/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: rqt_shell
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-rqt-srv/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-rqt-srv/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: rqt_srv
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-rqt-tf-tree/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-rqt-tf-tree/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: rqt_tf_tree
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-rqt-top/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-rqt-top/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: rqt_top
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-rqt-topic/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-rqt-topic/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: rqt_topic
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-rqt-web/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-rqt-web/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: rqt_web
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-rviz-imu-plugin/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-rviz-imu-plugin/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: rviz_imu_plugin
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-rviz/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-rviz/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: rviz
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-safety-limiter-msgs/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-safety-limiter-msgs/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: safety_limiter_msgs
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-safety-limiter/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-safety-limiter/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: safety_limiter
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-self-test/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-self-test/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: self_test
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-sensor-msgs/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-sensor-msgs/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: sensor_msgs
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-shape-msgs/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-shape-msgs/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: shape_msgs
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-smach-msgs/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-smach-msgs/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: smach_msgs
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-smach-ros/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-smach-ros/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: smach_ros
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-smach-viewer/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-smach-viewer/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: smach_viewer
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-smach/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-smach/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: smach
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-smclib/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-smclib/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: smclib
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-sound-play/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-sound-play/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: sound_play
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-std-msgs/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-std-msgs/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: std_msgs
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-std-srvs/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-std-srvs/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: std_srvs
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-stereo-image-proc/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-stereo-image-proc/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: stereo_image_proc
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-stereo-msgs/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-stereo-msgs/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: stereo_msgs
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-tf-conversions/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-tf-conversions/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: tf_conversions
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-tf/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-tf/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: tf
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-tf2-eigen/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-tf2-eigen/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: tf2_eigen
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-tf2-geometry-msgs/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-tf2-geometry-msgs/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: tf2_geometry_msgs
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-tf2-kdl/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-tf2-kdl/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: tf2_kdl
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-tf2-msgs/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-tf2-msgs/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: tf2_msgs
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-tf2-py/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-tf2-py/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: tf2_py
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-tf2-ros/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-tf2-ros/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: tf2_ros
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-tf2-sensor-msgs/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-tf2-sensor-msgs/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: tf2_sensor_msgs
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-tf2/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-tf2/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: tf2
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-theora-image-transport/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-theora-image-transport/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: theora_image_transport
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-topic-tools/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-topic-tools/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: topic_tools
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-track-odometry/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-track-odometry/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: track_odometry
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-trajectory-msgs/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-trajectory-msgs/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: trajectory_msgs
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-trajectory-tracker-msgs/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-trajectory-tracker-msgs/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: trajectory_tracker_msgs
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-trajectory-tracker-rviz-plugins/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-trajectory-tracker-rviz-plugins/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: trajectory_tracker_rviz_plugins
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-trajectory-tracker/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-trajectory-tracker/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: trajectory_tracker
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-transmission-interface/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-transmission-interface/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: transmission_interface
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-turtlesim/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-turtlesim/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: turtlesim
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-urdf-parser-plugin/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-urdf-parser-plugin/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: urdf_parser_plugin
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-urdf/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-urdf/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: urdf
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-urg-c/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-urg-c/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: urg_c
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-urg-node/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-urg-node/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: urg_node
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-urg-stamped/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-urg-stamped/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: urg_stamped
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-usb-cam/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-usb-cam/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: usb_cam
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-uuid-msgs/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-uuid-msgs/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: uuid_msgs
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-velodyne-driver/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-velodyne-driver/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: velodyne_driver
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-velodyne-laserscan/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-velodyne-laserscan/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: velodyne_laserscan
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-velodyne-msgs/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-velodyne-msgs/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: velodyne_msgs
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-velodyne-pcl/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-velodyne-pcl/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: velodyne_pcl
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-velodyne-pointcloud/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-velodyne-pointcloud/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: velodyne_pointcloud
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-velodyne/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-velodyne/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: velodyne
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-vision-opencv/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-vision-opencv/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: vision_opencv
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-visualization-msgs/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-visualization-msgs/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: visualization_msgs
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-viz/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-viz/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: viz
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-voxel-grid/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-voxel-grid/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: voxel_grid
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-webkit-dependency/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-webkit-dependency/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: webkit_dependency
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-xacro/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-xacro/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: xacro
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-xmlrpcpp/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-xmlrpcpp/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: xmlrpcpp
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-ypspur-ros/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-ypspur-ros/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: ypspur_ros
@@ -54,10 +55,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then
@@ -78,6 +79,11 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/noetic/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/ros/noetic.v3.17/ros-noetic-ypspur/APKBUILD
+++ b/ros/noetic.v3.17/ros-noetic-ypspur/APKBUILD
@@ -24,6 +24,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=3
 rosinstall="- git:
     local-name: ypspur


### PR DESCRIPTION
Updates found in rosdistro
- ros/noetic.v3.17/ros-noetic-actionlib-msgs [diff](https://github.com/ros-gbp/common_msgs-release/compare/release/noetic/actionlib_msgs/1.13.1-1...release/noetic/actionlib_msgs/1.13.1-1)
- ros/noetic.v3.17/ros-noetic-actionlib [diff](https://github.com/ros-gbp/actionlib-release/compare/release/noetic/actionlib/1.14.0-1...release/noetic/actionlib/1.14.0-1)
- ros/noetic.v3.17/ros-noetic-amcl [diff](https://github.com/ros-gbp/navigation-release/compare/release/noetic/amcl/1.17.2-1...release/noetic/amcl/1.17.2-1)
- ros/noetic.v3.17/ros-noetic-angles [diff](https://github.com/ros-gbp/geometry_angles_utils-release/compare/release/noetic/angles/1.9.13-1...release/noetic/angles/1.9.13-1)
- ros/noetic.v3.17/ros-noetic-aruco-msgs [diff](https://github.com/pal-gbp/aruco_ros-release/compare/release/noetic/aruco_msgs/3.1.3-1...release/noetic/aruco_msgs/3.1.3-1)
- ros/noetic.v3.17/ros-noetic-aruco-ros [diff](https://github.com/pal-gbp/aruco_ros-release/compare/release/noetic/aruco_ros/3.1.3-1...release/noetic/aruco_ros/3.1.3-1)
- ros/noetic.v3.17/ros-noetic-aruco [diff](https://github.com/pal-gbp/aruco_ros-release/compare/release/noetic/aruco/3.1.3-1...release/noetic/aruco/3.1.3-1)
- ros/noetic.v3.17/ros-noetic-audio-capture [diff](https://github.com/ros-gbp/audio_common-release/compare/release/noetic/audio_capture/0.3.16-1...release/noetic/audio_capture/0.3.16-1)
- ros/noetic.v3.17/ros-noetic-audio-common-msgs [diff](https://github.com/ros-gbp/audio_common-release/compare/release/noetic/audio_common_msgs/0.3.16-1...release/noetic/audio_common_msgs/0.3.16-1)
- ros/noetic.v3.17/ros-noetic-audio-common [diff](https://github.com/ros-gbp/audio_common-release/compare/release/noetic/audio_common/0.3.16-1...release/noetic/audio_common/0.3.16-1)
- ros/noetic.v3.17/ros-noetic-audio-play [diff](https://github.com/ros-gbp/audio_common-release/compare/release/noetic/audio_play/0.3.16-1...release/noetic/audio_play/0.3.16-1)
- ros/noetic.v3.17/ros-noetic-base-local-planner [diff](https://github.com/ros-gbp/navigation-release/compare/release/noetic/base_local_planner/1.17.2-1...release/noetic/base_local_planner/1.17.2-1)
- ros/noetic.v3.17/ros-noetic-bond-core [diff](https://github.com/ros-gbp/bond_core-release/compare/release/noetic/bond_core/1.8.6-1...release/noetic/bond_core/1.8.6-1)
- ros/noetic.v3.17/ros-noetic-bond [diff](https://github.com/ros-gbp/bond_core-release/compare/release/noetic/bond/1.8.6-1...release/noetic/bond/1.8.6-1)
- ros/noetic.v3.17/ros-noetic-bondcpp [diff](https://github.com/ros-gbp/bond_core-release/compare/release/noetic/bondcpp/1.8.6-1...release/noetic/bondcpp/1.8.6-1)
- ros/noetic.v3.17/ros-noetic-bondpy [diff](https://github.com/ros-gbp/bond_core-release/compare/release/noetic/bondpy/1.8.6-1...release/noetic/bondpy/1.8.6-1)
- ros/noetic.v3.17/ros-noetic-camera-calibration-parsers [diff](https://github.com/ros-gbp/image_common-release/compare/release/noetic/camera_calibration_parsers/1.12.0-1...release/noetic/camera_calibration_parsers/1.12.0-1)
- ros/noetic.v3.17/ros-noetic-camera-calibration [diff](https://github.com/ros-gbp/image_pipeline-release/compare/release/noetic/camera_calibration/1.17.0-1...release/noetic/camera_calibration/1.17.0-1)
- ros/noetic.v3.17/ros-noetic-camera-info-manager [diff](https://github.com/ros-gbp/image_common-release/compare/release/noetic/camera_info_manager/1.12.0-1...release/noetic/camera_info_manager/1.12.0-1)
- ros/noetic.v3.17/ros-noetic-carrot-planner [diff](https://github.com/ros-gbp/navigation-release/compare/release/noetic/carrot_planner/1.17.2-1...release/noetic/carrot_planner/1.17.2-1)
- ros/noetic.v3.17/ros-noetic-catkin [diff](https://github.com/ros-gbp/catkin-release/compare/release/noetic/catkin/0.8.10-1...release/noetic/catkin/0.8.10-1)
- ros/noetic.v3.17/ros-noetic-class-loader [diff](https://github.com/ros-gbp/class_loader-release/compare/release/noetic/class_loader/0.5.0-1...release/noetic/class_loader/0.5.0-1)
- ros/noetic.v3.17/ros-noetic-clear-costmap-recovery [diff](https://github.com/ros-gbp/navigation-release/compare/release/noetic/clear_costmap_recovery/1.17.2-1...release/noetic/clear_costmap_recovery/1.17.2-1)
- ros/noetic.v3.17/ros-noetic-cmake-modules [diff](https://github.com/ros-gbp/cmake_modules-release/compare/release/noetic/cmake_modules/0.5.0-1...release/noetic/cmake_modules/0.5.0-1)
- ros/noetic.v3.17/ros-noetic-combined-robot-hw [diff](https://github.com/ros-gbp/ros_control-release/compare/release/noetic/combined_robot_hw/0.19.6-1...release/noetic/combined_robot_hw/0.19.6-1)
- ros/noetic.v3.17/ros-noetic-common-msgs [diff](https://github.com/ros-gbp/common_msgs-release/compare/release/noetic/common_msgs/1.13.1-1...release/noetic/common_msgs/1.13.1-1)
- ros/noetic.v3.17/ros-noetic-compressed-depth-image-transport [diff](https://github.com/ros-gbp/image_transport_plugins-release/compare/release/noetic/compressed_depth_image_transport/1.14.0-1...release/noetic/compressed_depth_image_transport/1.14.0-1)
- ros/noetic.v3.17/ros-noetic-compressed-image-transport [diff](https://github.com/ros-gbp/image_transport_plugins-release/compare/release/noetic/compressed_image_transport/1.14.0-1...release/noetic/compressed_image_transport/1.14.0-1)
- ros/noetic.v3.17/ros-noetic-control-msgs [diff](https://github.com/ros-gbp/control_msgs-release/compare/release/noetic/control_msgs/1.5.2-1...release/noetic/control_msgs/1.5.2-1)
- ros/noetic.v3.17/ros-noetic-controller-interface [diff](https://github.com/ros-gbp/ros_control-release/compare/release/noetic/controller_interface/0.19.6-1...release/noetic/controller_interface/0.19.6-1)
- ros/noetic.v3.17/ros-noetic-controller-manager-msgs [diff](https://github.com/ros-gbp/ros_control-release/compare/release/noetic/controller_manager_msgs/0.19.6-1...release/noetic/controller_manager_msgs/0.19.6-1)
- ros/noetic.v3.17/ros-noetic-controller-manager [diff](https://github.com/ros-gbp/ros_control-release/compare/release/noetic/controller_manager/0.19.6-1...release/noetic/controller_manager/0.19.6-1)
- ros/noetic.v3.17/ros-noetic-costmap-2d [diff](https://github.com/ros-gbp/navigation-release/compare/release/noetic/costmap_2d/1.17.2-1...release/noetic/costmap_2d/1.17.2-1)
- ros/noetic.v3.17/ros-noetic-costmap-cspace-msgs [diff](https://github.com/at-wat/neonavigation_msgs-release/compare/release/noetic/costmap_cspace_msgs/0.8.0-1...release/noetic/costmap_cspace_msgs/0.8.0-1)
- ros/noetic.v3.17/ros-noetic-costmap-cspace [diff](https://github.com/at-wat/neonavigation-release/compare/release/noetic/costmap_cspace/0.11.7-1...release/noetic/costmap_cspace/0.11.7-1)
- ros/noetic.v3.17/ros-noetic-cpp-common [diff](https://github.com/ros-gbp/roscpp_core-release/compare/release/noetic/cpp_common/0.7.2-1...release/noetic/cpp_common/0.7.2-1)
- ros/noetic.v3.17/ros-noetic-cv-bridge [diff](https://github.com/ros-gbp/vision_opencv-release/compare/release/noetic/cv_bridge/1.16.2-1...release/noetic/cv_bridge/1.16.2-1)
- ros/noetic.v3.17/ros-noetic-depth-image-proc [diff](https://github.com/ros-gbp/image_pipeline-release/compare/release/noetic/depth_image_proc/1.17.0-1...release/noetic/depth_image_proc/1.17.0-1)
- ros/noetic.v3.17/ros-noetic-diagnostic-aggregator [diff](https://github.com/ros-gbp/diagnostics-release/compare/release/noetic/diagnostic_aggregator/1.11.0-1...release/noetic/diagnostic_aggregator/1.11.0-1)
- ros/noetic.v3.17/ros-noetic-diagnostic-analysis [diff](https://github.com/ros-gbp/diagnostics-release/compare/release/noetic/diagnostic_analysis/1.11.0-1...release/noetic/diagnostic_analysis/1.11.0-1)
- ros/noetic.v3.17/ros-noetic-diagnostic-common-diagnostics [diff](https://github.com/ros-gbp/diagnostics-release/compare/release/noetic/diagnostic_common_diagnostics/1.11.0-1...release/noetic/diagnostic_common_diagnostics/1.11.0-1)
- ros/noetic.v3.17/ros-noetic-diagnostic-msgs [diff](https://github.com/ros-gbp/common_msgs-release/compare/release/noetic/diagnostic_msgs/1.13.1-1...release/noetic/diagnostic_msgs/1.13.1-1)
- ros/noetic.v3.17/ros-noetic-diagnostic-updater [diff](https://github.com/ros-gbp/diagnostics-release/compare/release/noetic/diagnostic_updater/1.11.0-1...release/noetic/diagnostic_updater/1.11.0-1)
- ros/noetic.v3.17/ros-noetic-diagnostics [diff](https://github.com/ros-gbp/diagnostics-release/compare/release/noetic/diagnostics/1.11.0-1...release/noetic/diagnostics/1.11.0-1)
- ros/noetic.v3.17/ros-noetic-dwa-local-planner [diff](https://github.com/ros-gbp/navigation-release/compare/release/noetic/dwa_local_planner/1.17.2-1...release/noetic/dwa_local_planner/1.17.2-1)
- ros/noetic.v3.17/ros-noetic-dynamic-reconfigure [diff](https://github.com/ros-gbp/dynamic_reconfigure-release/compare/release/noetic/dynamic_reconfigure/1.7.3-1...release/noetic/dynamic_reconfigure/1.7.3-1)
- ros/noetic.v3.17/ros-noetic-eigen-conversions [diff](https://github.com/ros-gbp/geometry-release/compare/release/noetic/eigen_conversions/1.13.2-1...release/noetic/eigen_conversions/1.13.2-1)
- ros/noetic.v3.17/ros-noetic-executive-smach-visualization [diff](https://github.com/jbohren/executive_smach_visualization-release/compare/release/noetic/executive_smach_visualization/4.0.1-1...release/noetic/executive_smach_visualization/4.0.1-1)
- ros/noetic.v3.17/ros-noetic-executive-smach [diff](https://github.com/ros-gbp/executive_smach-release/compare/release/noetic/executive_smach/2.5.0-1...release/noetic/executive_smach/2.5.0-1)
- ros/noetic.v3.17/ros-noetic-fake-localization [diff](https://github.com/ros-gbp/navigation-release/compare/release/noetic/fake_localization/1.17.2-1...release/noetic/fake_localization/1.17.2-1)
- ros/noetic.v3.17/ros-noetic-filters [diff](https://github.com/ros-gbp/filters-release/compare/release/noetic/filters/1.9.2-1...release/noetic/filters/1.9.2-1)
- ros/noetic.v3.17/ros-noetic-gencpp [diff](https://github.com/ros-gbp/gencpp-release/compare/release/noetic/gencpp/0.7.0-1...release/noetic/gencpp/0.7.0-1)
- ros/noetic.v3.17/ros-noetic-geneus [diff](https://github.com/tork-a/geneus-release/compare/release/noetic/geneus/3.0.0-1...release/noetic/geneus/3.0.0-1)
- ros/noetic.v3.17/ros-noetic-genlisp [diff](https://github.com/ros-gbp/genlisp-release/compare/release/noetic/genlisp/0.4.18-1...release/noetic/genlisp/0.4.18-1)
- ros/noetic.v3.17/ros-noetic-genmsg [diff](https://github.com/ros-gbp/genmsg-release/compare/release/noetic/genmsg/0.6.0-1...release/noetic/genmsg/0.6.0-1)
- ros/noetic.v3.17/ros-noetic-gennodejs [diff](https://github.com/sloretz/gennodejs-release/compare/release/noetic/gennodejs/2.0.2-1...release/noetic/gennodejs/2.0.2-1)
- ros/noetic.v3.17/ros-noetic-genpy [diff](https://github.com/ros-gbp/genpy-release/compare/release/noetic/genpy/0.6.15-1...release/noetic/genpy/0.6.15-1)
- ros/noetic.v3.17/ros-noetic-geographic-msgs [diff](https://github.com/ros-geographic-info/geographic_info-release/compare/release/noetic/geographic_msgs/0.5.6-1...release/noetic/geographic_msgs/0.5.6-1)
- ros/noetic.v3.17/ros-noetic-geometry-msgs [diff](https://github.com/ros-gbp/common_msgs-release/compare/release/noetic/geometry_msgs/1.13.1-1...release/noetic/geometry_msgs/1.13.1-1)
- ros/noetic.v3.17/ros-noetic-geometry [diff](https://github.com/ros-gbp/geometry-release/compare/release/noetic/geometry/1.13.2-1...release/noetic/geometry/1.13.2-1)
- ros/noetic.v3.17/ros-noetic-gl-dependency [diff](https://github.com/ros-gbp/gl_dependency-release/compare/release/noetic/gl_dependency/1.1.2-1...release/noetic/gl_dependency/1.1.2-1)
- ros/noetic.v3.17/ros-noetic-global-planner [diff](https://github.com/ros-gbp/navigation-release/compare/release/noetic/global_planner/1.17.2-1...release/noetic/global_planner/1.17.2-1)
- ros/noetic.v3.17/ros-noetic-grid-map-core [diff](https://github.com/anybotics/grid_map-release/compare/release/noetic/grid_map_core/1.6.4-1...release/noetic/grid_map_core/1.6.4-1)
- ros/noetic.v3.17/ros-noetic-grid-map-cv [diff](https://github.com/anybotics/grid_map-release/compare/release/noetic/grid_map_cv/1.6.4-1...release/noetic/grid_map_cv/1.6.4-1)
- ros/noetic.v3.17/ros-noetic-grid-map-msgs [diff](https://github.com/anybotics/grid_map-release/compare/release/noetic/grid_map_msgs/1.6.4-1...release/noetic/grid_map_msgs/1.6.4-1)
- ros/noetic.v3.17/ros-noetic-grid-map-ros [diff](https://github.com/anybotics/grid_map-release/compare/release/noetic/grid_map_ros/1.6.4-1...release/noetic/grid_map_ros/1.6.4-1)
- ros/noetic.v3.17/ros-noetic-grid-map-rviz-plugin [diff](https://github.com/anybotics/grid_map-release/compare/release/noetic/grid_map_rviz_plugin/1.6.4-1...release/noetic/grid_map_rviz_plugin/1.6.4-1)
- ros/noetic.v3.17/ros-noetic-hardware-interface [diff](https://github.com/ros-gbp/ros_control-release/compare/release/noetic/hardware_interface/0.19.6-1...release/noetic/hardware_interface/0.19.6-1)
- ros/noetic.v3.17/ros-noetic-ifm3d-core [diff](https://github.com/ifm/ifm3d-release/compare/release/noetic/ifm3d_core/0.18.0-5...release/noetic/ifm3d_core/0.18.0-5)
- ros/noetic.v3.17/ros-noetic-ifm3d [diff](https://github.com/ifm/ifm3d-ros-release/compare/release/noetic/ifm3d/0.6.2-3...release/noetic/ifm3d/0.6.2-3)
- ros/noetic.v3.17/ros-noetic-image-common [diff](https://github.com/ros-gbp/image_common-release/compare/release/noetic/image_common/1.12.0-1...release/noetic/image_common/1.12.0-1)
- ros/noetic.v3.17/ros-noetic-image-geometry [diff](https://github.com/ros-gbp/vision_opencv-release/compare/release/noetic/image_geometry/1.16.2-1...release/noetic/image_geometry/1.16.2-1)
- ros/noetic.v3.17/ros-noetic-image-pipeline [diff](https://github.com/ros-gbp/image_pipeline-release/compare/release/noetic/image_pipeline/1.17.0-1...release/noetic/image_pipeline/1.17.0-1)
- ros/noetic.v3.17/ros-noetic-image-proc [diff](https://github.com/ros-gbp/image_pipeline-release/compare/release/noetic/image_proc/1.17.0-1...release/noetic/image_proc/1.17.0-1)
- ros/noetic.v3.17/ros-noetic-image-publisher [diff](https://github.com/ros-gbp/image_pipeline-release/compare/release/noetic/image_publisher/1.17.0-1...release/noetic/image_publisher/1.17.0-1)
- ros/noetic.v3.17/ros-noetic-image-rotate [diff](https://github.com/ros-gbp/image_pipeline-release/compare/release/noetic/image_rotate/1.17.0-1...release/noetic/image_rotate/1.17.0-1)
- ros/noetic.v3.17/ros-noetic-image-transport-plugins [diff](https://github.com/ros-gbp/image_transport_plugins-release/compare/release/noetic/image_transport_plugins/1.14.0-1...release/noetic/image_transport_plugins/1.14.0-1)
- ros/noetic.v3.17/ros-noetic-image-transport [diff](https://github.com/ros-gbp/image_common-release/compare/release/noetic/image_transport/1.12.0-1...release/noetic/image_transport/1.12.0-1)
- ros/noetic.v3.17/ros-noetic-image-view [diff](https://github.com/ros-gbp/image_pipeline-release/compare/release/noetic/image_view/1.17.0-1...release/noetic/image_view/1.17.0-1)
- ros/noetic.v3.17/ros-noetic-imu-complementary-filter [diff](https://github.com/uos-gbp/imu_tools-release/compare/release/noetic/imu_complementary_filter/1.2.5-1...release/noetic/imu_complementary_filter/1.2.5-1)
- ros/noetic.v3.17/ros-noetic-imu-filter-madgwick [diff](https://github.com/uos-gbp/imu_tools-release/compare/release/noetic/imu_filter_madgwick/1.2.5-1...release/noetic/imu_filter_madgwick/1.2.5-1)
- ros/noetic.v3.17/ros-noetic-imu-tools [diff](https://github.com/uos-gbp/imu_tools-release/compare/release/noetic/imu_tools/1.2.5-1...release/noetic/imu_tools/1.2.5-1)
- ros/noetic.v3.17/ros-noetic-interactive-markers [diff](https://github.com/ros-gbp/interactive_markers-release/compare/release/noetic/interactive_markers/1.12.0-1...release/noetic/interactive_markers/1.12.0-1)
- ros/noetic.v3.17/ros-noetic-joint-limits-interface [diff](https://github.com/ros-gbp/ros_control-release/compare/release/noetic/joint_limits_interface/0.19.6-1...release/noetic/joint_limits_interface/0.19.6-1)
- ros/noetic.v3.17/ros-noetic-joint-state-publisher-gui [diff](https://github.com/ros-gbp/joint_state_publisher-release/compare/release/noetic/joint_state_publisher_gui/1.15.1-1...release/noetic/joint_state_publisher_gui/1.15.1-1)
- ros/noetic.v3.17/ros-noetic-joint-state-publisher [diff](https://github.com/ros-gbp/joint_state_publisher-release/compare/release/noetic/joint_state_publisher/1.15.1-1...release/noetic/joint_state_publisher/1.15.1-1)
- ros/noetic.v3.17/ros-noetic-joy [diff](https://github.com/ros-gbp/joystick_drivers-release/compare/release/noetic/joy/1.15.1-1...release/noetic/joy/1.15.1-1)
- ros/noetic.v3.17/ros-noetic-joystick-interrupt [diff](https://github.com/at-wat/neonavigation-release/compare/release/noetic/joystick_interrupt/0.11.7-1...release/noetic/joystick_interrupt/0.11.7-1)
- ros/noetic.v3.17/ros-noetic-kdl-conversions [diff](https://github.com/ros-gbp/geometry-release/compare/release/noetic/kdl_conversions/1.13.2-1...release/noetic/kdl_conversions/1.13.2-1)
- ros/noetic.v3.17/ros-noetic-kdl-parser [diff](https://github.com/ros-gbp/kdl_parser-release/compare/release/noetic/kdl_parser/1.14.2-1...release/noetic/kdl_parser/1.14.2-1)
- ros/noetic.v3.17/ros-noetic-laser-assembler [diff](https://github.com/ros-gbp/laser_assembler-release/compare/release/noetic/laser_assembler/1.7.8-1...release/noetic/laser_assembler/1.7.8-1)
- ros/noetic.v3.17/ros-noetic-laser-filters [diff](https://github.com/ros-gbp/laser_filters-release/compare/release/noetic/laser_filters/1.9.0-1...release/noetic/laser_filters/1.9.0-1)
- ros/noetic.v3.17/ros-noetic-laser-geometry [diff](https://github.com/ros-gbp/laser_geometry-release/compare/release/noetic/laser_geometry/1.6.7-1...release/noetic/laser_geometry/1.6.7-1)
- ros/noetic.v3.17/ros-noetic-laser-pipeline [diff](https://github.com/ros-gbp/laser_pipeline-release/compare/release/noetic/laser_pipeline/1.6.4-1...release/noetic/laser_pipeline/1.6.4-1)
- ros/noetic.v3.17/ros-noetic-laser-proc [diff](https://github.com/ros-gbp/laser_proc-release/compare/release/noetic/laser_proc/0.1.6-1...release/noetic/laser_proc/0.1.6-1)
- ros/noetic.v3.17/ros-noetic-map-msgs [diff](https://github.com/ros-gbp/navigation_msgs-release/compare/release/noetic/map_msgs/1.14.1-1...release/noetic/map_msgs/1.14.1-1)
- ros/noetic.v3.17/ros-noetic-map-organizer-msgs [diff](https://github.com/at-wat/neonavigation_msgs-release/compare/release/noetic/map_organizer_msgs/0.8.0-1...release/noetic/map_organizer_msgs/0.8.0-1)
- ros/noetic.v3.17/ros-noetic-map-organizer [diff](https://github.com/at-wat/neonavigation-release/compare/release/noetic/map_organizer/0.11.7-1...release/noetic/map_organizer/0.11.7-1)
- ros/noetic.v3.17/ros-noetic-map-server [diff](https://github.com/ros-gbp/navigation-release/compare/release/noetic/map_server/1.17.2-1...release/noetic/map_server/1.17.2-1)
- ros/noetic.v3.17/ros-noetic-mcl-3dl-msgs [diff](https://github.com/at-wat/mcl_3dl_msgs-release/compare/release/noetic/mcl_3dl_msgs/0.6.0-1...release/noetic/mcl_3dl_msgs/0.6.0-1)
- ros/noetic.v3.17/ros-noetic-mcl-3dl [diff](https://github.com/at-wat/mcl_3dl-release/compare/release/noetic/mcl_3dl/0.6.0-1...release/noetic/mcl_3dl/0.6.0-1)
- ros/noetic.v3.17/ros-noetic-media-export [diff](https://github.com/ros-gbp/media_export-release/compare/release/noetic/media_export/0.3.0-1...release/noetic/media_export/0.3.0-1)
- ros/noetic.v3.17/ros-noetic-message-filters [diff](https://github.com/ros-gbp/ros_comm-release/compare/release/noetic/message_filters/1.15.15-1...release/noetic/message_filters/1.15.15-1)
- ros/noetic.v3.17/ros-noetic-message-generation [diff](https://github.com/ros-gbp/message_generation-release/compare/release/noetic/message_generation/0.4.1-1...release/noetic/message_generation/0.4.1-1)
- ros/noetic.v3.17/ros-noetic-message-runtime [diff](https://github.com/ros-gbp/message_runtime-release/compare/release/noetic/message_runtime/0.4.13-1...release/noetic/message_runtime/0.4.13-1)
- ros/noetic.v3.17/ros-noetic-mk [diff](https://github.com/ros-gbp/ros-release/compare/release/noetic/mk/1.15.8-1...release/noetic/mk/1.15.8-1)
- ros/noetic.v3.17/ros-noetic-move-base-msgs [diff](https://github.com/ros-gbp/navigation_msgs-release/compare/release/noetic/move_base_msgs/1.14.1-1...release/noetic/move_base_msgs/1.14.1-1)
- ros/noetic.v3.17/ros-noetic-move-base [diff](https://github.com/ros-gbp/navigation-release/compare/release/noetic/move_base/1.17.2-1...release/noetic/move_base/1.17.2-1)
- ros/noetic.v3.17/ros-noetic-move-slow-and-clear [diff](https://github.com/ros-gbp/navigation-release/compare/release/noetic/move_slow_and_clear/1.17.2-1...release/noetic/move_slow_and_clear/1.17.2-1)
- ros/noetic.v3.17/ros-noetic-nav-core [diff](https://github.com/ros-gbp/navigation-release/compare/release/noetic/nav_core/1.17.2-1...release/noetic/nav_core/1.17.2-1)
- ros/noetic.v3.17/ros-noetic-nav-msgs [diff](https://github.com/ros-gbp/common_msgs-release/compare/release/noetic/nav_msgs/1.13.1-1...release/noetic/nav_msgs/1.13.1-1)
- ros/noetic.v3.17/ros-noetic-navfn [diff](https://github.com/ros-gbp/navigation-release/compare/release/noetic/navfn/1.17.2-1...release/noetic/navfn/1.17.2-1)
- ros/noetic.v3.17/ros-noetic-navigation [diff](https://github.com/ros-gbp/navigation-release/compare/release/noetic/navigation/1.17.2-1...release/noetic/navigation/1.17.2-1)
- ros/noetic.v3.17/ros-noetic-neonavigation-common [diff](https://github.com/at-wat/neonavigation-release/compare/release/noetic/neonavigation_common/0.11.7-1...release/noetic/neonavigation_common/0.11.7-1)
- ros/noetic.v3.17/ros-noetic-neonavigation-launch [diff](https://github.com/at-wat/neonavigation-release/compare/release/noetic/neonavigation_launch/0.11.7-1...release/noetic/neonavigation_launch/0.11.7-1)
- ros/noetic.v3.17/ros-noetic-neonavigation-msgs [diff](https://github.com/at-wat/neonavigation_msgs-release/compare/release/noetic/neonavigation_msgs/0.8.0-1...release/noetic/neonavigation_msgs/0.8.0-1)
- ros/noetic.v3.17/ros-noetic-neonavigation-rviz-plugins [diff](https://github.com/at-wat/neonavigation_rviz_plugins-release/compare/release/noetic/neonavigation_rviz_plugins/0.11.6-1...release/noetic/neonavigation_rviz_plugins/0.11.6-1)
- ros/noetic.v3.17/ros-noetic-neonavigation [diff](https://github.com/at-wat/neonavigation-release/compare/release/noetic/neonavigation/0.11.7-1...release/noetic/neonavigation/0.11.7-1)
- ros/noetic.v3.17/ros-noetic-nodelet-core [diff](https://github.com/ros-gbp/nodelet_core-release/compare/release/noetic/nodelet_core/1.10.2-1...release/noetic/nodelet_core/1.10.2-1)
- ros/noetic.v3.17/ros-noetic-nodelet-topic-tools [diff](https://github.com/ros-gbp/nodelet_core-release/compare/release/noetic/nodelet_topic_tools/1.10.2-1...release/noetic/nodelet_topic_tools/1.10.2-1)
- ros/noetic.v3.17/ros-noetic-nodelet [diff](https://github.com/ros-gbp/nodelet_core-release/compare/release/noetic/nodelet/1.10.2-1...release/noetic/nodelet/1.10.2-1)
- ros/noetic.v3.17/ros-noetic-obj-to-pointcloud [diff](https://github.com/at-wat/neonavigation-release/compare/release/noetic/obj_to_pointcloud/0.11.7-1...release/noetic/obj_to_pointcloud/0.11.7-1)
- ros/noetic.v3.17/ros-noetic-octomap-msgs [diff](https://github.com/ros-gbp/octomap_msgs-release/compare/release/noetic/octomap_msgs/0.3.5-1...release/noetic/octomap_msgs/0.3.5-1)
- ros/noetic.v3.17/ros-noetic-octomap-ros [diff](https://github.com/ros-gbp/octomap_ros-release/compare/release/noetic/octomap_ros/0.4.1-1...release/noetic/octomap_ros/0.4.1-1)
- ros/noetic.v3.17/ros-noetic-octomap [diff](https://github.com/ros-gbp/octomap-release/compare/release/noetic/octomap/1.9.8-1...release/noetic/octomap/1.9.8-1)
- ros/noetic.v3.17/ros-noetic-pcl-conversions [diff](https://github.com/ros-gbp/perception_pcl-release/compare/release/noetic/pcl_conversions/1.7.4-1...release/noetic/pcl_conversions/1.7.4-1)
- ros/noetic.v3.17/ros-noetic-pcl-msgs [diff](https://github.com/ros-gbp/pcl_msgs-release/compare/release/noetic/pcl_msgs/0.3.0-1...release/noetic/pcl_msgs/0.3.0-1)
- ros/noetic.v3.17/ros-noetic-pcl-ros [diff](https://github.com/ros-gbp/perception_pcl-release/compare/release/noetic/pcl_ros/1.7.4-1...release/noetic/pcl_ros/1.7.4-1)
- ros/noetic.v3.17/ros-noetic-perception-pcl [diff](https://github.com/ros-gbp/perception_pcl-release/compare/release/noetic/perception_pcl/1.7.4-1...release/noetic/perception_pcl/1.7.4-1)
- ros/noetic.v3.17/ros-noetic-perception [diff](https://github.com/ros-gbp/metapackages-release/compare/release/noetic/perception/1.5.0-1...release/noetic/perception/1.5.0-1)
- ros/noetic.v3.17/ros-noetic-planner-cspace-msgs [diff](https://github.com/at-wat/neonavigation_msgs-release/compare/release/noetic/planner_cspace_msgs/0.8.0-1...release/noetic/planner_cspace_msgs/0.8.0-1)
- ros/noetic.v3.17/ros-noetic-planner-cspace [diff](https://github.com/at-wat/neonavigation-release/compare/release/noetic/planner_cspace/0.11.7-1...release/noetic/planner_cspace/0.11.7-1)
- ros/noetic.v3.17/ros-noetic-pluginlib [diff](https://github.com/ros-gbp/pluginlib-release/compare/release/noetic/pluginlib/1.13.0-1...release/noetic/pluginlib/1.13.0-1)
- ros/noetic.v3.17/ros-noetic-polled-camera [diff](https://github.com/ros-gbp/image_common-release/compare/release/noetic/polled_camera/1.12.0-1...release/noetic/polled_camera/1.12.0-1)
- ros/noetic.v3.17/ros-noetic-python-qt-binding [diff](https://github.com/ros-gbp/python_qt_binding-release/compare/release/noetic/python_qt_binding/0.4.4-1...release/noetic/python_qt_binding/0.4.4-1)
- ros/noetic.v3.17/ros-noetic-qt-dotgraph [diff](https://github.com/ros-gbp/qt_gui_core-release/compare/release/noetic/qt_dotgraph/0.4.2-1...release/noetic/qt_dotgraph/0.4.2-1)
- ros/noetic.v3.17/ros-noetic-qt-gui-cpp [diff](https://github.com/ros-gbp/qt_gui_core-release/compare/release/noetic/qt_gui_cpp/0.4.2-1...release/noetic/qt_gui_cpp/0.4.2-1)
- ros/noetic.v3.17/ros-noetic-qt-gui-py-common [diff](https://github.com/ros-gbp/qt_gui_core-release/compare/release/noetic/qt_gui_py_common/0.4.2-1...release/noetic/qt_gui_py_common/0.4.2-1)
- ros/noetic.v3.17/ros-noetic-qt-gui [diff](https://github.com/ros-gbp/qt_gui_core-release/compare/release/noetic/qt_gui/0.4.2-1...release/noetic/qt_gui/0.4.2-1)
- ros/noetic.v3.17/ros-noetic-qwt-dependency [diff](https://github.com/ros-gbp/qwt_dependency-release/compare/release/noetic/qwt_dependency/1.1.1-2...release/noetic/qwt_dependency/1.1.1-2)
- ros/noetic.v3.17/ros-noetic-realtime-tools [diff](https://github.com/ros-gbp/realtime_tools-release/compare/release/noetic/realtime_tools/1.16.1-1...release/noetic/realtime_tools/1.16.1-1)
- ros/noetic.v3.17/ros-noetic-resource-retriever [diff](https://github.com/ros-gbp/resource_retriever-release/compare/release/noetic/resource_retriever/1.12.7-1...release/noetic/resource_retriever/1.12.7-1)
- ros/noetic.v3.17/ros-noetic-robot-state-publisher [diff](https://github.com/ros-gbp/robot_state_publisher-release/compare/release/noetic/robot_state_publisher/1.15.2-1...release/noetic/robot_state_publisher/1.15.2-1)
- ros/noetic.v3.17/ros-noetic-robot [diff](https://github.com/ros-gbp/metapackages-release/compare/release/noetic/robot/1.5.0-1...release/noetic/robot/1.5.0-1)
- ros/noetic.v3.17/ros-noetic-ros-base [diff](https://github.com/ros-gbp/metapackages-release/compare/release/noetic/ros_base/1.5.0-1...release/noetic/ros_base/1.5.0-1)
- ros/noetic.v3.17/ros-noetic-ros-comm [diff](https://github.com/ros-gbp/ros_comm-release/compare/release/noetic/ros_comm/1.15.15-1...release/noetic/ros_comm/1.15.15-1)
- ros/noetic.v3.17/ros-noetic-ros-control [diff](https://github.com/ros-gbp/ros_control-release/compare/release/noetic/ros_control/0.19.6-1...release/noetic/ros_control/0.19.6-1)
- ros/noetic.v3.17/ros-noetic-ros-core [diff](https://github.com/ros-gbp/metapackages-release/compare/release/noetic/ros_core/1.5.0-1...release/noetic/ros_core/1.5.0-1)
- ros/noetic.v3.17/ros-noetic-ros-environment [diff](https://github.com/ros-gbp/ros_environment-release/compare/release/noetic/ros_environment/1.3.2-1...release/noetic/ros_environment/1.3.2-1)
- ros/noetic.v3.17/ros-noetic-ros-tutorials [diff](https://github.com/ros-gbp/ros_tutorials-release/compare/release/noetic/ros_tutorials/0.10.2-1...release/noetic/ros_tutorials/0.10.2-1)
- ros/noetic.v3.17/ros-noetic-ros [diff](https://github.com/ros-gbp/ros-release/compare/release/noetic/ros/1.15.8-1...release/noetic/ros/1.15.8-1)
- ros/noetic.v3.17/ros-noetic-rosapi [diff](https://github.com/RobotWebTools-release/rosbridge_suite-release/compare/release/noetic/rosapi/0.11.16-2...release/noetic/rosapi/0.11.16-2)
- ros/noetic.v3.17/ros-noetic-rosauth [diff](https://github.com/gt-rail-release/rosauth-release/compare/release/noetic/rosauth/1.0.1-1...release/noetic/rosauth/1.0.1-1)
- ros/noetic.v3.17/ros-noetic-rosbag-migration-rule [diff](https://github.com/ros-gbp/rosbag_migration_rule-release/compare/release/noetic/rosbag_migration_rule/1.0.1-1...release/noetic/rosbag_migration_rule/1.0.1-1)
- ros/noetic.v3.17/ros-noetic-rosbag-storage [diff](https://github.com/ros-gbp/ros_comm-release/compare/release/noetic/rosbag_storage/1.15.15-1...release/noetic/rosbag_storage/1.15.15-1)
- ros/noetic.v3.17/ros-noetic-rosbag [diff](https://github.com/ros-gbp/ros_comm-release/compare/release/noetic/rosbag/1.15.15-1...release/noetic/rosbag/1.15.15-1)
- ros/noetic.v3.17/ros-noetic-rosbash [diff](https://github.com/ros-gbp/ros-release/compare/release/noetic/rosbash/1.15.8-1...release/noetic/rosbash/1.15.8-1)
- ros/noetic.v3.17/ros-noetic-rosboost-cfg [diff](https://github.com/ros-gbp/ros-release/compare/release/noetic/rosboost_cfg/1.15.8-1...release/noetic/rosboost_cfg/1.15.8-1)
- ros/noetic.v3.17/ros-noetic-rosbridge-library [diff](https://github.com/RobotWebTools-release/rosbridge_suite-release/compare/release/noetic/rosbridge_library/0.11.16-2...release/noetic/rosbridge_library/0.11.16-2)
- ros/noetic.v3.17/ros-noetic-rosbridge-msgs [diff](https://github.com/RobotWebTools-release/rosbridge_suite-release/compare/release/noetic/rosbridge_msgs/0.11.16-2...release/noetic/rosbridge_msgs/0.11.16-2)
- ros/noetic.v3.17/ros-noetic-rosbridge-server [diff](https://github.com/RobotWebTools-release/rosbridge_suite-release/compare/release/noetic/rosbridge_server/0.11.16-2...release/noetic/rosbridge_server/0.11.16-2)
- ros/noetic.v3.17/ros-noetic-rosbridge-suite [diff](https://github.com/RobotWebTools-release/rosbridge_suite-release/compare/release/noetic/rosbridge_suite/0.11.16-2...release/noetic/rosbridge_suite/0.11.16-2)
- ros/noetic.v3.17/ros-noetic-rosbuild [diff](https://github.com/ros-gbp/ros-release/compare/release/noetic/rosbuild/1.15.8-1...release/noetic/rosbuild/1.15.8-1)
- ros/noetic.v3.17/ros-noetic-rosclean [diff](https://github.com/ros-gbp/ros-release/compare/release/noetic/rosclean/1.15.8-1...release/noetic/rosclean/1.15.8-1)
- ros/noetic.v3.17/ros-noetic-rosconsole-bridge [diff](https://github.com/ros-gbp/rosconsole_bridge-release/compare/release/noetic/rosconsole_bridge/0.5.4-1...release/noetic/rosconsole_bridge/0.5.4-1)
- ros/noetic.v3.17/ros-noetic-rosconsole [diff](https://github.com/ros-gbp/rosconsole-release/compare/release/noetic/rosconsole/1.14.3-1...release/noetic/rosconsole/1.14.3-1)
- ros/noetic.v3.17/ros-noetic-roscpp-core [diff](https://github.com/ros-gbp/roscpp_core-release/compare/release/noetic/roscpp_core/0.7.2-1...release/noetic/roscpp_core/0.7.2-1)
- ros/noetic.v3.17/ros-noetic-roscpp-serialization [diff](https://github.com/ros-gbp/roscpp_core-release/compare/release/noetic/roscpp_serialization/0.7.2-1...release/noetic/roscpp_serialization/0.7.2-1)
- ros/noetic.v3.17/ros-noetic-roscpp-traits [diff](https://github.com/ros-gbp/roscpp_core-release/compare/release/noetic/roscpp_traits/0.7.2-1...release/noetic/roscpp_traits/0.7.2-1)
- ros/noetic.v3.17/ros-noetic-roscpp-tutorials [diff](https://github.com/ros-gbp/ros_tutorials-release/compare/release/noetic/roscpp_tutorials/0.10.2-1...release/noetic/roscpp_tutorials/0.10.2-1)
- ros/noetic.v3.17/ros-noetic-roscpp [diff](https://github.com/ros-gbp/ros_comm-release/compare/release/noetic/roscpp/1.15.15-1...release/noetic/roscpp/1.15.15-1)
- ros/noetic.v3.17/ros-noetic-roscreate [diff](https://github.com/ros-gbp/ros-release/compare/release/noetic/roscreate/1.15.8-1...release/noetic/roscreate/1.15.8-1)
- ros/noetic.v3.17/ros-noetic-rosgraph-msgs [diff](https://github.com/ros-gbp/ros_comm_msgs-release/compare/release/noetic/rosgraph_msgs/1.11.3-1...release/noetic/rosgraph_msgs/1.11.3-1)
- ros/noetic.v3.17/ros-noetic-rosgraph [diff](https://github.com/ros-gbp/ros_comm-release/compare/release/noetic/rosgraph/1.15.15-1...release/noetic/rosgraph/1.15.15-1)
- ros/noetic.v3.17/ros-noetic-roslang [diff](https://github.com/ros-gbp/ros-release/compare/release/noetic/roslang/1.15.8-1...release/noetic/roslang/1.15.8-1)
- ros/noetic.v3.17/ros-noetic-roslaunch [diff](https://github.com/ros-gbp/ros_comm-release/compare/release/noetic/roslaunch/1.15.15-1...release/noetic/roslaunch/1.15.15-1)
- ros/noetic.v3.17/ros-noetic-roslib [diff](https://github.com/ros-gbp/ros-release/compare/release/noetic/roslib/1.15.8-1...release/noetic/roslib/1.15.8-1)
- ros/noetic.v3.17/ros-noetic-roslint [diff](https://github.com/ros-gbp/roslint-release/compare/release/noetic/roslint/0.12.0-1...release/noetic/roslint/0.12.0-1)
- ros/noetic.v3.17/ros-noetic-roslisp [diff](https://github.com/ros-gbp/roslisp-release/compare/release/noetic/roslisp/1.9.24-1...release/noetic/roslisp/1.9.24-1)
- ros/noetic.v3.17/ros-noetic-roslz4 [diff](https://github.com/ros-gbp/ros_comm-release/compare/release/noetic/roslz4/1.15.15-1...release/noetic/roslz4/1.15.15-1)
- ros/noetic.v3.17/ros-noetic-rosmake [diff](https://github.com/ros-gbp/ros-release/compare/release/noetic/rosmake/1.15.8-1...release/noetic/rosmake/1.15.8-1)
- ros/noetic.v3.17/ros-noetic-rosmaster [diff](https://github.com/ros-gbp/ros_comm-release/compare/release/noetic/rosmaster/1.15.15-1...release/noetic/rosmaster/1.15.15-1)
- ros/noetic.v3.17/ros-noetic-rosmsg [diff](https://github.com/ros-gbp/ros_comm-release/compare/release/noetic/rosmsg/1.15.15-1...release/noetic/rosmsg/1.15.15-1)
- ros/noetic.v3.17/ros-noetic-rosnode [diff](https://github.com/ros-gbp/ros_comm-release/compare/release/noetic/rosnode/1.15.15-1...release/noetic/rosnode/1.15.15-1)
- ros/noetic.v3.17/ros-noetic-rosout [diff](https://github.com/ros-gbp/ros_comm-release/compare/release/noetic/rosout/1.15.15-1...release/noetic/rosout/1.15.15-1)
- ros/noetic.v3.17/ros-noetic-rospack [diff](https://github.com/ros-gbp/rospack-release/compare/release/noetic/rospack/2.6.2-1...release/noetic/rospack/2.6.2-1)
- ros/noetic.v3.17/ros-noetic-rosparam [diff](https://github.com/ros-gbp/ros_comm-release/compare/release/noetic/rosparam/1.15.15-1...release/noetic/rosparam/1.15.15-1)
- ros/noetic.v3.17/ros-noetic-rospy-tutorials [diff](https://github.com/ros-gbp/ros_tutorials-release/compare/release/noetic/rospy_tutorials/0.10.2-1...release/noetic/rospy_tutorials/0.10.2-1)
- ros/noetic.v3.17/ros-noetic-rospy [diff](https://github.com/ros-gbp/ros_comm-release/compare/release/noetic/rospy/1.15.15-1...release/noetic/rospy/1.15.15-1)
- ros/noetic.v3.17/ros-noetic-rosserial-client [diff](https://github.com/ros-gbp/rosserial-release/compare/release/noetic/rosserial_client/0.9.2-1...release/noetic/rosserial_client/0.9.2-1)
- ros/noetic.v3.17/ros-noetic-rosserial-msgs [diff](https://github.com/ros-gbp/rosserial-release/compare/release/noetic/rosserial_msgs/0.9.2-1...release/noetic/rosserial_msgs/0.9.2-1)
- ros/noetic.v3.17/ros-noetic-rosserial-python [diff](https://github.com/ros-gbp/rosserial-release/compare/release/noetic/rosserial_python/0.9.2-1...release/noetic/rosserial_python/0.9.2-1)
- ros/noetic.v3.17/ros-noetic-rosserial [diff](https://github.com/ros-gbp/rosserial-release/compare/release/noetic/rosserial/0.9.2-1...release/noetic/rosserial/0.9.2-1)
- ros/noetic.v3.17/ros-noetic-rosservice [diff](https://github.com/ros-gbp/ros_comm-release/compare/release/noetic/rosservice/1.15.15-1...release/noetic/rosservice/1.15.15-1)
- ros/noetic.v3.17/ros-noetic-rostest [diff](https://github.com/ros-gbp/ros_comm-release/compare/release/noetic/rostest/1.15.15-1...release/noetic/rostest/1.15.15-1)
- ros/noetic.v3.17/ros-noetic-rostime [diff](https://github.com/ros-gbp/roscpp_core-release/compare/release/noetic/rostime/0.7.2-1...release/noetic/rostime/0.7.2-1)
- ros/noetic.v3.17/ros-noetic-rostopic [diff](https://github.com/ros-gbp/ros_comm-release/compare/release/noetic/rostopic/1.15.15-1...release/noetic/rostopic/1.15.15-1)
- ros/noetic.v3.17/ros-noetic-rosunit [diff](https://github.com/ros-gbp/ros-release/compare/release/noetic/rosunit/1.15.8-1...release/noetic/rosunit/1.15.8-1)
- ros/noetic.v3.17/ros-noetic-roswtf [diff](https://github.com/ros-gbp/ros_comm-release/compare/release/noetic/roswtf/1.15.15-1...release/noetic/roswtf/1.15.15-1)
- ros/noetic.v3.17/ros-noetic-rotate-recovery [diff](https://github.com/ros-gbp/navigation-release/compare/release/noetic/rotate_recovery/1.17.2-1...release/noetic/rotate_recovery/1.17.2-1)
- ros/noetic.v3.17/ros-noetic-rqt-action [diff](https://github.com/ros-gbp/rqt_action-release/compare/release/noetic/rqt_action/0.4.9-1...release/noetic/rqt_action/0.4.9-1)
- ros/noetic.v3.17/ros-noetic-rqt-bag-plugins [diff](https://github.com/ros-gbp/rqt_bag-release/compare/release/noetic/rqt_bag_plugins/0.5.1-1...release/noetic/rqt_bag_plugins/0.5.1-1)
- ros/noetic.v3.17/ros-noetic-rqt-bag [diff](https://github.com/ros-gbp/rqt_bag-release/compare/release/noetic/rqt_bag/0.5.1-1...release/noetic/rqt_bag/0.5.1-1)
- ros/noetic.v3.17/ros-noetic-rqt-common-plugins [diff](https://github.com/ros-gbp/rqt_common_plugins-release/compare/release/noetic/rqt_common_plugins/0.4.9-1...release/noetic/rqt_common_plugins/0.4.9-1)
- ros/noetic.v3.17/ros-noetic-rqt-console [diff](https://github.com/ros-gbp/rqt_console-release/compare/release/noetic/rqt_console/0.4.11-1...release/noetic/rqt_console/0.4.11-1)
- ros/noetic.v3.17/ros-noetic-rqt-dep [diff](https://github.com/ros-gbp/rqt_dep-release/compare/release/noetic/rqt_dep/0.4.12-1...release/noetic/rqt_dep/0.4.12-1)
- ros/noetic.v3.17/ros-noetic-rqt-graph [diff](https://github.com/ros-gbp/rqt_graph-release/compare/release/noetic/rqt_graph/0.4.14-1...release/noetic/rqt_graph/0.4.14-1)
- ros/noetic.v3.17/ros-noetic-rqt-gui-cpp [diff](https://github.com/ros-gbp/rqt-release/compare/release/noetic/rqt_gui_cpp/0.5.3-1...release/noetic/rqt_gui_cpp/0.5.3-1)
- ros/noetic.v3.17/ros-noetic-rqt-gui-py [diff](https://github.com/ros-gbp/rqt-release/compare/release/noetic/rqt_gui_py/0.5.3-1...release/noetic/rqt_gui_py/0.5.3-1)
- ros/noetic.v3.17/ros-noetic-rqt-gui [diff](https://github.com/ros-gbp/rqt-release/compare/release/noetic/rqt_gui/0.5.3-1...release/noetic/rqt_gui/0.5.3-1)
- ros/noetic.v3.17/ros-noetic-rqt-image-view [diff](https://github.com/ros-gbp/rqt_image_view-release/compare/release/noetic/rqt_image_view/0.4.16-1...release/noetic/rqt_image_view/0.4.16-1)
- ros/noetic.v3.17/ros-noetic-rqt-launch [diff](https://github.com/ros-gbp/rqt_launch-release/compare/release/noetic/rqt_launch/0.4.9-1...release/noetic/rqt_launch/0.4.9-1)
- ros/noetic.v3.17/ros-noetic-rqt-logger-level [diff](https://github.com/ros-gbp/rqt_logger_level-release/compare/release/noetic/rqt_logger_level/0.4.11-1...release/noetic/rqt_logger_level/0.4.11-1)
- ros/noetic.v3.17/ros-noetic-rqt-moveit [diff](https://github.com/ros-gbp/rqt_moveit-release/compare/release/noetic/rqt_moveit/0.5.10-1...release/noetic/rqt_moveit/0.5.10-1)
- ros/noetic.v3.17/ros-noetic-rqt-msg [diff](https://github.com/ros-gbp/rqt_msg-release/compare/release/noetic/rqt_msg/0.4.10-1...release/noetic/rqt_msg/0.4.10-1)
- ros/noetic.v3.17/ros-noetic-rqt-nav-view [diff](https://github.com/ros-gbp/rqt_nav_view-release/compare/release/noetic/rqt_nav_view/0.5.7-1...release/noetic/rqt_nav_view/0.5.7-1)
- ros/noetic.v3.17/ros-noetic-rqt-plot [diff](https://github.com/ros-gbp/rqt_plot-release/compare/release/noetic/rqt_plot/0.4.13-2...release/noetic/rqt_plot/0.4.13-2)
- ros/noetic.v3.17/ros-noetic-rqt-pose-view [diff](https://github.com/ros-gbp/rqt_pose_view-release/compare/release/noetic/rqt_pose_view/0.5.11-1...release/noetic/rqt_pose_view/0.5.11-1)
- ros/noetic.v3.17/ros-noetic-rqt-publisher [diff](https://github.com/ros-gbp/rqt_publisher-release/compare/release/noetic/rqt_publisher/0.4.10-1...release/noetic/rqt_publisher/0.4.10-1)
- ros/noetic.v3.17/ros-noetic-rqt-py-common [diff](https://github.com/ros-gbp/rqt-release/compare/release/noetic/rqt_py_common/0.5.3-1...release/noetic/rqt_py_common/0.5.3-1)
- ros/noetic.v3.17/ros-noetic-rqt-py-console [diff](https://github.com/ros-gbp/rqt_py_console-release/compare/release/noetic/rqt_py_console/0.4.10-1...release/noetic/rqt_py_console/0.4.10-1)
- ros/noetic.v3.17/ros-noetic-rqt-reconfigure [diff](https://github.com/ros-gbp/rqt_reconfigure-release/compare/release/noetic/rqt_reconfigure/0.5.5-1...release/noetic/rqt_reconfigure/0.5.5-1)
- ros/noetic.v3.17/ros-noetic-rqt-robot-dashboard [diff](https://github.com/ros-gbp/rqt_robot_dashboard-release/compare/release/noetic/rqt_robot_dashboard/0.5.8-1...release/noetic/rqt_robot_dashboard/0.5.8-1)
- ros/noetic.v3.17/ros-noetic-rqt-robot-monitor [diff](https://github.com/ros-gbp/rqt_robot_monitor-release/compare/release/noetic/rqt_robot_monitor/0.5.14-1...release/noetic/rqt_robot_monitor/0.5.14-1)
- ros/noetic.v3.17/ros-noetic-rqt-robot-plugins [diff](https://github.com/ros-gbp/rqt_robot_plugins-release/compare/release/noetic/rqt_robot_plugins/0.5.8-1...release/noetic/rqt_robot_plugins/0.5.8-1)
- ros/noetic.v3.17/ros-noetic-rqt-robot-steering [diff](https://github.com/ros-gbp/rqt_robot_steering-release/compare/release/noetic/rqt_robot_steering/0.5.12-1...release/noetic/rqt_robot_steering/0.5.12-1)
- ros/noetic.v3.17/ros-noetic-rqt-runtime-monitor [diff](https://github.com/ros-gbp/rqt_runtime_monitor-release/compare/release/noetic/rqt_runtime_monitor/0.5.9-1...release/noetic/rqt_runtime_monitor/0.5.9-1)
- ros/noetic.v3.17/ros-noetic-rqt-rviz [diff](https://github.com/ros-gbp/rqt_rviz-release/compare/release/noetic/rqt_rviz/0.7.0-1...release/noetic/rqt_rviz/0.7.0-1)
- ros/noetic.v3.17/ros-noetic-rqt-service-caller [diff](https://github.com/ros-gbp/rqt_service_caller-release/compare/release/noetic/rqt_service_caller/0.4.10-1...release/noetic/rqt_service_caller/0.4.10-1)
- ros/noetic.v3.17/ros-noetic-rqt-shell [diff](https://github.com/ros-gbp/rqt_shell-release/compare/release/noetic/rqt_shell/0.4.11-1...release/noetic/rqt_shell/0.4.11-1)
- ros/noetic.v3.17/ros-noetic-rqt-srv [diff](https://github.com/ros-gbp/rqt_srv-release/compare/release/noetic/rqt_srv/0.4.9-1...release/noetic/rqt_srv/0.4.9-1)
- ros/noetic.v3.17/ros-noetic-rqt-tf-tree [diff](https://github.com/ros-gbp/rqt_tf_tree-release/compare/release/noetic/rqt_tf_tree/0.6.3-1...release/noetic/rqt_tf_tree/0.6.3-1)
- ros/noetic.v3.17/ros-noetic-rqt-top [diff](https://github.com/ros-gbp/rqt_top-release/compare/release/noetic/rqt_top/0.4.10-1...release/noetic/rqt_top/0.4.10-1)
- ros/noetic.v3.17/ros-noetic-rqt-topic [diff](https://github.com/ros-gbp/rqt_topic-release/compare/release/noetic/rqt_topic/0.4.13-1...release/noetic/rqt_topic/0.4.13-1)
- ros/noetic.v3.17/ros-noetic-rqt-web [diff](https://github.com/ros-gbp/rqt_web-release/compare/release/noetic/rqt_web/0.4.10-1...release/noetic/rqt_web/0.4.10-1)
- ros/noetic.v3.17/ros-noetic-rviz-imu-plugin [diff](https://github.com/uos-gbp/imu_tools-release/compare/release/noetic/rviz_imu_plugin/1.2.5-1...release/noetic/rviz_imu_plugin/1.2.5-1)
- ros/noetic.v3.17/ros-noetic-rviz [diff](https://github.com/ros-gbp/rviz-release/compare/release/noetic/rviz/1.14.19-1...release/noetic/rviz/1.14.19-1)
- ros/noetic.v3.17/ros-noetic-safety-limiter-msgs [diff](https://github.com/at-wat/neonavigation_msgs-release/compare/release/noetic/safety_limiter_msgs/0.8.0-1...release/noetic/safety_limiter_msgs/0.8.0-1)
- ros/noetic.v3.17/ros-noetic-safety-limiter [diff](https://github.com/at-wat/neonavigation-release/compare/release/noetic/safety_limiter/0.11.7-1...release/noetic/safety_limiter/0.11.7-1)
- ros/noetic.v3.17/ros-noetic-self-test [diff](https://github.com/ros-gbp/diagnostics-release/compare/release/noetic/self_test/1.11.0-1...release/noetic/self_test/1.11.0-1)
- ros/noetic.v3.17/ros-noetic-sensor-msgs [diff](https://github.com/ros-gbp/common_msgs-release/compare/release/noetic/sensor_msgs/1.13.1-1...release/noetic/sensor_msgs/1.13.1-1)
- ros/noetic.v3.17/ros-noetic-shape-msgs [diff](https://github.com/ros-gbp/common_msgs-release/compare/release/noetic/shape_msgs/1.13.1-1...release/noetic/shape_msgs/1.13.1-1)
- ros/noetic.v3.17/ros-noetic-smach-msgs [diff](https://github.com/ros-gbp/executive_smach-release/compare/release/noetic/smach_msgs/2.5.0-1...release/noetic/smach_msgs/2.5.0-1)
- ros/noetic.v3.17/ros-noetic-smach-ros [diff](https://github.com/ros-gbp/executive_smach-release/compare/release/noetic/smach_ros/2.5.0-1...release/noetic/smach_ros/2.5.0-1)
- ros/noetic.v3.17/ros-noetic-smach-viewer [diff](https://github.com/jbohren/executive_smach_visualization-release/compare/release/noetic/smach_viewer/4.0.1-1...release/noetic/smach_viewer/4.0.1-1)
- ros/noetic.v3.17/ros-noetic-smach [diff](https://github.com/ros-gbp/executive_smach-release/compare/release/noetic/smach/2.5.0-1...release/noetic/smach/2.5.0-1)
- ros/noetic.v3.17/ros-noetic-smclib [diff](https://github.com/ros-gbp/bond_core-release/compare/release/noetic/smclib/1.8.6-1...release/noetic/smclib/1.8.6-1)
- ros/noetic.v3.17/ros-noetic-sound-play [diff](https://github.com/ros-gbp/audio_common-release/compare/release/noetic/sound_play/0.3.16-1...release/noetic/sound_play/0.3.16-1)
- ros/noetic.v3.17/ros-noetic-std-msgs [diff](https://github.com/ros-gbp/std_msgs-release/compare/release/noetic/std_msgs/0.5.13-1...release/noetic/std_msgs/0.5.13-1)
- ros/noetic.v3.17/ros-noetic-std-srvs [diff](https://github.com/ros-gbp/ros_comm_msgs-release/compare/release/noetic/std_srvs/1.11.3-1...release/noetic/std_srvs/1.11.3-1)
- ros/noetic.v3.17/ros-noetic-stereo-image-proc [diff](https://github.com/ros-gbp/image_pipeline-release/compare/release/noetic/stereo_image_proc/1.17.0-1...release/noetic/stereo_image_proc/1.17.0-1)
- ros/noetic.v3.17/ros-noetic-stereo-msgs [diff](https://github.com/ros-gbp/common_msgs-release/compare/release/noetic/stereo_msgs/1.13.1-1...release/noetic/stereo_msgs/1.13.1-1)
- ros/noetic.v3.17/ros-noetic-tf-conversions [diff](https://github.com/ros-gbp/geometry-release/compare/release/noetic/tf_conversions/1.13.2-1...release/noetic/tf_conversions/1.13.2-1)
- ros/noetic.v3.17/ros-noetic-tf [diff](https://github.com/ros-gbp/geometry-release/compare/release/noetic/tf/1.13.2-1...release/noetic/tf/1.13.2-1)
- ros/noetic.v3.17/ros-noetic-tf2-eigen [diff](https://github.com/ros-gbp/geometry2-release/compare/release/noetic/tf2_eigen/0.7.6-1...release/noetic/tf2_eigen/0.7.6-1)
- ros/noetic.v3.17/ros-noetic-tf2-geometry-msgs [diff](https://github.com/ros-gbp/geometry2-release/compare/release/noetic/tf2_geometry_msgs/0.7.6-1...release/noetic/tf2_geometry_msgs/0.7.6-1)
- ros/noetic.v3.17/ros-noetic-tf2-kdl [diff](https://github.com/ros-gbp/geometry2-release/compare/release/noetic/tf2_kdl/0.7.6-1...release/noetic/tf2_kdl/0.7.6-1)
- ros/noetic.v3.17/ros-noetic-tf2-msgs [diff](https://github.com/ros-gbp/geometry2-release/compare/release/noetic/tf2_msgs/0.7.6-1...release/noetic/tf2_msgs/0.7.6-1)
- ros/noetic.v3.17/ros-noetic-tf2-py [diff](https://github.com/ros-gbp/geometry2-release/compare/release/noetic/tf2_py/0.7.6-1...release/noetic/tf2_py/0.7.6-1)
- ros/noetic.v3.17/ros-noetic-tf2-ros [diff](https://github.com/ros-gbp/geometry2-release/compare/release/noetic/tf2_ros/0.7.6-1...release/noetic/tf2_ros/0.7.6-1)
- ros/noetic.v3.17/ros-noetic-tf2-sensor-msgs [diff](https://github.com/ros-gbp/geometry2-release/compare/release/noetic/tf2_sensor_msgs/0.7.6-1...release/noetic/tf2_sensor_msgs/0.7.6-1)
- ros/noetic.v3.17/ros-noetic-tf2 [diff](https://github.com/ros-gbp/geometry2-release/compare/release/noetic/tf2/0.7.6-1...release/noetic/tf2/0.7.6-1)
- ros/noetic.v3.17/ros-noetic-theora-image-transport [diff](https://github.com/ros-gbp/image_transport_plugins-release/compare/release/noetic/theora_image_transport/1.14.0-1...release/noetic/theora_image_transport/1.14.0-1)
- ros/noetic.v3.17/ros-noetic-topic-tools [diff](https://github.com/ros-gbp/ros_comm-release/compare/release/noetic/topic_tools/1.15.15-1...release/noetic/topic_tools/1.15.15-1)
- ros/noetic.v3.17/ros-noetic-track-odometry [diff](https://github.com/at-wat/neonavigation-release/compare/release/noetic/track_odometry/0.11.7-1...release/noetic/track_odometry/0.11.7-1)
- ros/noetic.v3.17/ros-noetic-trajectory-msgs [diff](https://github.com/ros-gbp/common_msgs-release/compare/release/noetic/trajectory_msgs/1.13.1-1...release/noetic/trajectory_msgs/1.13.1-1)
- ros/noetic.v3.17/ros-noetic-trajectory-tracker-msgs [diff](https://github.com/at-wat/neonavigation_msgs-release/compare/release/noetic/trajectory_tracker_msgs/0.8.0-1...release/noetic/trajectory_tracker_msgs/0.8.0-1)
- ros/noetic.v3.17/ros-noetic-trajectory-tracker-rviz-plugins [diff](https://github.com/at-wat/neonavigation_rviz_plugins-release/compare/release/noetic/trajectory_tracker_rviz_plugins/0.11.6-1...release/noetic/trajectory_tracker_rviz_plugins/0.11.6-1)
- ros/noetic.v3.17/ros-noetic-trajectory-tracker [diff](https://github.com/at-wat/neonavigation-release/compare/release/noetic/trajectory_tracker/0.11.7-1...release/noetic/trajectory_tracker/0.11.7-1)
- ros/noetic.v3.17/ros-noetic-transmission-interface [diff](https://github.com/ros-gbp/ros_control-release/compare/release/noetic/transmission_interface/0.19.6-1...release/noetic/transmission_interface/0.19.6-1)
- ros/noetic.v3.17/ros-noetic-turtlesim [diff](https://github.com/ros-gbp/ros_tutorials-release/compare/release/noetic/turtlesim/0.10.2-1...release/noetic/turtlesim/0.10.2-1)
- ros/noetic.v3.17/ros-noetic-urdf-parser-plugin [diff](https://github.com/ros-gbp/urdf-release/compare/release/noetic/urdf_parser_plugin/1.13.2-1...release/noetic/urdf_parser_plugin/1.13.2-1)
- ros/noetic.v3.17/ros-noetic-urdf [diff](https://github.com/ros-gbp/urdf-release/compare/release/noetic/urdf/1.13.2-1...release/noetic/urdf/1.13.2-1)
- ros/noetic.v3.17/ros-noetic-urg-c [diff](https://github.com/ros-gbp/urg_c-release/compare/release/noetic/urg_c/1.0.405-1...release/noetic/urg_c/1.0.405-1)
- ros/noetic.v3.17/ros-noetic-urg-node [diff](https://github.com/ros-gbp/urg_node-release/compare/release/noetic/urg_node/0.1.18-1...release/noetic/urg_node/0.1.18-1)
- ros/noetic.v3.17/ros-noetic-urg-stamped [diff](https://github.com/seqsense/urg_stamped-release/compare/release/noetic/urg_stamped/0.0.15-1...release/noetic/urg_stamped/0.0.15-1)
- ros/noetic.v3.17/ros-noetic-usb-cam [diff](https://github.com/ros-gbp/usb_cam-release/compare/release/noetic/usb_cam/0.3.6-1...release/noetic/usb_cam/0.3.6-1)
- ros/noetic.v3.17/ros-noetic-uuid-msgs [diff](https://github.com/ros-geographic-info/unique_identifier-release/compare/release/noetic/uuid_msgs/1.0.6-1...release/noetic/uuid_msgs/1.0.6-1)
- ros/noetic.v3.17/ros-noetic-velodyne-driver [diff](https://github.com/ros-drivers-gbp/velodyne-release/compare/release/noetic/velodyne_driver/1.7.0-1...release/noetic/velodyne_driver/1.7.0-1)
- ros/noetic.v3.17/ros-noetic-velodyne-laserscan [diff](https://github.com/ros-drivers-gbp/velodyne-release/compare/release/noetic/velodyne_laserscan/1.7.0-1...release/noetic/velodyne_laserscan/1.7.0-1)
- ros/noetic.v3.17/ros-noetic-velodyne-msgs [diff](https://github.com/ros-drivers-gbp/velodyne-release/compare/release/noetic/velodyne_msgs/1.7.0-1...release/noetic/velodyne_msgs/1.7.0-1)
- ros/noetic.v3.17/ros-noetic-velodyne-pcl [diff](https://github.com/ros-drivers-gbp/velodyne-release/compare/release/noetic/velodyne_pcl/1.7.0-1...release/noetic/velodyne_pcl/1.7.0-1)
- ros/noetic.v3.17/ros-noetic-velodyne-pointcloud [diff](https://github.com/ros-drivers-gbp/velodyne-release/compare/release/noetic/velodyne_pointcloud/1.7.0-1...release/noetic/velodyne_pointcloud/1.7.0-1)
- ros/noetic.v3.17/ros-noetic-velodyne [diff](https://github.com/ros-drivers-gbp/velodyne-release/compare/release/noetic/velodyne/1.7.0-1...release/noetic/velodyne/1.7.0-1)
- ros/noetic.v3.17/ros-noetic-vision-opencv [diff](https://github.com/ros-gbp/vision_opencv-release/compare/release/noetic/vision_opencv/1.16.2-1...release/noetic/vision_opencv/1.16.2-1)
- ros/noetic.v3.17/ros-noetic-visualization-msgs [diff](https://github.com/ros-gbp/common_msgs-release/compare/release/noetic/visualization_msgs/1.13.1-1...release/noetic/visualization_msgs/1.13.1-1)
- ros/noetic.v3.17/ros-noetic-viz [diff](https://github.com/ros-gbp/metapackages-release/compare/release/noetic/viz/1.5.0-1...release/noetic/viz/1.5.0-1)
- ros/noetic.v3.17/ros-noetic-voxel-grid [diff](https://github.com/ros-gbp/navigation-release/compare/release/noetic/voxel_grid/1.17.2-1...release/noetic/voxel_grid/1.17.2-1)
- ros/noetic.v3.17/ros-noetic-webkit-dependency [diff](https://github.com/ros-gbp/webkit_dependency-release/compare/release/noetic/webkit_dependency/1.1.2-1...release/noetic/webkit_dependency/1.1.2-1)
- ros/noetic.v3.17/ros-noetic-xacro [diff](https://github.com/ros-gbp/xacro-release/compare/release/noetic/xacro/1.14.14-1...release/noetic/xacro/1.14.14-1)
- ros/noetic.v3.17/ros-noetic-xmlrpcpp [diff](https://github.com/ros-gbp/ros_comm-release/compare/release/noetic/xmlrpcpp/1.15.15-1...release/noetic/xmlrpcpp/1.15.15-1)
- ros/noetic.v3.17/ros-noetic-ypspur-ros [diff](https://github.com/openspur/ypspur_ros-release/compare/release/noetic/ypspur_ros/0.3.5-1...release/noetic/ypspur_ros/0.3.5-1)
- ros/noetic.v3.17/ros-noetic-ypspur [diff](https://github.com/openspur/yp-spur-release/compare/release/noetic/ypspur/1.20.2-1...release/noetic/ypspur/1.20.2-1)
