### PR TITLE
v3.17/ros/hoetic/ros-noetic-catkin: Fix APKBUILD

### DIFF
--- a/v3.17/ros/noetic/ros-noetic-catkin/APKBUILD
+++ b/v3.17/ros/noetic/ros-noetic-catkin/APKBUILD
@@ -1,7 +1,7 @@
 pkgname=ros-noetic-catkin
 _pkgname=catkin
 pkgver=0.8.10
-pkgrel=2
+pkgrel=3
 pkgdesc="$_pkgname package for ROS noetic"
 url="http://wiki.ros.org/catkin"
 arch="all"
@@ -51,24 +51,13 @@ build() {
   set -o pipefail
   echo "building" > $statuslog
   cd "$builddir"
-  # Overwrite shebang
-  find src -type f | while read file; do
-    h=$(head -n1 "$file")
-    rewrite_shebang=false
-    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
-      rewrite_shebang=true
-    fi
-    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
-      rewrite_shebang=true
-    fi
-    if [ $rewrite_shebang == "true" ]; then
-      echo "WARN: rewriting python shebang of $file"
-      sed -i "1c#\!/usr/bin/env python3" "$file"
-    fi
-  done
-  source /usr/ros/noetic/setup.sh
-  catkin_make_isolated \
-    -DCMAKE_BUILD_TYPE=RelWithDebInfo 2>&1 | tee $buildlog
+  mkdir build
+  cd build
+  cmake ../src/$_pkgname \
+    -DCMAKE_INSTALL_PREFIX=/usr/ros/noetic \
+    -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+    -DCMAKE_INSTALL_LIBDIR=lib 2>&1 | tee $buildlog
+  make 2>&1 | tee -a $buildlog
 }
 
 check() {
@@ -79,19 +68,10 @@ check() {
   set -o pipefail
   echo "checking" >> $statuslog
   cd "$builddir"
-
-  if [ -z "$ROS_LOG_DIR" ]; then
-    logdir="$builddir/log"
-    mkdir -p "$logdir"
-    export ROS_LOG_DIR="$logdir"
+  cd build
+  if [ $(make -q test > /dev/null 2> /dev/null; echo $?) -eq 1 ]; then
+    make test 2>&1 | tee $checklog
   fi
-
-  source /usr/ros/noetic/setup.sh
-  source devel_isolated/setup.sh
-  catkin_make_isolated \
-    -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-    --catkin-make-args run_tests 2>&1 | tee $checklog
-  catkin_test_results 2>&1 | tee $checklog
 }
 
 dbg() {
@@ -105,20 +85,8 @@ package() {
   cd "$builddir"
   export DESTDIR="$pkgdir"
 
-  source /usr/ros/noetic/setup.sh
-  catkin_make_isolated \
-    -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-    --install-space /usr/ros/noetic
-  catkin_make_isolated \
-    -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-    --install --install-space /usr/ros/noetic
-  rm -f \
-    "$pkgdir"/usr/ros/noetic/setup.* \
-    "$pkgdir"/usr/ros/noetic/local_setup.* \
-    "$pkgdir"/usr/ros/noetic/.rosinstall \
-    "$pkgdir"/usr/ros/noetic/_setup_util.py \
-    "$pkgdir"/usr/ros/noetic/env.sh \
-    "$pkgdir"/usr/ros/noetic/.catkin
+  cd build
+  make install
 
   # Tweak invalid RPATH
   find $pkgdir -name "*.so" | while read so; do
@@ -173,6 +141,10 @@ package() {
     # Copy license files under the source
     if echo $file | grep -e '^\./\.'; then
       # Omit files under hidden directory
+      continue
+    fi
+    if echo $file | grep -e '^\./build/'; then
+      # Omit files under build directory
       continue
     fi
     echo "Copying license files from source tree: $file"


### PR DESCRIPTION
APKBUILD of catkin has been mistakenly changed by the automatic update to use catkin to build it.

ref: https://github.com/alpine-ros/ros-abuild-docker/pull/168