### PR TITLE
v3.20/ros/noetic/ros-noetic-roslint: unuse bash

### DIFF
--- a/v3.20/ros/noetic/ros-noetic-roslint/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-roslint/APKBUILD
@@ -1,7 +1,7 @@
 pkgname=ros-noetic-roslint
 _pkgname=roslint
 pkgver=0.12.0
-pkgrel=3
+pkgrel=4
 pkgdesc="$_pkgname package for ROS noetic"
 url="http://ros.org/wiki/roslint"
 arch="all"

--- a/v3.20/ros/noetic/ros-noetic-roslint/unuse-bash.patch
+++ b/v3.20/ros/noetic/ros-noetic-roslint/unuse-bash.patch
@@ -1,0 +1,10 @@
+diff --git a/scripts/test_wrapper b/scripts/test_wrapper
+index 88d7d02..17aee57 100755
+--- a/scripts/test_wrapper
++++ b/scripts/test_wrapper
+@@ -1,4 +1,4 @@
+-#!/bin/bash
++#!/bin/sh
+ 
+ set -o pipefail
+ 


### PR DESCRIPTION
Copy the patch from v3.17