### PR TITLE
v3.20/ros/noetic/ros-noetic-roslint: fix E231 false-positive in python fstring

### DIFF
--- a/v3.20/ros/noetic/ros-noetic-roslint/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-roslint/APKBUILD
@@ -1,7 +1,7 @@
 pkgname=ros-noetic-roslint
 _pkgname=roslint
 pkgver=0.12.0
-pkgrel=1
+pkgrel=2
 pkgdesc="$_pkgname package for ROS noetic"
 url="http://ros.org/wiki/roslint"
 arch="all"

--- a/v3.20/ros/noetic/ros-noetic-roslint/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-roslint/APKBUILD
@@ -1,7 +1,7 @@
 pkgname=ros-noetic-roslint
 _pkgname=roslint
 pkgver=0.12.0
-pkgrel=0
+pkgrel=1
 pkgdesc="$_pkgname package for ROS noetic"
 url="http://ros.org/wiki/roslint"
 arch="all"

--- a/v3.20/ros/noetic/ros-noetic-roslint/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-roslint/APKBUILD
@@ -1,7 +1,7 @@
 pkgname=ros-noetic-roslint
 _pkgname=roslint
 pkgver=0.12.0
-pkgrel=2
+pkgrel=3
 pkgdesc="$_pkgname package for ROS noetic"
 url="http://ros.org/wiki/roslint"
 arch="all"

--- a/v3.20/ros/noetic/ros-noetic-roslint/fix-E231-in-py-fstring.patch
+++ b/v3.20/ros/noetic/ros-noetic-roslint/fix-E231-in-py-fstring.patch
@@ -1,0 +1,11 @@
+diff --git a/tests/clean1.py b/tests/clean1.py
+index 3147046..2d6a05a 100644
+--- a/tests/clean1.py
++++ b/tests/clean1.py
+@@ -19,3 +19,6 @@ def get(msg, key):
+         if prop.key == key:
+             return prop.value
+     return None
++
++def colon_in_fstring(hoge, foo):
++    return f"{hoge}:{foo}"

--- a/v3.20/ros/noetic/ros-noetic-roslint/fix-E231-in-py-fstring.patch
+++ b/v3.20/ros/noetic/ros-noetic-roslint/fix-E231-in-py-fstring.patch
@@ -1,5 +1,5 @@
 diff --git a/tests/clean1.py b/tests/clean1.py
-index 3147046..2d6a05a 100644
+index 3147046..cc88503 100644
 --- a/tests/clean1.py
 +++ b/tests/clean1.py
 @@ -19,3 +19,6 @@ def get(msg, key):
@@ -8,4 +8,4 @@ index 3147046..2d6a05a 100644
      return None
 +
 +def colon_in_fstring(hoge, foo):
-+    return f"{hoge}:{foo}"
++    print(f"{hoge}:{foo}")

--- a/v3.20/ros/noetic/ros-noetic-roslint/fix-E231-in-py-fstring.patch
+++ b/v3.20/ros/noetic/ros-noetic-roslint/fix-E231-in-py-fstring.patch
@@ -1,22 +1,45 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 6f90978..e4b2eb4 100644
+index 6f90978..970400a 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -26,4 +26,6 @@ if(CATKIN_ENABLE_TESTING)
+@@ -26,4 +26,20 @@ if(CATKIN_ENABLE_TESTING)
      src/roslint/cpplint_wrapper.py
      src/roslint/pycodestyle_wrapper.py)
    roslint_add_test()
 +
-+  add_subdirectory(tests)
++  # Run tests in tests/CMakeLists.txt.
++  # add_subdirectory(tests) doesn't work due to
++  # "TARGET 'roslint_roslint' was not created in this directory" error.
++
++  # Some simple Python unit tests, which must return zero status or make
++  # run_tests appears to fail.
++  roslint_python(tests/clean1.py)
++
++  # Run pylint with expected return status:
++  set(_RUNLINT "tests/runlint.py")
++  roslint_custom(${_RUNLINT} "0 pylint tests/clean1.py")
++  roslint_custom(${_RUNLINT} "16 pylint tests/dirty1.py")
++
++  # Make run_tests depend on the roslint targets created above.
++  add_dependencies(run_tests_${PROJECT_NAME} roslint_${PROJECT_NAME})
  endif()
 diff --git a/tests/clean1.py b/tests/clean1.py
-index 3147046..cc88503 100644
+index 3147046..43f5b99 100644
 --- a/tests/clean1.py
 +++ b/tests/clean1.py
-@@ -19,3 +19,6 @@ def get(msg, key):
+@@ -5,6 +5,7 @@ This Python module should pass ``pylint`` cleanly.
+ 
+ """
+ 
++
+ def get(msg, key):
+     """ Get property value.
+ 
+@@ -19,3 +20,7 @@ def get(msg, key):
          if prop.key == key:
              return prop.value
      return None
++
 +
 +def colon_in_fstring(hoge, foo):
 +    print(f"{hoge}:{foo}")

--- a/v3.20/ros/noetic/ros-noetic-roslint/fix-E231-in-py-fstring.patch
+++ b/v3.20/ros/noetic/ros-noetic-roslint/fix-E231-in-py-fstring.patch
@@ -23,6 +23,25 @@ index 6f90978..970400a 100644
 +  # Make run_tests depend on the roslint targets created above.
 +  add_dependencies(run_tests_${PROJECT_NAME} roslint_${PROJECT_NAME})
  endif()
+diff --git a/src/roslint/pycodestyle.py b/src/roslint/pycodestyle.py
+index b7e0b2f..60a3016 100644
+
+Ported https://github.com/PyCQA/pycodestyle/pull/1148
+
+--- a/src/roslint/pycodestyle.py
++++ b/src/roslint/pycodestyle.py
+@@ -2011,6 +2011,11 @@ class Checker(object):
+                 continue
+             if token_type == tokenize.STRING:
+                 text = mute_string(text)
++            elif (
++                    sys.version_info >= (3, 12) and
++                    token_type == tokenize.FSTRING_MIDDLE
++            ):
++                text = 'x' * len(text)
+             if prev_row:
+                 (start_row, start_col) = start
+                 if prev_row != start_row:    # different row
 diff --git a/tests/clean1.py b/tests/clean1.py
 index 3147046..43f5b99 100644
 --- a/tests/clean1.py

--- a/v3.20/ros/noetic/ros-noetic-roslint/fix-E231-in-py-fstring.patch
+++ b/v3.20/ros/noetic/ros-noetic-roslint/fix-E231-in-py-fstring.patch
@@ -1,3 +1,14 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 6f90978..e4b2eb4 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -26,4 +26,6 @@ if(CATKIN_ENABLE_TESTING)
+     src/roslint/cpplint_wrapper.py
+     src/roslint/pycodestyle_wrapper.py)
+   roslint_add_test()
++
++  add_subdirectory(tests)
+ endif()
 diff --git a/tests/clean1.py b/tests/clean1.py
 index 3147046..cc88503 100644
 --- a/tests/clean1.py


### PR DESCRIPTION
Port the fix from https://github.com/PyCQA/pycodestyle/pull/1148
and enable unused test in ros/roslint.

### Before porting the fix:

https://github.com/seqsense/aports-ros-experimental/runs/25776861476
```
Built target clean_test_results_roslint
tests/clean1.py:26:19: E231 missing whitespace after ':'
make[7]: *** [CMakeFiles/roslint_roslint.dir/build.make:71: roslint_roslint] Error 1
```

### After porting the fix:

https://github.com/seqsense/aports-ros-experimental/pull/951/checks?check_run_id=25776986808
No error