### PR TITLE
Alpine 3.20: add roscpp fix poll path patch

### DIFF
--- a/v3.20/ros/noetic/ros-noetic-roscpp/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-roscpp/APKBUILD
@@ -1,7 +1,7 @@
 pkgname=ros-noetic-roscpp
 _pkgname=roscpp
 pkgver=1.16.0
-pkgrel=1
+pkgrel=2
 pkgdesc="$_pkgname package for ROS noetic"
 url="http://ros.org/wiki/roscpp"
 arch="all"

--- a/v3.20/ros/noetic/ros-noetic-roscpp/fix-poll-path.patch
+++ b/v3.20/ros/noetic/ros-noetic-roscpp/fix-poll-path.patch
@@ -1,0 +1,12 @@
+diff --git a/include/ros/io.h b/include/ros/io.h
+index 19db3d790..f2558e837 100644
+--- a/include/ros/io.h
++++ b/include/ros/io.h
+@@ -53,7 +53,6 @@
+ 	#include <process.h> // for _getpid
+ #else
+ 	#include <poll.h> // should get cmake to explicitly check for poll.h?
+-	#include <sys/poll.h>
+ 	#include <arpa/inet.h>
+ 	#include <netdb.h>
+     #include <unistd.h>


### PR DESCRIPTION
I think this patch is still necessary when compiling packages that consider warnings as errors e.g. https://github.com/cra-ros-pkg/robot_localization/blob/af30f3bc0592d84fcc06bdbdf6063c126f834493/CMakeLists.txt#L53