### PR TITLE
Restore Melodic build

### DIFF
--- a/.aports.yml
+++ b/.aports.yml
@@ -1,4 +1,25 @@
 repos:
+  melodic-3.8:
+    main_ref: "master"
+    build_args:
+      ALPINE_VERSION: "3.8"
+      ROS_DISTRO: "melodic"
+    envs:
+      JOBS: 4
+      PURGE_OBSOLETE: "yes"
+      STACK_PROTECTOR: "off"
+      ADDITIONAL_APK_REPO: "http://alpine-ros.seqsense.org/v3.8/backports"
+    args: ["ros/melodic"]
+    repo_path: "/home/builder/packages/melodic"
+    cache_path: "/cache"
+    sign_key_path: "/home/builder/.abuild/builder@alpine-ros-experimental.rsa"
+    upload:
+      - remote: "main"
+        paths: ["v3.8/ros/melodic"]
+        archive_paths: ["archives/v3.8/ros/melodic"]
+      - remote: "mirror"
+        paths: ["v3.8/ros/melodic"]
+        archive_paths: ["archives/v3.8/ros/melodic"]
   backports-3.14:
     main_ref: "master"
     build_args:

--- a/build-repo.sh
+++ b/build-repo.sh
@@ -19,7 +19,7 @@ esac
 
 
 if [ -n "${ADDITIONAL_APK_REPO:-}" ]; then
-  echo "${ADDITIONAL_APK_REPO}" >> /etc/apk/repositories
+  echo "${ADDITIONAL_APK_REPO}" | sudo tee -a /etc/apk/repositories
 fi
 
 

--- a/build-repo.sh
+++ b/build-repo.sh
@@ -18,6 +18,11 @@ case "${PURGE_OBSOLETE:-no}" in
 esac
 
 
+if [ -n "${ADDITIONAL_APK_REPO:-}" ]; then
+  echo "${ADDITIONAL_APK_REPO}" >> /etc/apk/repositories
+fi
+
+
 # Disable stack protection to improve performance
 
 CFLAGS="-fomit-frame-pointer -march=x86-64 -mtune=generic -Os"


### PR DESCRIPTION
Melodic EOL seems be [May 2023](http://wiki.ros.org/Distributions) (it was originally April) and may have the last sync before EOL.
As it's too complicated to restore backports for 3.8, only ROS package build is restored.