### PR TITLE
noetic-3.20: automatic update on 20240716-090812

### DIFF
--- a/v3.20/ros/noetic/ros-noetic-actionlib-msgs/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-actionlib-msgs/APKBUILD
@@ -7,10 +7,11 @@ url="http://wiki.ros.org/actionlib_msgs"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-message-generation ros-noetic-message-runtime ros-noetic-std-msgs ros-noetic-message-generation ros-noetic-message-runtime ros-noetic-std-msgs"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin>=0.5.78 ros-noetic-message-generation ros-noetic-std-msgs"
+depends="ros-noetic-message-generation ros-noetic-message-runtime ros-noetic-std-msgs"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin-dev>=0.5.78 ros-noetic-catkin>=0.5.78 ros-noetic-message-generation ros-noetic-message-generation-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev"
+depends_dev="ros-noetic-message-generation ros-noetic-message-generation-dev ros-noetic-message-runtime ros-noetic-message-runtime-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-actionlib/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-actionlib/APKBUILD
@@ -7,10 +7,11 @@ url="http://www.ros.org/wiki/actionlib"
 arch="all"
 license="BSD"
 
-depends="boost-dev ros-noetic-actionlib-msgs ros-noetic-message-runtime ros-noetic-roscpp ros-noetic-rospy ros-noetic-rostest ros-noetic-std-msgs boost-dev ros-noetic-actionlib-msgs ros-noetic-roscpp ros-noetic-rospy ros-noetic-rostest ros-noetic-std-msgs"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath boost-dev ros-noetic-actionlib-msgs ros-noetic-catkin>=0.5.78 ros-noetic-message-generation ros-noetic-roscpp ros-noetic-rosnode ros-noetic-rospy ros-noetic-rostest ros-noetic-rosunit ros-noetic-std-msgs"
+depends="ros-noetic-actionlib-msgs ros-noetic-message-runtime ros-noetic-roscpp ros-noetic-rospy ros-noetic-rostest ros-noetic-std-msgs"
+makedepends="boost-dev chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-actionlib-msgs ros-noetic-actionlib-msgs-dev ros-noetic-catkin-dev>=0.5.78 ros-noetic-catkin>=0.5.78 ros-noetic-message-generation ros-noetic-message-generation-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-rosnode ros-noetic-rosnode-dev ros-noetic-rospy ros-noetic-rospy-dev ros-noetic-rostest ros-noetic-rostest-dev ros-noetic-rosunit ros-noetic-rosunit-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev"
+depends_dev="boost-dev ros-noetic-actionlib-msgs ros-noetic-actionlib-msgs-dev ros-noetic-message-runtime-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-rospy ros-noetic-rospy-dev ros-noetic-rostest ros-noetic-rostest-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-amcl/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-amcl/APKBUILD
@@ -7,10 +7,11 @@ url="http://wiki.ros.org/amcl"
 arch="all"
 license="LGPL"
 
-depends="ros-noetic-diagnostic-updater ros-noetic-dynamic-reconfigure ros-noetic-geometry-msgs ros-noetic-nav-msgs ros-noetic-rosbag ros-noetic-roscpp ros-noetic-sensor-msgs ros-noetic-std-srvs ros-noetic-tf2 ros-noetic-tf2-msgs ros-noetic-tf2-ros ros-noetic-diagnostic-updater ros-noetic-dynamic-reconfigure ros-noetic-geometry-msgs ros-noetic-nav-msgs ros-noetic-rosbag ros-noetic-roscpp ros-noetic-sensor-msgs ros-noetic-std-srvs ros-noetic-tf2 ros-noetic-tf2-msgs ros-noetic-tf2-ros"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath py3-kdl ros-noetic-catkin ros-noetic-diagnostic-updater ros-noetic-dynamic-reconfigure ros-noetic-geometry-msgs ros-noetic-map-server ros-noetic-message-filters ros-noetic-nav-msgs ros-noetic-rosbag ros-noetic-roscpp ros-noetic-rostest ros-noetic-sensor-msgs ros-noetic-std-srvs ros-noetic-tf2 ros-noetic-tf2-geometry-msgs ros-noetic-tf2-msgs ros-noetic-tf2-py ros-noetic-tf2-ros"
+depends="ros-noetic-diagnostic-updater ros-noetic-dynamic-reconfigure ros-noetic-geometry-msgs ros-noetic-nav-msgs ros-noetic-rosbag ros-noetic-roscpp ros-noetic-sensor-msgs ros-noetic-std-srvs ros-noetic-tf2 ros-noetic-tf2-msgs ros-noetic-tf2-ros"
+makedepends="chrpath py3-kdl py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-diagnostic-updater ros-noetic-diagnostic-updater-dev ros-noetic-dynamic-reconfigure ros-noetic-dynamic-reconfigure-dev ros-noetic-geometry-msgs ros-noetic-geometry-msgs-dev ros-noetic-map-server ros-noetic-map-server-dev ros-noetic-message-filters ros-noetic-message-filters-dev ros-noetic-nav-msgs ros-noetic-nav-msgs-dev ros-noetic-rosbag ros-noetic-rosbag-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-rostest ros-noetic-rostest-dev ros-noetic-sensor-msgs ros-noetic-sensor-msgs-dev ros-noetic-std-srvs ros-noetic-std-srvs-dev ros-noetic-tf2 ros-noetic-tf2-dev ros-noetic-tf2-geometry-msgs ros-noetic-tf2-geometry-msgs-dev ros-noetic-tf2-msgs ros-noetic-tf2-msgs-dev ros-noetic-tf2-py ros-noetic-tf2-py-dev ros-noetic-tf2-ros ros-noetic-tf2-ros-dev"
+depends_dev="ros-noetic-diagnostic-updater ros-noetic-diagnostic-updater-dev ros-noetic-dynamic-reconfigure ros-noetic-dynamic-reconfigure-dev ros-noetic-geometry-msgs ros-noetic-geometry-msgs-dev ros-noetic-nav-msgs ros-noetic-nav-msgs-dev ros-noetic-rosbag ros-noetic-rosbag-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-sensor-msgs ros-noetic-sensor-msgs-dev ros-noetic-std-srvs ros-noetic-std-srvs-dev ros-noetic-tf2 ros-noetic-tf2-dev ros-noetic-tf2-msgs ros-noetic-tf2-msgs-dev ros-noetic-tf2-ros ros-noetic-tf2-ros-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-angles/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-angles/APKBUILD
@@ -8,9 +8,10 @@ arch="all"
 license="BSD"
 
 depends=""
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin>=0.5.68 ros-noetic-rosunit"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin-dev>=0.5.68 ros-noetic-catkin>=0.5.68 ros-noetic-rosunit ros-noetic-rosunit-dev"
+depends_dev=""
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-aruco-msgs/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-aruco-msgs/APKBUILD
@@ -7,10 +7,11 @@ url="http://wiki.ros.org/$_pkgname"
 arch="all"
 license="MIT"
 
-depends="ros-noetic-geometry-msgs ros-noetic-message-runtime ros-noetic-std-msgs ros-noetic-geometry-msgs ros-noetic-std-msgs"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin ros-noetic-geometry-msgs ros-noetic-message-generation ros-noetic-std-msgs"
+depends="ros-noetic-geometry-msgs ros-noetic-message-runtime ros-noetic-std-msgs"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-geometry-msgs ros-noetic-geometry-msgs-dev ros-noetic-message-generation ros-noetic-message-generation-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev"
+depends_dev="ros-noetic-geometry-msgs ros-noetic-geometry-msgs-dev ros-noetic-message-runtime-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-aruco-ros/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-aruco-ros/APKBUILD
@@ -7,10 +7,11 @@ url="http://www.uco.es/investiga/grupos/ava/node/26"
 arch="all"
 license="MIT"
 
-depends="ros-noetic-aruco ros-noetic-aruco-msgs ros-noetic-cv-bridge ros-noetic-dynamic-reconfigure ros-noetic-geometry-msgs ros-noetic-image-transport ros-noetic-roscpp ros-noetic-sensor-msgs ros-noetic-tf ros-noetic-visualization-msgs ros-noetic-aruco ros-noetic-aruco-msgs ros-noetic-cv-bridge ros-noetic-dynamic-reconfigure ros-noetic-geometry-msgs ros-noetic-image-transport ros-noetic-roscpp ros-noetic-sensor-msgs ros-noetic-tf ros-noetic-visualization-msgs"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-aruco ros-noetic-aruco-msgs ros-noetic-catkin ros-noetic-cv-bridge ros-noetic-dynamic-reconfigure ros-noetic-geometry-msgs ros-noetic-image-transport ros-noetic-roscpp ros-noetic-sensor-msgs ros-noetic-tf ros-noetic-visualization-msgs"
+depends="ros-noetic-aruco ros-noetic-aruco-msgs ros-noetic-cv-bridge ros-noetic-dynamic-reconfigure ros-noetic-geometry-msgs ros-noetic-image-transport ros-noetic-roscpp ros-noetic-sensor-msgs ros-noetic-tf ros-noetic-visualization-msgs"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-aruco ros-noetic-aruco-dev ros-noetic-aruco-msgs ros-noetic-aruco-msgs-dev ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-cv-bridge ros-noetic-cv-bridge-dev ros-noetic-dynamic-reconfigure ros-noetic-dynamic-reconfigure-dev ros-noetic-geometry-msgs ros-noetic-geometry-msgs-dev ros-noetic-image-transport ros-noetic-image-transport-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-sensor-msgs ros-noetic-sensor-msgs-dev ros-noetic-tf ros-noetic-tf-dev ros-noetic-visualization-msgs ros-noetic-visualization-msgs-dev"
+depends_dev="ros-noetic-aruco ros-noetic-aruco-dev ros-noetic-aruco-msgs ros-noetic-aruco-msgs-dev ros-noetic-cv-bridge ros-noetic-cv-bridge-dev ros-noetic-dynamic-reconfigure ros-noetic-dynamic-reconfigure-dev ros-noetic-geometry-msgs ros-noetic-geometry-msgs-dev ros-noetic-image-transport ros-noetic-image-transport-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-sensor-msgs ros-noetic-sensor-msgs-dev ros-noetic-tf ros-noetic-tf-dev ros-noetic-visualization-msgs ros-noetic-visualization-msgs-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-aruco/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-aruco/APKBUILD
@@ -7,10 +7,11 @@ url="http://www.uco.es/investiga/grupos/ava/node/26"
 arch="all"
 license="MIT"
 
-depends="eigen-dev ros-noetic-cv-bridge eigen-dev ros-noetic-cv-bridge"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath eigen-dev ros-noetic-catkin ros-noetic-cv-bridge"
+depends="ros-noetic-cv-bridge"
+makedepends="chrpath eigen-dev py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-cv-bridge ros-noetic-cv-bridge-dev"
+depends_dev="eigen-dev ros-noetic-cv-bridge ros-noetic-cv-bridge-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-audio-capture/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-audio-capture/APKBUILD
@@ -7,10 +7,11 @@ url="http://ros.org/wiki/audio_capture"
 arch="all"
 license="BSD"
 
-depends="gst-plugins-base gst-plugins-good gst-plugins-ugly gstreamer ros-noetic-audio-common-msgs ros-noetic-roscpp gst-plugins-base gst-plugins-good gst-plugins-ugly gstreamer ros-noetic-audio-common-msgs ros-noetic-roscpp"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath gst-plugins-base-dev gstreamer-dev ros-noetic-audio-common-msgs ros-noetic-catkin ros-noetic-roscpp"
+depends="gst-plugins-base gst-plugins-good gst-plugins-ugly gstreamer ros-noetic-audio-common-msgs ros-noetic-roscpp"
+makedepends="chrpath gst-plugins-base-dev gstreamer-dev py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-audio-common-msgs ros-noetic-audio-common-msgs-dev ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-roscpp ros-noetic-roscpp-dev"
+depends_dev="gst-plugins-base gst-plugins-good gst-plugins-ugly gstreamer ros-noetic-audio-common-msgs ros-noetic-audio-common-msgs-dev ros-noetic-roscpp ros-noetic-roscpp-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-audio-common-msgs/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-audio-common-msgs/APKBUILD
@@ -7,10 +7,11 @@ url="http://ros.org/wiki/audio_common_msgs"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-message-runtime ros-noetic-std-msgs ros-noetic-message-runtime ros-noetic-std-msgs"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin ros-noetic-message-generation ros-noetic-std-msgs"
+depends="ros-noetic-message-runtime ros-noetic-std-msgs"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-message-generation ros-noetic-message-generation-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev"
+depends_dev="ros-noetic-message-runtime ros-noetic-message-runtime-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-audio-common/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-audio-common/APKBUILD
@@ -7,10 +7,11 @@ url="http://ros.org/wiki/audio_common"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-audio-capture ros-noetic-audio-common-msgs ros-noetic-audio-play ros-noetic-sound-play ros-noetic-audio-capture ros-noetic-audio-common-msgs ros-noetic-audio-play ros-noetic-sound-play"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin"
+depends="ros-noetic-audio-capture ros-noetic-audio-common-msgs ros-noetic-audio-play ros-noetic-sound-play"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev"
+depends_dev="ros-noetic-audio-capture ros-noetic-audio-capture-dev ros-noetic-audio-common-msgs ros-noetic-audio-common-msgs-dev ros-noetic-audio-play ros-noetic-audio-play-dev ros-noetic-sound-play ros-noetic-sound-play-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-audio-play/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-audio-play/APKBUILD
@@ -7,10 +7,11 @@ url="http://ros.org/wiki/audio_play"
 arch="all"
 license="BSD"
 
-depends="gst-plugins-base gst-plugins-good gst-plugins-ugly gstreamer ros-noetic-audio-common-msgs ros-noetic-roscpp gst-plugins-base gst-plugins-good gst-plugins-ugly gstreamer ros-noetic-audio-common-msgs ros-noetic-roscpp"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath gst-plugins-base-dev gstreamer-dev ros-noetic-audio-common-msgs ros-noetic-catkin ros-noetic-roscpp"
+depends="gst-plugins-base gst-plugins-good gst-plugins-ugly gstreamer ros-noetic-audio-common-msgs ros-noetic-roscpp"
+makedepends="chrpath gst-plugins-base-dev gstreamer-dev py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-audio-common-msgs ros-noetic-audio-common-msgs-dev ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-roscpp ros-noetic-roscpp-dev"
+depends_dev="gst-plugins-base gst-plugins-good gst-plugins-ugly gstreamer ros-noetic-audio-common-msgs ros-noetic-audio-common-msgs-dev ros-noetic-roscpp ros-noetic-roscpp-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-base-local-planner/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-base-local-planner/APKBUILD
@@ -7,10 +7,11 @@ url="http://wiki.ros.org/base_local_planner"
 arch="all"
 license="BSD"
 
-depends="eigen-dev ros-noetic-angles ros-noetic-costmap-2d ros-noetic-dynamic-reconfigure ros-noetic-geometry-msgs ros-noetic-message-runtime ros-noetic-nav-core ros-noetic-nav-msgs ros-noetic-pluginlib ros-noetic-rosconsole ros-noetic-roscpp ros-noetic-rospy ros-noetic-sensor-msgs ros-noetic-std-msgs ros-noetic-tf2 ros-noetic-tf2-ros ros-noetic-visualization-msgs ros-noetic-voxel-grid eigen-dev ros-noetic-angles ros-noetic-costmap-2d ros-noetic-dynamic-reconfigure ros-noetic-geometry-msgs ros-noetic-nav-core ros-noetic-nav-msgs ros-noetic-pluginlib ros-noetic-rosconsole ros-noetic-roscpp ros-noetic-rospy ros-noetic-sensor-msgs ros-noetic-std-msgs ros-noetic-tf2 ros-noetic-tf2-ros ros-noetic-visualization-msgs ros-noetic-voxel-grid"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath eigen-dev ros-noetic-angles ros-noetic-catkin>=0.5.68 ros-noetic-cmake-modules ros-noetic-costmap-2d ros-noetic-dynamic-reconfigure ros-noetic-geometry-msgs ros-noetic-message-generation ros-noetic-nav-core ros-noetic-nav-msgs ros-noetic-pluginlib ros-noetic-rosconsole ros-noetic-roscpp ros-noetic-rospy ros-noetic-rosunit ros-noetic-sensor-msgs ros-noetic-std-msgs ros-noetic-tf2 ros-noetic-tf2-geometry-msgs ros-noetic-tf2-ros ros-noetic-visualization-msgs ros-noetic-voxel-grid"
+depends="ros-noetic-angles ros-noetic-costmap-2d ros-noetic-dynamic-reconfigure ros-noetic-geometry-msgs ros-noetic-message-runtime ros-noetic-nav-core ros-noetic-nav-msgs ros-noetic-pluginlib ros-noetic-rosconsole ros-noetic-roscpp ros-noetic-rospy ros-noetic-sensor-msgs ros-noetic-std-msgs ros-noetic-tf2 ros-noetic-tf2-ros ros-noetic-visualization-msgs ros-noetic-voxel-grid"
+makedepends="chrpath eigen-dev py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-angles ros-noetic-angles-dev ros-noetic-catkin-dev>=0.5.68 ros-noetic-catkin>=0.5.68 ros-noetic-cmake-modules ros-noetic-cmake-modules-dev ros-noetic-costmap-2d ros-noetic-costmap-2d-dev ros-noetic-dynamic-reconfigure ros-noetic-dynamic-reconfigure-dev ros-noetic-geometry-msgs ros-noetic-geometry-msgs-dev ros-noetic-message-generation ros-noetic-message-generation-dev ros-noetic-nav-core ros-noetic-nav-core-dev ros-noetic-nav-msgs ros-noetic-nav-msgs-dev ros-noetic-pluginlib ros-noetic-pluginlib-dev ros-noetic-rosconsole ros-noetic-rosconsole-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-rospy ros-noetic-rospy-dev ros-noetic-rosunit ros-noetic-rosunit-dev ros-noetic-sensor-msgs ros-noetic-sensor-msgs-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev ros-noetic-tf2 ros-noetic-tf2-dev ros-noetic-tf2-geometry-msgs ros-noetic-tf2-geometry-msgs-dev ros-noetic-tf2-ros ros-noetic-tf2-ros-dev ros-noetic-visualization-msgs ros-noetic-visualization-msgs-dev ros-noetic-voxel-grid ros-noetic-voxel-grid-dev"
+depends_dev="eigen-dev ros-noetic-angles ros-noetic-angles-dev ros-noetic-costmap-2d ros-noetic-costmap-2d-dev ros-noetic-dynamic-reconfigure ros-noetic-dynamic-reconfigure-dev ros-noetic-geometry-msgs ros-noetic-geometry-msgs-dev ros-noetic-message-runtime-dev ros-noetic-nav-core ros-noetic-nav-core-dev ros-noetic-nav-msgs ros-noetic-nav-msgs-dev ros-noetic-pluginlib ros-noetic-pluginlib-dev ros-noetic-rosconsole ros-noetic-rosconsole-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-rospy ros-noetic-rospy-dev ros-noetic-sensor-msgs ros-noetic-sensor-msgs-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev ros-noetic-tf2 ros-noetic-tf2-dev ros-noetic-tf2-ros ros-noetic-tf2-ros-dev ros-noetic-visualization-msgs ros-noetic-visualization-msgs-dev ros-noetic-voxel-grid ros-noetic-voxel-grid-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-behaviortree-cpp-v3/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-behaviortree-cpp-v3/APKBUILD
@@ -7,10 +7,11 @@ url="http://wiki.ros.org/$_pkgname"
 arch="all"
 license="MIT"
 
-depends="boost-dev ncurses-dev ros-noetic-roslib zeromq-dev boost-dev ncurses-dev ros-noetic-roslib zeromq-dev"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath boost-dev ncurses-dev ros-noetic-catkin ros-noetic-ros-environment ros-noetic-roslib zeromq-dev"
+depends="ros-noetic-roslib"
+makedepends="boost-dev chrpath ncurses-dev py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-ros-environment ros-noetic-ros-environment-dev ros-noetic-roslib ros-noetic-roslib-dev zeromq-dev"
+depends_dev="boost-dev ncurses-dev ros-noetic-roslib ros-noetic-roslib-dev zeromq-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-behaviortree-cpp/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-behaviortree-cpp/APKBUILD
@@ -7,10 +7,11 @@ url="http://wiki.ros.org/$_pkgname"
 arch="all"
 license="MIT"
 
-depends="ros-noetic-roslib sqlite-dev zeromq-dev ros-noetic-roslib sqlite-dev zeromq-dev"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin ros-noetic-ros-environment ros-noetic-roslib sqlite-dev zeromq-dev"
+depends="ros-noetic-roslib"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-ros-environment ros-noetic-ros-environment-dev ros-noetic-roslib ros-noetic-roslib-dev sqlite-dev zeromq-dev"
+depends_dev="ros-noetic-roslib ros-noetic-roslib-dev sqlite-dev zeromq-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-bond-core/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-bond-core/APKBUILD
@@ -8,9 +8,10 @@ arch="all"
 license="BSD"
 
 depends="ros-noetic-bond ros-noetic-bondcpp ros-noetic-bondpy ros-noetic-smclib"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev"
+depends_dev="ros-noetic-bond-dev ros-noetic-bondcpp-dev ros-noetic-bondpy-dev ros-noetic-smclib-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-bond/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-bond/APKBUILD
@@ -8,9 +8,10 @@ arch="all"
 license="BSD"
 
 depends="ros-noetic-message-runtime ros-noetic-std-msgs"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin ros-noetic-message-generation ros-noetic-std-msgs"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-message-generation ros-noetic-message-generation-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev"
+depends_dev="ros-noetic-message-runtime-dev ros-noetic-std-msgs-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-bondcpp/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-bondcpp/APKBUILD
@@ -7,10 +7,11 @@ url="http://www.ros.org/wiki/bondcpp"
 arch="all"
 license="BSD"
 
-depends="boost-dev ros-noetic-bond ros-noetic-roscpp ros-noetic-smclib util-linux-dev boost-dev ros-noetic-bond ros-noetic-roscpp ros-noetic-smclib util-linux-dev"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath boost-dev ros-noetic-bond ros-noetic-catkin ros-noetic-cmake-modules>=0.3.2 ros-noetic-roscpp ros-noetic-smclib util-linux-dev"
+depends="ros-noetic-bond ros-noetic-roscpp ros-noetic-smclib"
+makedepends="boost-dev chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-bond ros-noetic-bond-dev ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-cmake-modules-dev>=0.3.2 ros-noetic-cmake-modules>=0.3.2 ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-smclib ros-noetic-smclib-dev util-linux-dev"
+depends_dev="boost-dev ros-noetic-bond ros-noetic-bond-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-smclib ros-noetic-smclib-dev util-linux-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-bondpy/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-bondpy/APKBUILD
@@ -7,10 +7,11 @@ url="http://www.ros.org/wiki/bondpy"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-rospy ros-noetic-smclib util-linux-dev"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath py3-setuptools ros-noetic-bond ros-noetic-catkin ros-noetic-rospy ros-noetic-smclib"
+depends="ros-noetic-rospy ros-noetic-smclib"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-bond ros-noetic-bond-dev ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-rospy ros-noetic-rospy-dev ros-noetic-smclib ros-noetic-smclib-dev"
+depends_dev="ros-noetic-rospy-dev ros-noetic-smclib-dev util-linux-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-camera-calibration-parsers/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-camera-calibration-parsers/APKBUILD
@@ -7,10 +7,11 @@ url="http://ros.org/wiki/camera_calibration_parsers"
 arch="all"
 license="BSD"
 
-depends="boost-dev ros-noetic-roscpp ros-noetic-roscpp-serialization ros-noetic-sensor-msgs yaml-cpp-dev boost-dev ros-noetic-roscpp ros-noetic-roscpp-serialization ros-noetic-sensor-msgs yaml-cpp-dev"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath boost-dev pkgconf ros-noetic-catkin ros-noetic-rosbash ros-noetic-rosconsole ros-noetic-roscpp ros-noetic-roscpp-serialization ros-noetic-rosunit ros-noetic-sensor-msgs yaml-cpp-dev"
+depends="ros-noetic-roscpp ros-noetic-roscpp-serialization ros-noetic-sensor-msgs"
+makedepends="boost-dev chrpath pkgconf py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-rosbash ros-noetic-rosbash-dev ros-noetic-rosconsole ros-noetic-rosconsole-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-roscpp-serialization ros-noetic-roscpp-serialization-dev ros-noetic-rosunit ros-noetic-rosunit-dev ros-noetic-sensor-msgs ros-noetic-sensor-msgs-dev yaml-cpp-dev"
+depends_dev="boost-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-roscpp-serialization ros-noetic-roscpp-serialization-dev ros-noetic-sensor-msgs ros-noetic-sensor-msgs-dev yaml-cpp-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-camera-calibration/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-camera-calibration/APKBUILD
@@ -7,10 +7,11 @@ url="http://www.ros.org/wiki/camera_calibration"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-cv-bridge ros-noetic-image-geometry ros-noetic-message-filters ros-noetic-rospy ros-noetic-sensor-msgs ros-noetic-std-srvs ros-noetic-cv-bridge ros-noetic-image-geometry ros-noetic-message-filters ros-noetic-rospy ros-noetic-sensor-msgs ros-noetic-std-srvs"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin>=0.5.68 ros-noetic-rostest"
+depends="ros-noetic-cv-bridge ros-noetic-image-geometry ros-noetic-message-filters ros-noetic-rospy ros-noetic-sensor-msgs ros-noetic-std-srvs"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin-dev>=0.5.68 ros-noetic-catkin>=0.5.68 ros-noetic-rostest ros-noetic-rostest-dev"
+depends_dev="ros-noetic-cv-bridge ros-noetic-cv-bridge-dev ros-noetic-image-geometry ros-noetic-image-geometry-dev ros-noetic-message-filters ros-noetic-message-filters-dev ros-noetic-rospy ros-noetic-rospy-dev ros-noetic-sensor-msgs ros-noetic-sensor-msgs-dev ros-noetic-std-srvs ros-noetic-std-srvs-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-camera-info-manager/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-camera-info-manager/APKBUILD
@@ -7,10 +7,11 @@ url="http://ros.org/wiki/camera_info_manager"
 arch="all"
 license="BSD"
 
-depends="boost-dev ros-noetic-camera-calibration-parsers ros-noetic-image-transport ros-noetic-roscpp ros-noetic-roslib ros-noetic-sensor-msgs boost-dev ros-noetic-camera-calibration-parsers ros-noetic-image-transport ros-noetic-roscpp ros-noetic-roslib ros-noetic-sensor-msgs"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath boost-dev gtest gtest-dev ros-noetic-camera-calibration-parsers ros-noetic-catkin>=0.5.68 ros-noetic-image-transport ros-noetic-roscpp ros-noetic-roslib ros-noetic-rostest ros-noetic-sensor-msgs"
+depends="ros-noetic-camera-calibration-parsers ros-noetic-image-transport ros-noetic-roscpp ros-noetic-roslib ros-noetic-sensor-msgs"
+makedepends="boost-dev chrpath gtest gtest-dev py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-camera-calibration-parsers ros-noetic-camera-calibration-parsers-dev ros-noetic-catkin-dev>=0.5.68 ros-noetic-catkin>=0.5.68 ros-noetic-image-transport ros-noetic-image-transport-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-roslib ros-noetic-roslib-dev ros-noetic-rostest ros-noetic-rostest-dev ros-noetic-sensor-msgs ros-noetic-sensor-msgs-dev"
+depends_dev="boost-dev ros-noetic-camera-calibration-parsers ros-noetic-camera-calibration-parsers-dev ros-noetic-image-transport ros-noetic-image-transport-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-roslib ros-noetic-roslib-dev ros-noetic-sensor-msgs ros-noetic-sensor-msgs-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-carrot-planner/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-carrot-planner/APKBUILD
@@ -7,10 +7,11 @@ url="http://wiki.ros.org/carrot_planner"
 arch="all"
 license="BSD"
 
-depends="eigen-dev ros-noetic-angles ros-noetic-base-local-planner ros-noetic-costmap-2d ros-noetic-nav-core ros-noetic-pluginlib ros-noetic-roscpp ros-noetic-tf2 ros-noetic-tf2-ros eigen-dev ros-noetic-angles ros-noetic-base-local-planner ros-noetic-costmap-2d ros-noetic-nav-core ros-noetic-pluginlib ros-noetic-roscpp ros-noetic-tf2 ros-noetic-tf2-ros"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath eigen-dev ros-noetic-angles ros-noetic-base-local-planner ros-noetic-catkin ros-noetic-costmap-2d ros-noetic-nav-core ros-noetic-pluginlib ros-noetic-roscpp ros-noetic-tf2 ros-noetic-tf2-geometry-msgs ros-noetic-tf2-ros"
+depends="ros-noetic-angles ros-noetic-base-local-planner ros-noetic-costmap-2d ros-noetic-nav-core ros-noetic-pluginlib ros-noetic-roscpp ros-noetic-tf2 ros-noetic-tf2-ros"
+makedepends="chrpath eigen-dev py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-angles ros-noetic-angles-dev ros-noetic-base-local-planner ros-noetic-base-local-planner-dev ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-costmap-2d ros-noetic-costmap-2d-dev ros-noetic-nav-core ros-noetic-nav-core-dev ros-noetic-pluginlib ros-noetic-pluginlib-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-tf2 ros-noetic-tf2-dev ros-noetic-tf2-geometry-msgs ros-noetic-tf2-geometry-msgs-dev ros-noetic-tf2-ros ros-noetic-tf2-ros-dev"
+depends_dev="eigen-dev ros-noetic-angles ros-noetic-angles-dev ros-noetic-base-local-planner ros-noetic-base-local-planner-dev ros-noetic-costmap-2d ros-noetic-costmap-2d-dev ros-noetic-nav-core ros-noetic-nav-core-dev ros-noetic-pluginlib ros-noetic-pluginlib-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-tf2 ros-noetic-tf2-dev ros-noetic-tf2-ros ros-noetic-tf2-ros-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-catkin/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-catkin/APKBUILD
@@ -7,10 +7,11 @@ url="http://wiki.ros.org/catkin"
 arch="all"
 license="BSD"
 
-depends="py3-catkin-pkg>=0.4.3 py3-empy cmake gmock gtest gtest-dev py3-catkin-pkg>=0.4.3 py3-empy py3-nose py3-setuptools"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath cmake py3-catkin-pkg>=0.4.3 py3-empy py3-mock py3-nose py3-setuptools"
+depends="py3-catkin-pkg>=0.4.3 py3-empy"
+makedepends="chrpath cmake py3-catkin-pkg>=0.4.3 py3-empy py3-mock py3-nose py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool"
+depends_dev="cmake gmock gtest gtest-dev py3-catkin-pkg>=0.4.3 py3-empy py3-nose py3-setuptools"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -231,6 +232,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-class-loader/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-class-loader/APKBUILD
@@ -7,10 +7,11 @@ url="http://ros.org/wiki/class_loader"
 arch="all"
 license="BSD"
 
-depends="boost-dev console_bridge-dev poco-dev boost-dev console_bridge-dev poco-dev"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath boost-dev console_bridge-dev poco-dev ros-noetic-catkin>=0.5.68 ros-noetic-cmake-modules>=0.3.3"
+depends=""
+makedepends="boost-dev chrpath console_bridge-dev poco-dev py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin-dev>=0.5.68 ros-noetic-catkin>=0.5.68 ros-noetic-cmake-modules-dev>=0.3.3 ros-noetic-cmake-modules>=0.3.3"
+depends_dev="boost-dev console_bridge-dev poco-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-clear-costmap-recovery/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-clear-costmap-recovery/APKBUILD
@@ -7,10 +7,11 @@ url="http://wiki.ros.org/clear_costmap_recovery"
 arch="all"
 license="BSD"
 
-depends="eigen-dev ros-noetic-costmap-2d ros-noetic-nav-core ros-noetic-pluginlib ros-noetic-roscpp ros-noetic-tf2-ros eigen-dev ros-noetic-costmap-2d ros-noetic-nav-core ros-noetic-pluginlib ros-noetic-roscpp ros-noetic-tf2-ros"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath eigen-dev ros-noetic-catkin ros-noetic-cmake-modules ros-noetic-costmap-2d ros-noetic-nav-core ros-noetic-pluginlib ros-noetic-roscpp ros-noetic-rostest ros-noetic-tf2-ros"
+depends="ros-noetic-costmap-2d ros-noetic-nav-core ros-noetic-pluginlib ros-noetic-roscpp ros-noetic-tf2-ros"
+makedepends="chrpath eigen-dev py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-cmake-modules ros-noetic-cmake-modules-dev ros-noetic-costmap-2d ros-noetic-costmap-2d-dev ros-noetic-nav-core ros-noetic-nav-core-dev ros-noetic-pluginlib ros-noetic-pluginlib-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-rostest ros-noetic-rostest-dev ros-noetic-tf2-ros ros-noetic-tf2-ros-dev"
+depends_dev="eigen-dev ros-noetic-costmap-2d ros-noetic-costmap-2d-dev ros-noetic-nav-core ros-noetic-nav-core-dev ros-noetic-pluginlib ros-noetic-pluginlib-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-tf2-ros ros-noetic-tf2-ros-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-cmake-modules/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-cmake-modules/APKBUILD
@@ -8,9 +8,10 @@ arch="all"
 license="BSD"
 
 depends=""
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev"
+depends_dev=""
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-combined-robot-hw/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-combined-robot-hw/APKBUILD
@@ -7,10 +7,11 @@ url="https://github.com/ros-controls/ros_control/wiki"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-roscpp ros-noetic-hardware-interface ros-noetic-pluginlib ros-noetic-roscpp"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin ros-noetic-hardware-interface ros-noetic-pluginlib ros-noetic-roscpp"
+depends="ros-noetic-roscpp"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-hardware-interface ros-noetic-hardware-interface-dev ros-noetic-pluginlib ros-noetic-pluginlib-dev ros-noetic-roscpp ros-noetic-roscpp-dev"
+depends_dev="ros-noetic-hardware-interface ros-noetic-hardware-interface-dev ros-noetic-pluginlib ros-noetic-pluginlib-dev ros-noetic-roscpp ros-noetic-roscpp-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-common-msgs/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-common-msgs/APKBUILD
@@ -7,10 +7,11 @@ url="http://wiki.ros.org/common_msgs"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-actionlib-msgs ros-noetic-diagnostic-msgs ros-noetic-geometry-msgs ros-noetic-nav-msgs ros-noetic-sensor-msgs ros-noetic-shape-msgs ros-noetic-stereo-msgs ros-noetic-trajectory-msgs ros-noetic-visualization-msgs ros-noetic-actionlib-msgs ros-noetic-diagnostic-msgs ros-noetic-geometry-msgs ros-noetic-nav-msgs ros-noetic-sensor-msgs ros-noetic-shape-msgs ros-noetic-stereo-msgs ros-noetic-trajectory-msgs ros-noetic-visualization-msgs"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin"
+depends="ros-noetic-actionlib-msgs ros-noetic-diagnostic-msgs ros-noetic-geometry-msgs ros-noetic-nav-msgs ros-noetic-sensor-msgs ros-noetic-shape-msgs ros-noetic-stereo-msgs ros-noetic-trajectory-msgs ros-noetic-visualization-msgs"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev"
+depends_dev="ros-noetic-actionlib-msgs ros-noetic-actionlib-msgs-dev ros-noetic-diagnostic-msgs ros-noetic-diagnostic-msgs-dev ros-noetic-geometry-msgs ros-noetic-geometry-msgs-dev ros-noetic-nav-msgs ros-noetic-nav-msgs-dev ros-noetic-sensor-msgs ros-noetic-sensor-msgs-dev ros-noetic-shape-msgs ros-noetic-shape-msgs-dev ros-noetic-stereo-msgs ros-noetic-stereo-msgs-dev ros-noetic-trajectory-msgs ros-noetic-trajectory-msgs-dev ros-noetic-visualization-msgs ros-noetic-visualization-msgs-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-compressed-depth-image-transport/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-compressed-depth-image-transport/APKBUILD
@@ -7,10 +7,11 @@ url="http://www.ros.org/wiki/image_transport_plugins"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-cv-bridge ros-noetic-dynamic-reconfigure ros-noetic-image-transport ros-noetic-cv-bridge ros-noetic-dynamic-reconfigure ros-noetic-image-transport"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin ros-noetic-cv-bridge ros-noetic-dynamic-reconfigure ros-noetic-image-transport"
+depends="ros-noetic-cv-bridge ros-noetic-dynamic-reconfigure ros-noetic-image-transport"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-cv-bridge ros-noetic-cv-bridge-dev ros-noetic-dynamic-reconfigure ros-noetic-dynamic-reconfigure-dev ros-noetic-image-transport ros-noetic-image-transport-dev"
+depends_dev="ros-noetic-cv-bridge ros-noetic-cv-bridge-dev ros-noetic-dynamic-reconfigure ros-noetic-dynamic-reconfigure-dev ros-noetic-image-transport ros-noetic-image-transport-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-compressed-image-transport/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-compressed-image-transport/APKBUILD
@@ -7,10 +7,11 @@ url="http://www.ros.org/wiki/image_transport_plugins"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-cv-bridge ros-noetic-dynamic-reconfigure ros-noetic-image-transport ros-noetic-cv-bridge ros-noetic-dynamic-reconfigure ros-noetic-image-transport"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin ros-noetic-cv-bridge ros-noetic-dynamic-reconfigure ros-noetic-image-transport"
+depends="ros-noetic-cv-bridge ros-noetic-dynamic-reconfigure ros-noetic-image-transport"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-cv-bridge ros-noetic-cv-bridge-dev ros-noetic-dynamic-reconfigure ros-noetic-dynamic-reconfigure-dev ros-noetic-image-transport ros-noetic-image-transport-dev"
+depends_dev="ros-noetic-cv-bridge ros-noetic-cv-bridge-dev ros-noetic-dynamic-reconfigure ros-noetic-dynamic-reconfigure-dev ros-noetic-image-transport ros-noetic-image-transport-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-control-msgs/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-control-msgs/APKBUILD
@@ -7,10 +7,11 @@ url="http://ros.org/wiki/control_msgs"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-actionlib-msgs ros-noetic-geometry-msgs ros-noetic-message-runtime ros-noetic-std-msgs ros-noetic-trajectory-msgs ros-noetic-actionlib-msgs ros-noetic-geometry-msgs ros-noetic-message-runtime ros-noetic-std-msgs ros-noetic-trajectory-msgs"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-actionlib-msgs ros-noetic-catkin ros-noetic-geometry-msgs ros-noetic-message-generation ros-noetic-std-msgs ros-noetic-trajectory-msgs"
+depends="ros-noetic-actionlib-msgs ros-noetic-geometry-msgs ros-noetic-message-runtime ros-noetic-std-msgs ros-noetic-trajectory-msgs"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-actionlib-msgs ros-noetic-actionlib-msgs-dev ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-geometry-msgs ros-noetic-geometry-msgs-dev ros-noetic-message-generation ros-noetic-message-generation-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev ros-noetic-trajectory-msgs ros-noetic-trajectory-msgs-dev"
+depends_dev="ros-noetic-actionlib-msgs ros-noetic-actionlib-msgs-dev ros-noetic-geometry-msgs ros-noetic-geometry-msgs-dev ros-noetic-message-runtime ros-noetic-message-runtime-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev ros-noetic-trajectory-msgs ros-noetic-trajectory-msgs-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-controller-interface/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-controller-interface/APKBUILD
@@ -7,10 +7,11 @@ url="https://github.com/ros-controls/ros_control/wiki"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-roscpp ros-noetic-hardware-interface ros-noetic-roscpp"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin ros-noetic-hardware-interface ros-noetic-roscpp"
+depends="ros-noetic-roscpp"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-hardware-interface ros-noetic-hardware-interface-dev ros-noetic-roscpp ros-noetic-roscpp-dev"
+depends_dev="ros-noetic-hardware-interface ros-noetic-hardware-interface-dev ros-noetic-roscpp ros-noetic-roscpp-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-controller-manager-msgs/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-controller-manager-msgs/APKBUILD
@@ -7,10 +7,11 @@ url="https://github.com/ros-controls/ros_control/wiki"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-message-runtime ros-noetic-rospy ros-noetic-rosservice ros-noetic-std-msgs ros-noetic-std-msgs"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath py3-setuptools ros-noetic-catkin ros-noetic-message-generation ros-noetic-std-msgs"
+depends="ros-noetic-message-runtime ros-noetic-rospy ros-noetic-rosservice ros-noetic-std-msgs"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-message-generation ros-noetic-message-generation-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev"
+depends_dev="ros-noetic-message-runtime-dev ros-noetic-rospy-dev ros-noetic-rosservice-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-controller-manager/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-controller-manager/APKBUILD
@@ -7,10 +7,11 @@ url="https://github.com/ros-controls/ros_control/wiki"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-roscpp ros-noetic-rosparam ros-noetic-rospy ros-noetic-std-msgs ros-noetic-controller-interface ros-noetic-controller-manager-msgs ros-noetic-hardware-interface ros-noetic-pluginlib ros-noetic-roscpp"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath py3-setuptools ros-noetic-catkin ros-noetic-controller-interface ros-noetic-controller-manager-msgs ros-noetic-hardware-interface ros-noetic-pluginlib ros-noetic-roscpp ros-noetic-rostest"
+depends="ros-noetic-roscpp ros-noetic-rosparam ros-noetic-rospy ros-noetic-std-msgs"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-controller-interface ros-noetic-controller-interface-dev ros-noetic-controller-manager-msgs ros-noetic-controller-manager-msgs-dev ros-noetic-hardware-interface ros-noetic-hardware-interface-dev ros-noetic-pluginlib ros-noetic-pluginlib-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-rostest ros-noetic-rostest-dev"
+depends_dev="ros-noetic-controller-interface ros-noetic-controller-interface-dev ros-noetic-controller-manager-msgs ros-noetic-controller-manager-msgs-dev ros-noetic-hardware-interface ros-noetic-hardware-interface-dev ros-noetic-pluginlib ros-noetic-pluginlib-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-rosparam-dev ros-noetic-rospy-dev ros-noetic-std-msgs-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-costmap-2d/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-costmap-2d/APKBUILD
@@ -7,10 +7,11 @@ url="http://wiki.ros.org/costmap_2d"
 arch="all"
 license="BSD"
 
-depends="eigen-dev ros-noetic-dynamic-reconfigure ros-noetic-geometry-msgs ros-noetic-laser-geometry ros-noetic-map-msgs ros-noetic-message-filters ros-noetic-message-runtime ros-noetic-nav-msgs ros-noetic-pluginlib ros-noetic-rosconsole ros-noetic-roscpp ros-noetic-rostest ros-noetic-sensor-msgs ros-noetic-std-msgs ros-noetic-tf2 ros-noetic-tf2-ros ros-noetic-visualization-msgs ros-noetic-voxel-grid eigen-dev ros-noetic-dynamic-reconfigure ros-noetic-geometry-msgs ros-noetic-laser-geometry ros-noetic-map-msgs ros-noetic-message-filters ros-noetic-nav-msgs ros-noetic-pluginlib ros-noetic-roscpp ros-noetic-rostest ros-noetic-sensor-msgs ros-noetic-std-msgs ros-noetic-tf2 ros-noetic-tf2-ros ros-noetic-visualization-msgs ros-noetic-voxel-grid"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath eigen-dev ros-noetic-catkin ros-noetic-cmake-modules ros-noetic-dynamic-reconfigure ros-noetic-geometry-msgs ros-noetic-laser-geometry ros-noetic-map-msgs ros-noetic-map-server ros-noetic-message-filters ros-noetic-message-generation ros-noetic-nav-msgs ros-noetic-pluginlib ros-noetic-rosbag ros-noetic-roscpp ros-noetic-rostest ros-noetic-rosunit ros-noetic-sensor-msgs ros-noetic-std-msgs ros-noetic-tf2 ros-noetic-tf2-geometry-msgs ros-noetic-tf2-ros ros-noetic-tf2-sensor-msgs ros-noetic-visualization-msgs ros-noetic-voxel-grid"
+depends="ros-noetic-dynamic-reconfigure ros-noetic-geometry-msgs ros-noetic-laser-geometry ros-noetic-map-msgs ros-noetic-message-filters ros-noetic-message-runtime ros-noetic-nav-msgs ros-noetic-pluginlib ros-noetic-rosconsole ros-noetic-roscpp ros-noetic-rostest ros-noetic-sensor-msgs ros-noetic-std-msgs ros-noetic-tf2 ros-noetic-tf2-ros ros-noetic-visualization-msgs ros-noetic-voxel-grid"
+makedepends="chrpath eigen-dev py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-cmake-modules ros-noetic-cmake-modules-dev ros-noetic-dynamic-reconfigure ros-noetic-dynamic-reconfigure-dev ros-noetic-geometry-msgs ros-noetic-geometry-msgs-dev ros-noetic-laser-geometry ros-noetic-laser-geometry-dev ros-noetic-map-msgs ros-noetic-map-msgs-dev ros-noetic-map-server ros-noetic-map-server-dev ros-noetic-message-filters ros-noetic-message-filters-dev ros-noetic-message-generation ros-noetic-message-generation-dev ros-noetic-nav-msgs ros-noetic-nav-msgs-dev ros-noetic-pluginlib ros-noetic-pluginlib-dev ros-noetic-rosbag ros-noetic-rosbag-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-rostest ros-noetic-rostest-dev ros-noetic-rosunit ros-noetic-rosunit-dev ros-noetic-sensor-msgs ros-noetic-sensor-msgs-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev ros-noetic-tf2 ros-noetic-tf2-dev ros-noetic-tf2-geometry-msgs ros-noetic-tf2-geometry-msgs-dev ros-noetic-tf2-ros ros-noetic-tf2-ros-dev ros-noetic-tf2-sensor-msgs ros-noetic-tf2-sensor-msgs-dev ros-noetic-visualization-msgs ros-noetic-visualization-msgs-dev ros-noetic-voxel-grid ros-noetic-voxel-grid-dev"
+depends_dev="eigen-dev ros-noetic-dynamic-reconfigure ros-noetic-dynamic-reconfigure-dev ros-noetic-geometry-msgs ros-noetic-geometry-msgs-dev ros-noetic-laser-geometry ros-noetic-laser-geometry-dev ros-noetic-map-msgs ros-noetic-map-msgs-dev ros-noetic-message-filters ros-noetic-message-filters-dev ros-noetic-message-runtime-dev ros-noetic-nav-msgs ros-noetic-nav-msgs-dev ros-noetic-pluginlib ros-noetic-pluginlib-dev ros-noetic-rosconsole-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-rostest ros-noetic-rostest-dev ros-noetic-sensor-msgs ros-noetic-sensor-msgs-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev ros-noetic-tf2 ros-noetic-tf2-dev ros-noetic-tf2-ros ros-noetic-tf2-ros-dev ros-noetic-visualization-msgs ros-noetic-visualization-msgs-dev ros-noetic-voxel-grid ros-noetic-voxel-grid-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-costmap-cspace-msgs/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-costmap-cspace-msgs/APKBUILD
@@ -7,10 +7,11 @@ url="http://wiki.ros.org/$_pkgname"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-geometry-msgs ros-noetic-message-runtime ros-noetic-std-msgs ros-noetic-geometry-msgs ros-noetic-message-runtime ros-noetic-std-msgs"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin ros-noetic-geometry-msgs ros-noetic-message-generation ros-noetic-std-msgs"
+depends="ros-noetic-geometry-msgs ros-noetic-message-runtime ros-noetic-std-msgs"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-geometry-msgs ros-noetic-geometry-msgs-dev ros-noetic-message-generation ros-noetic-message-generation-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev"
+depends_dev="ros-noetic-geometry-msgs ros-noetic-geometry-msgs-dev ros-noetic-message-runtime ros-noetic-message-runtime-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-costmap-cspace-rviz-plugins/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-costmap-cspace-rviz-plugins/APKBUILD
@@ -7,10 +7,11 @@ url="http://wiki.ros.org/$_pkgname"
 arch="all"
 license="BSD"
 
-depends="qt5-qtbase-dev ros-noetic-costmap-cspace-msgs ros-noetic-roscpp ros-noetic-rviz>=1.14.21 qt5-qtbase-dev ros-noetic-costmap-cspace-msgs ros-noetic-roscpp ros-noetic-rviz>=1.14.21"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath qt5-qtbase-dev ros-noetic-catkin ros-noetic-costmap-cspace-msgs ros-noetic-roscpp ros-noetic-roslint ros-noetic-rviz>=1.14.21"
+depends="ros-noetic-costmap-cspace-msgs ros-noetic-roscpp ros-noetic-rviz>=1.14.21"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool qt5-qtbase-dev ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-costmap-cspace-msgs ros-noetic-costmap-cspace-msgs-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-roslint ros-noetic-roslint-dev ros-noetic-rviz-dev>=1.14.21 ros-noetic-rviz>=1.14.21"
+depends_dev="qt5-qtbase-dev ros-noetic-costmap-cspace-msgs ros-noetic-costmap-cspace-msgs-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-rviz-dev>=1.14.21 ros-noetic-rviz>=1.14.21"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-costmap-cspace/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-costmap-cspace/APKBUILD
@@ -7,10 +7,11 @@ url="http://wiki.ros.org/$_pkgname"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-costmap-cspace-msgs ros-noetic-geometry-msgs ros-noetic-laser-geometry ros-noetic-nav-msgs ros-noetic-neonavigation-common ros-noetic-roscpp ros-noetic-sensor-msgs ros-noetic-tf2-geometry-msgs ros-noetic-tf2-ros ros-noetic-tf2-sensor-msgs ros-noetic-xmlrpcpp ros-noetic-costmap-cspace-msgs ros-noetic-geometry-msgs ros-noetic-laser-geometry ros-noetic-nav-msgs ros-noetic-neonavigation-common ros-noetic-roscpp ros-noetic-sensor-msgs ros-noetic-tf2-geometry-msgs ros-noetic-tf2-ros ros-noetic-tf2-sensor-msgs ros-noetic-xmlrpcpp"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin ros-noetic-costmap-cspace-msgs ros-noetic-geometry-msgs ros-noetic-laser-geometry ros-noetic-nav-msgs ros-noetic-neonavigation-common ros-noetic-roscpp ros-noetic-roslint ros-noetic-rostest ros-noetic-sensor-msgs ros-noetic-tf2-geometry-msgs ros-noetic-tf2-ros ros-noetic-tf2-sensor-msgs ros-noetic-xmlrpcpp"
+depends="ros-noetic-costmap-cspace-msgs ros-noetic-geometry-msgs ros-noetic-laser-geometry ros-noetic-nav-msgs ros-noetic-neonavigation-common ros-noetic-roscpp ros-noetic-sensor-msgs ros-noetic-tf2-geometry-msgs ros-noetic-tf2-ros ros-noetic-tf2-sensor-msgs ros-noetic-xmlrpcpp"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-costmap-cspace-msgs ros-noetic-costmap-cspace-msgs-dev ros-noetic-geometry-msgs ros-noetic-geometry-msgs-dev ros-noetic-laser-geometry ros-noetic-laser-geometry-dev ros-noetic-nav-msgs ros-noetic-nav-msgs-dev ros-noetic-neonavigation-common ros-noetic-neonavigation-common-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-roslint ros-noetic-roslint-dev ros-noetic-rostest ros-noetic-rostest-dev ros-noetic-sensor-msgs ros-noetic-sensor-msgs-dev ros-noetic-tf2-geometry-msgs ros-noetic-tf2-geometry-msgs-dev ros-noetic-tf2-ros ros-noetic-tf2-ros-dev ros-noetic-tf2-sensor-msgs ros-noetic-tf2-sensor-msgs-dev ros-noetic-xmlrpcpp ros-noetic-xmlrpcpp-dev"
+depends_dev="ros-noetic-costmap-cspace-msgs ros-noetic-costmap-cspace-msgs-dev ros-noetic-geometry-msgs ros-noetic-geometry-msgs-dev ros-noetic-laser-geometry ros-noetic-laser-geometry-dev ros-noetic-nav-msgs ros-noetic-nav-msgs-dev ros-noetic-neonavigation-common ros-noetic-neonavigation-common-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-sensor-msgs ros-noetic-sensor-msgs-dev ros-noetic-tf2-geometry-msgs ros-noetic-tf2-geometry-msgs-dev ros-noetic-tf2-ros ros-noetic-tf2-ros-dev ros-noetic-tf2-sensor-msgs ros-noetic-tf2-sensor-msgs-dev ros-noetic-xmlrpcpp ros-noetic-xmlrpcpp-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-cpp-common/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-cpp-common/APKBUILD
@@ -7,10 +7,11 @@ url="http://www.ros.org/wiki/cpp_common"
 arch="all"
 license="BSD"
 
-depends="boost-dev console_bridge-dev boost-dev console_bridge-dev"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath boost-dev console_bridge-dev ros-noetic-catkin"
+depends=""
+makedepends="boost-dev chrpath console_bridge-dev py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev"
+depends_dev="boost-dev console_bridge-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-cv-bridge/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-cv-bridge/APKBUILD
@@ -7,10 +7,11 @@ url="http://www.ros.org/wiki/cv_bridge"
 arch="all"
 license="BSD"
 
-depends="boost-dev opencv-dev py3-opencv python3-dev ros-noetic-rosconsole opencv-dev ros-noetic-sensor-msgs"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath boost-dev opencv-dev py3-numpy py3-numpy-dev py3-opencv python3-dev ros-noetic-catkin ros-noetic-rosconsole ros-noetic-rostest ros-noetic-sensor-msgs"
+depends="py3-opencv ros-noetic-rosconsole"
+makedepends="boost-dev chrpath opencv-dev py3-numpy py3-numpy-dev py3-opencv py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool python3-dev ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-rosconsole ros-noetic-rosconsole-dev ros-noetic-rostest ros-noetic-rostest-dev ros-noetic-sensor-msgs ros-noetic-sensor-msgs-dev"
+depends_dev="boost-dev opencv-dev python3-dev ros-noetic-rosconsole-dev ros-noetic-sensor-msgs ros-noetic-sensor-msgs-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-depth-image-proc/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-depth-image-proc/APKBUILD
@@ -7,10 +7,11 @@ url="http://ros.org/wiki/depth_image_proc"
 arch="all"
 license="BSD"
 
-depends="boost-dev ros-noetic-cv-bridge ros-noetic-eigen-conversions ros-noetic-image-geometry ros-noetic-image-transport ros-noetic-nodelet ros-noetic-sensor-msgs ros-noetic-tf2 ros-noetic-tf2-ros boost-dev ros-noetic-cv-bridge ros-noetic-eigen-conversions ros-noetic-image-geometry ros-noetic-image-transport ros-noetic-nodelet ros-noetic-sensor-msgs ros-noetic-tf2 ros-noetic-tf2-ros"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath boost-dev ros-noetic-catkin ros-noetic-cmake-modules ros-noetic-cv-bridge ros-noetic-eigen-conversions ros-noetic-image-geometry ros-noetic-image-transport ros-noetic-message-filters ros-noetic-nodelet ros-noetic-rostest ros-noetic-sensor-msgs ros-noetic-stereo-msgs ros-noetic-tf2 ros-noetic-tf2-ros"
+depends="ros-noetic-cv-bridge ros-noetic-eigen-conversions ros-noetic-image-geometry ros-noetic-image-transport ros-noetic-nodelet ros-noetic-sensor-msgs ros-noetic-tf2 ros-noetic-tf2-ros"
+makedepends="boost-dev chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-cmake-modules ros-noetic-cmake-modules-dev ros-noetic-cv-bridge ros-noetic-cv-bridge-dev ros-noetic-eigen-conversions ros-noetic-eigen-conversions-dev ros-noetic-image-geometry ros-noetic-image-geometry-dev ros-noetic-image-transport ros-noetic-image-transport-dev ros-noetic-message-filters ros-noetic-message-filters-dev ros-noetic-nodelet ros-noetic-nodelet-dev ros-noetic-rostest ros-noetic-rostest-dev ros-noetic-sensor-msgs ros-noetic-sensor-msgs-dev ros-noetic-stereo-msgs ros-noetic-stereo-msgs-dev ros-noetic-tf2 ros-noetic-tf2-dev ros-noetic-tf2-ros ros-noetic-tf2-ros-dev"
+depends_dev="boost-dev ros-noetic-cv-bridge ros-noetic-cv-bridge-dev ros-noetic-eigen-conversions ros-noetic-eigen-conversions-dev ros-noetic-image-geometry ros-noetic-image-geometry-dev ros-noetic-image-transport ros-noetic-image-transport-dev ros-noetic-nodelet ros-noetic-nodelet-dev ros-noetic-sensor-msgs ros-noetic-sensor-msgs-dev ros-noetic-tf2 ros-noetic-tf2-dev ros-noetic-tf2-ros ros-noetic-tf2-ros-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-diagnostic-aggregator/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-diagnostic-aggregator/APKBUILD
@@ -7,10 +7,11 @@ url="http://www.ros.org/wiki/diagnostic_aggregator"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-bondcpp ros-noetic-bondpy ros-noetic-diagnostic-msgs>=1.11.9 ros-noetic-pluginlib ros-noetic-roscpp ros-noetic-rospy ros-noetic-xmlrpcpp ros-noetic-bondcpp ros-noetic-bondpy ros-noetic-diagnostic-msgs>=1.11.9 ros-noetic-pluginlib ros-noetic-roscpp ros-noetic-rospy ros-noetic-xmlrpcpp"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-bondcpp ros-noetic-bondpy ros-noetic-catkin>=0.5.68 ros-noetic-diagnostic-msgs>=1.11.9 ros-noetic-pluginlib ros-noetic-roscpp ros-noetic-rospy ros-noetic-rostest ros-noetic-xmlrpcpp"
+depends="ros-noetic-bondcpp ros-noetic-bondpy ros-noetic-diagnostic-msgs>=1.11.9 ros-noetic-pluginlib ros-noetic-roscpp ros-noetic-rospy ros-noetic-xmlrpcpp"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-bondcpp ros-noetic-bondcpp-dev ros-noetic-bondpy ros-noetic-bondpy-dev ros-noetic-catkin-dev>=0.5.68 ros-noetic-catkin>=0.5.68 ros-noetic-diagnostic-msgs-dev>=1.11.9 ros-noetic-diagnostic-msgs>=1.11.9 ros-noetic-pluginlib ros-noetic-pluginlib-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-rospy ros-noetic-rospy-dev ros-noetic-rostest ros-noetic-rostest-dev ros-noetic-xmlrpcpp ros-noetic-xmlrpcpp-dev"
+depends_dev="ros-noetic-bondcpp ros-noetic-bondcpp-dev ros-noetic-bondpy ros-noetic-bondpy-dev ros-noetic-diagnostic-msgs-dev>=1.11.9 ros-noetic-diagnostic-msgs>=1.11.9 ros-noetic-pluginlib ros-noetic-pluginlib-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-rospy ros-noetic-rospy-dev ros-noetic-xmlrpcpp ros-noetic-xmlrpcpp-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-diagnostic-analysis/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-diagnostic-analysis/APKBUILD
@@ -7,10 +7,11 @@ url="http://www.ros.org/wiki/diagnostics_analysis"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-diagnostic-msgs ros-noetic-rosbag ros-noetic-roslib ros-noetic-diagnostic-msgs ros-noetic-rosbag ros-noetic-roslib"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin>=0.5.68 ros-noetic-diagnostic-msgs ros-noetic-rosbag ros-noetic-roslib ros-noetic-rostest"
+depends="ros-noetic-diagnostic-msgs ros-noetic-rosbag ros-noetic-roslib"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin-dev>=0.5.68 ros-noetic-catkin>=0.5.68 ros-noetic-diagnostic-msgs ros-noetic-diagnostic-msgs-dev ros-noetic-rosbag ros-noetic-rosbag-dev ros-noetic-roslib ros-noetic-roslib-dev ros-noetic-rostest ros-noetic-rostest-dev"
+depends_dev="ros-noetic-diagnostic-msgs ros-noetic-diagnostic-msgs-dev ros-noetic-rosbag ros-noetic-rosbag-dev ros-noetic-roslib ros-noetic-roslib-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-diagnostic-common-diagnostics/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-diagnostic-common-diagnostics/APKBUILD
@@ -7,10 +7,11 @@ url="http://ros.org/wiki/diagnostic_common_diagnostics"
 arch="all"
 license="BSD"
 
-depends="hddtemp lm-sensors py3-psutil ros-noetic-diagnostic-updater ros-noetic-rospy ros-noetic-tf hddtemp lm-sensors py3-psutil ros-noetic-diagnostic-updater ros-noetic-rospy ros-noetic-tf"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin ros-noetic-diagnostic-updater ros-noetic-rospy ros-noetic-rostest"
+depends="hddtemp lm-sensors py3-psutil ros-noetic-diagnostic-updater ros-noetic-rospy ros-noetic-tf"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-diagnostic-updater ros-noetic-diagnostic-updater-dev ros-noetic-rospy ros-noetic-rospy-dev ros-noetic-rostest ros-noetic-rostest-dev"
+depends_dev="hddtemp lm-sensors py3-psutil ros-noetic-diagnostic-updater ros-noetic-diagnostic-updater-dev ros-noetic-rospy ros-noetic-rospy-dev ros-noetic-tf ros-noetic-tf-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-diagnostic-msgs/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-diagnostic-msgs/APKBUILD
@@ -7,10 +7,11 @@ url="http://wiki.ros.org/diagnostic_msgs"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-message-runtime ros-noetic-std-msgs ros-noetic-message-runtime ros-noetic-std-msgs"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin ros-noetic-message-generation ros-noetic-std-msgs"
+depends="ros-noetic-message-runtime ros-noetic-std-msgs"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-message-generation ros-noetic-message-generation-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev"
+depends_dev="ros-noetic-message-runtime ros-noetic-message-runtime-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-diagnostic-updater/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-diagnostic-updater/APKBUILD
@@ -7,10 +7,11 @@ url="http://www.ros.org/wiki/diagnostic_updater"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-diagnostic-msgs ros-noetic-roscpp ros-noetic-std-msgs ros-noetic-diagnostic-msgs ros-noetic-roscpp ros-noetic-std-msgs"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin>=0.5.68 ros-noetic-diagnostic-msgs ros-noetic-roscpp ros-noetic-rostest ros-noetic-std-msgs"
+depends="ros-noetic-diagnostic-msgs ros-noetic-roscpp ros-noetic-std-msgs"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin-dev>=0.5.68 ros-noetic-catkin>=0.5.68 ros-noetic-diagnostic-msgs ros-noetic-diagnostic-msgs-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-rostest ros-noetic-rostest-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev"
+depends_dev="ros-noetic-diagnostic-msgs ros-noetic-diagnostic-msgs-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-diagnostics/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-diagnostics/APKBUILD
@@ -7,10 +7,11 @@ url="http://www.ros.org/wiki/diagnostics"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-diagnostic-aggregator ros-noetic-diagnostic-analysis ros-noetic-diagnostic-common-diagnostics ros-noetic-diagnostic-updater ros-noetic-self-test ros-noetic-diagnostic-aggregator ros-noetic-diagnostic-analysis ros-noetic-diagnostic-common-diagnostics ros-noetic-diagnostic-updater ros-noetic-self-test"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin"
+depends="ros-noetic-diagnostic-aggregator ros-noetic-diagnostic-analysis ros-noetic-diagnostic-common-diagnostics ros-noetic-diagnostic-updater ros-noetic-self-test"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev"
+depends_dev="ros-noetic-diagnostic-aggregator ros-noetic-diagnostic-aggregator-dev ros-noetic-diagnostic-analysis ros-noetic-diagnostic-analysis-dev ros-noetic-diagnostic-common-diagnostics ros-noetic-diagnostic-common-diagnostics-dev ros-noetic-diagnostic-updater ros-noetic-diagnostic-updater-dev ros-noetic-self-test ros-noetic-self-test-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-dwa-local-planner/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-dwa-local-planner/APKBUILD
@@ -7,10 +7,11 @@ url="http://wiki.ros.org/dwa_local_planner"
 arch="all"
 license="BSD"
 
-depends="eigen-dev ros-noetic-base-local-planner ros-noetic-costmap-2d ros-noetic-dynamic-reconfigure ros-noetic-nav-core ros-noetic-nav-msgs ros-noetic-pluginlib ros-noetic-roscpp ros-noetic-sensor-msgs ros-noetic-tf2 ros-noetic-tf2-geometry-msgs ros-noetic-tf2-ros eigen-dev ros-noetic-base-local-planner ros-noetic-costmap-2d ros-noetic-dynamic-reconfigure ros-noetic-nav-core ros-noetic-nav-msgs ros-noetic-pluginlib ros-noetic-roscpp ros-noetic-sensor-msgs ros-noetic-tf2 ros-noetic-tf2-geometry-msgs ros-noetic-tf2-ros"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath eigen-dev ros-noetic-angles ros-noetic-base-local-planner ros-noetic-catkin ros-noetic-cmake-modules ros-noetic-costmap-2d ros-noetic-dynamic-reconfigure ros-noetic-nav-core ros-noetic-nav-msgs ros-noetic-pluginlib ros-noetic-roscpp ros-noetic-sensor-msgs ros-noetic-tf2 ros-noetic-tf2-geometry-msgs ros-noetic-tf2-ros"
+depends="ros-noetic-base-local-planner ros-noetic-costmap-2d ros-noetic-dynamic-reconfigure ros-noetic-nav-core ros-noetic-nav-msgs ros-noetic-pluginlib ros-noetic-roscpp ros-noetic-sensor-msgs ros-noetic-tf2 ros-noetic-tf2-geometry-msgs ros-noetic-tf2-ros"
+makedepends="chrpath eigen-dev py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-angles ros-noetic-angles-dev ros-noetic-base-local-planner ros-noetic-base-local-planner-dev ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-cmake-modules ros-noetic-cmake-modules-dev ros-noetic-costmap-2d ros-noetic-costmap-2d-dev ros-noetic-dynamic-reconfigure ros-noetic-dynamic-reconfigure-dev ros-noetic-nav-core ros-noetic-nav-core-dev ros-noetic-nav-msgs ros-noetic-nav-msgs-dev ros-noetic-pluginlib ros-noetic-pluginlib-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-sensor-msgs ros-noetic-sensor-msgs-dev ros-noetic-tf2 ros-noetic-tf2-dev ros-noetic-tf2-geometry-msgs ros-noetic-tf2-geometry-msgs-dev ros-noetic-tf2-ros ros-noetic-tf2-ros-dev"
+depends_dev="eigen-dev ros-noetic-base-local-planner ros-noetic-base-local-planner-dev ros-noetic-costmap-2d ros-noetic-costmap-2d-dev ros-noetic-dynamic-reconfigure ros-noetic-dynamic-reconfigure-dev ros-noetic-nav-core ros-noetic-nav-core-dev ros-noetic-nav-msgs ros-noetic-nav-msgs-dev ros-noetic-pluginlib ros-noetic-pluginlib-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-sensor-msgs ros-noetic-sensor-msgs-dev ros-noetic-tf2 ros-noetic-tf2-dev ros-noetic-tf2-geometry-msgs ros-noetic-tf2-geometry-msgs-dev ros-noetic-tf2-ros ros-noetic-tf2-ros-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-dynamic-reconfigure/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-dynamic-reconfigure/APKBUILD
@@ -7,10 +7,11 @@ url="http://ros.org/wiki/dynamic_reconfigure"
 arch="all"
 license="BSD"
 
-depends="boost-dev ros-noetic-message-runtime ros-noetic-roscpp ros-noetic-roslib ros-noetic-rospy ros-noetic-rosservice ros-noetic-std-msgs boost-dev ros-noetic-roscpp ros-noetic-std-msgs"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath boost-dev ros-noetic-catkin>=0.5.87 ros-noetic-cpp-common ros-noetic-message-generation ros-noetic-roscpp ros-noetic-roscpp-serialization ros-noetic-rostest ros-noetic-std-msgs"
+depends="ros-noetic-message-runtime ros-noetic-roscpp ros-noetic-roslib ros-noetic-rospy ros-noetic-rosservice ros-noetic-std-msgs"
+makedepends="boost-dev chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin-dev>=0.5.87 ros-noetic-catkin>=0.5.87 ros-noetic-cpp-common ros-noetic-cpp-common-dev ros-noetic-message-generation ros-noetic-message-generation-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-roscpp-serialization ros-noetic-roscpp-serialization-dev ros-noetic-rostest ros-noetic-rostest-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev"
+depends_dev="boost-dev ros-noetic-message-runtime-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-roslib-dev ros-noetic-rospy-dev ros-noetic-rosservice-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-eigen-conversions/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-eigen-conversions/APKBUILD
@@ -7,10 +7,11 @@ url="http://ros.org/wiki/eigen_conversions"
 arch="all"
 license="BSD"
 
-depends="eigen-dev orocos-kdl ros-noetic-geometry-msgs ros-noetic-std-msgs orocos-kdl-dev"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath eigen-dev orocos-kdl-dev ros-noetic-catkin ros-noetic-geometry-msgs ros-noetic-std-msgs"
+depends="orocos-kdl ros-noetic-geometry-msgs ros-noetic-std-msgs"
+makedepends="chrpath eigen-dev orocos-kdl-dev py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-geometry-msgs ros-noetic-geometry-msgs-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev"
+depends_dev="eigen-dev orocos-kdl-dev ros-noetic-geometry-msgs-dev ros-noetic-std-msgs-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-executive-smach-visualization/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-executive-smach-visualization/APKBUILD
@@ -7,10 +7,11 @@ url="http://ros.org/wiki/smach"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-smach-viewer ros-noetic-smach-viewer"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin"
+depends="ros-noetic-smach-viewer"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev"
+depends_dev="ros-noetic-smach-viewer ros-noetic-smach-viewer-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-executive-smach/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-executive-smach/APKBUILD
@@ -8,9 +8,10 @@ arch="all"
 license="BSD"
 
 depends="ros-noetic-smach ros-noetic-smach-msgs ros-noetic-smach-ros"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev"
+depends_dev="ros-noetic-smach-dev ros-noetic-smach-msgs-dev ros-noetic-smach-ros-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-fake-localization/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-fake-localization/APKBUILD
@@ -7,10 +7,11 @@ url="http://wiki.ros.org/fake_localization"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-geometry-msgs ros-noetic-message-filters ros-noetic-nav-msgs ros-noetic-rosconsole ros-noetic-roscpp ros-noetic-rospy ros-noetic-tf2-ros ros-noetic-geometry-msgs ros-noetic-message-filters ros-noetic-nav-msgs ros-noetic-rosconsole ros-noetic-roscpp ros-noetic-rospy ros-noetic-tf2-ros"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-angles ros-noetic-catkin ros-noetic-geometry-msgs ros-noetic-message-filters ros-noetic-nav-msgs ros-noetic-rosconsole ros-noetic-roscpp ros-noetic-rospy ros-noetic-tf2-geometry-msgs ros-noetic-tf2-ros"
+depends="ros-noetic-geometry-msgs ros-noetic-message-filters ros-noetic-nav-msgs ros-noetic-rosconsole ros-noetic-roscpp ros-noetic-rospy ros-noetic-tf2-ros"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-angles ros-noetic-angles-dev ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-geometry-msgs ros-noetic-geometry-msgs-dev ros-noetic-message-filters ros-noetic-message-filters-dev ros-noetic-nav-msgs ros-noetic-nav-msgs-dev ros-noetic-rosconsole ros-noetic-rosconsole-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-rospy ros-noetic-rospy-dev ros-noetic-tf2-geometry-msgs ros-noetic-tf2-geometry-msgs-dev ros-noetic-tf2-ros ros-noetic-tf2-ros-dev"
+depends_dev="ros-noetic-geometry-msgs ros-noetic-geometry-msgs-dev ros-noetic-message-filters ros-noetic-message-filters-dev ros-noetic-nav-msgs ros-noetic-nav-msgs-dev ros-noetic-rosconsole ros-noetic-rosconsole-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-rospy ros-noetic-rospy-dev ros-noetic-tf2-ros ros-noetic-tf2-ros-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-filters/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-filters/APKBUILD
@@ -7,10 +7,11 @@ url="http://ros.org/wiki/filters"
 arch="all"
 license="BSD"
 
-depends="boost-dev ros-noetic-pluginlib ros-noetic-rosconsole ros-noetic-roscpp ros-noetic-roslib boost-dev ros-noetic-pluginlib ros-noetic-rosconsole ros-noetic-roscpp ros-noetic-roslib"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath boost-dev ros-noetic-catkin>=0.5.68 ros-noetic-pluginlib ros-noetic-rosconsole ros-noetic-roscpp ros-noetic-roslib ros-noetic-rostest"
+depends="ros-noetic-pluginlib ros-noetic-rosconsole ros-noetic-roscpp ros-noetic-roslib"
+makedepends="boost-dev chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin-dev>=0.5.68 ros-noetic-catkin>=0.5.68 ros-noetic-pluginlib ros-noetic-pluginlib-dev ros-noetic-rosconsole ros-noetic-rosconsole-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-roslib ros-noetic-roslib-dev ros-noetic-rostest ros-noetic-rostest-dev"
+depends_dev="boost-dev ros-noetic-pluginlib ros-noetic-pluginlib-dev ros-noetic-rosconsole ros-noetic-rosconsole-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-roslib ros-noetic-roslib-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-gencpp/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-gencpp/APKBUILD
@@ -8,9 +8,10 @@ arch="all"
 license="BSD"
 
 depends="ros-noetic-genmsg"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath py3-setuptools ros-noetic-catkin>=0.5.78 ros-noetic-genmsg"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin-dev>=0.5.78 ros-noetic-catkin>=0.5.78 ros-noetic-genmsg ros-noetic-genmsg-dev"
+depends_dev="ros-noetic-genmsg-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-geneus/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-geneus/APKBUILD
@@ -8,9 +8,10 @@ arch="all"
 license="BSD"
 
 depends="ros-noetic-genmsg"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath py3-setuptools ros-noetic-catkin>=0.5.78 ros-noetic-genmsg"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin-dev>=0.5.78 ros-noetic-catkin>=0.5.78 ros-noetic-genmsg ros-noetic-genmsg-dev"
+depends_dev="ros-noetic-genmsg-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-genlisp/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-genlisp/APKBUILD
@@ -8,9 +8,10 @@ arch="all"
 license="BSD"
 
 depends="ros-noetic-genmsg"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath py3-setuptools ros-noetic-catkin>=0.5.78 ros-noetic-genmsg"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin-dev>=0.5.78 ros-noetic-catkin>=0.5.78 ros-noetic-genmsg ros-noetic-genmsg-dev"
+depends_dev="ros-noetic-genmsg-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-genmsg/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-genmsg/APKBUILD
@@ -8,9 +8,10 @@ arch="all"
 license="BSD"
 
 depends="py3-empy ros-noetic-catkin"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath py3-setuptools ros-noetic-catkin>=0.5.74"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin-dev>=0.5.74 ros-noetic-catkin>=0.5.74"
+depends_dev="ros-noetic-catkin-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-gennodejs/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-gennodejs/APKBUILD
@@ -8,9 +8,10 @@ arch="all"
 license="Apache 2.0"
 
 depends="ros-noetic-genmsg"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath py3-setuptools ros-noetic-catkin ros-noetic-genmsg"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-genmsg ros-noetic-genmsg-dev"
+depends_dev="ros-noetic-genmsg-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-genpy/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-genpy/APKBUILD
@@ -7,10 +7,11 @@ url="http://wiki.ros.org/genpy"
 arch="all"
 license="BSD"
 
-depends="py3-yaml ros-noetic-genmsg ros-noetic-genmsg"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath py3-numpy py3-numpy-dev py3-setuptools ros-noetic-catkin>=0.5.78 ros-noetic-genmsg"
+depends="py3-yaml ros-noetic-genmsg"
+makedepends="chrpath py3-numpy py3-numpy-dev py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin-dev>=0.5.78 ros-noetic-catkin>=0.5.78 ros-noetic-genmsg ros-noetic-genmsg-dev"
+depends_dev="ros-noetic-genmsg ros-noetic-genmsg-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-geographic-msgs/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-geographic-msgs/APKBUILD
@@ -7,10 +7,11 @@ url="http://wiki.ros.org/geographic_msgs"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-geometry-msgs ros-noetic-message-runtime ros-noetic-std-msgs ros-noetic-uuid-msgs ros-noetic-geometry-msgs ros-noetic-message-runtime ros-noetic-std-msgs ros-noetic-uuid-msgs"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin ros-noetic-geometry-msgs ros-noetic-message-generation ros-noetic-std-msgs ros-noetic-uuid-msgs"
+depends="ros-noetic-geometry-msgs ros-noetic-message-runtime ros-noetic-std-msgs ros-noetic-uuid-msgs"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-geometry-msgs ros-noetic-geometry-msgs-dev ros-noetic-message-generation ros-noetic-message-generation-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev ros-noetic-uuid-msgs ros-noetic-uuid-msgs-dev"
+depends_dev="ros-noetic-geometry-msgs ros-noetic-geometry-msgs-dev ros-noetic-message-runtime ros-noetic-message-runtime-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev ros-noetic-uuid-msgs ros-noetic-uuid-msgs-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-geometry-msgs/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-geometry-msgs/APKBUILD
@@ -7,10 +7,11 @@ url="http://wiki.ros.org/geometry_msgs"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-message-runtime ros-noetic-std-msgs ros-noetic-message-runtime ros-noetic-std-msgs"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin ros-noetic-message-generation ros-noetic-std-msgs"
+depends="ros-noetic-message-runtime ros-noetic-std-msgs"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-message-generation ros-noetic-message-generation-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev"
+depends_dev="ros-noetic-message-runtime ros-noetic-message-runtime-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-geometry/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-geometry/APKBUILD
@@ -7,10 +7,11 @@ url="http://www.ros.org/wiki/geometry"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-angles ros-noetic-eigen-conversions ros-noetic-kdl-conversions ros-noetic-tf ros-noetic-tf-conversions ros-noetic-angles ros-noetic-eigen-conversions ros-noetic-kdl-conversions ros-noetic-tf ros-noetic-tf-conversions"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin"
+depends="ros-noetic-angles ros-noetic-eigen-conversions ros-noetic-kdl-conversions ros-noetic-tf ros-noetic-tf-conversions"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev"
+depends_dev="ros-noetic-angles ros-noetic-angles-dev ros-noetic-eigen-conversions ros-noetic-eigen-conversions-dev ros-noetic-kdl-conversions ros-noetic-kdl-conversions-dev ros-noetic-tf ros-noetic-tf-conversions ros-noetic-tf-conversions-dev ros-noetic-tf-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-gl-dependency/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-gl-dependency/APKBUILD
@@ -8,9 +8,10 @@ arch="all"
 license="BSD"
 
 depends="py3-qt5"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev"
+depends_dev=""
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-global-planner/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-global-planner/APKBUILD
@@ -7,10 +7,11 @@ url="http://wiki.ros.org/global_planner"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-costmap-2d ros-noetic-dynamic-reconfigure ros-noetic-geometry-msgs ros-noetic-nav-core ros-noetic-nav-msgs ros-noetic-navfn ros-noetic-pluginlib ros-noetic-roscpp ros-noetic-tf2-ros ros-noetic-costmap-2d ros-noetic-dynamic-reconfigure ros-noetic-geometry-msgs ros-noetic-nav-core ros-noetic-nav-msgs ros-noetic-navfn ros-noetic-pluginlib ros-noetic-roscpp ros-noetic-tf2-ros"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-angles ros-noetic-catkin ros-noetic-costmap-2d ros-noetic-dynamic-reconfigure ros-noetic-geometry-msgs ros-noetic-nav-core ros-noetic-nav-msgs ros-noetic-navfn ros-noetic-pluginlib ros-noetic-roscpp ros-noetic-tf2-geometry-msgs ros-noetic-tf2-ros"
+depends="ros-noetic-costmap-2d ros-noetic-dynamic-reconfigure ros-noetic-geometry-msgs ros-noetic-nav-core ros-noetic-nav-msgs ros-noetic-navfn ros-noetic-pluginlib ros-noetic-roscpp ros-noetic-tf2-ros"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-angles ros-noetic-angles-dev ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-costmap-2d ros-noetic-costmap-2d-dev ros-noetic-dynamic-reconfigure ros-noetic-dynamic-reconfigure-dev ros-noetic-geometry-msgs ros-noetic-geometry-msgs-dev ros-noetic-nav-core ros-noetic-nav-core-dev ros-noetic-nav-msgs ros-noetic-nav-msgs-dev ros-noetic-navfn ros-noetic-navfn-dev ros-noetic-pluginlib ros-noetic-pluginlib-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-tf2-geometry-msgs ros-noetic-tf2-geometry-msgs-dev ros-noetic-tf2-ros ros-noetic-tf2-ros-dev"
+depends_dev="ros-noetic-costmap-2d ros-noetic-costmap-2d-dev ros-noetic-dynamic-reconfigure ros-noetic-dynamic-reconfigure-dev ros-noetic-geometry-msgs ros-noetic-geometry-msgs-dev ros-noetic-nav-core ros-noetic-nav-core-dev ros-noetic-nav-msgs ros-noetic-nav-msgs-dev ros-noetic-navfn ros-noetic-navfn-dev ros-noetic-pluginlib ros-noetic-pluginlib-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-tf2-ros ros-noetic-tf2-ros-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-grid-map-core/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-grid-map-core/APKBUILD
@@ -7,10 +7,11 @@ url="http://github.com/anybotics/grid_map"
 arch="all"
 license="BSD"
 
-depends="eigen-dev eigen-dev"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath eigen-dev gtest gtest-dev ros-noetic-catkin"
+depends=""
+makedepends="chrpath eigen-dev gtest gtest-dev py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev"
+depends_dev="eigen-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-grid-map-cv/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-grid-map-cv/APKBUILD
@@ -7,10 +7,11 @@ url="http://github.com/anybotics/grid_map"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-cv-bridge ros-noetic-filters ros-noetic-grid-map-core ros-noetic-cv-bridge ros-noetic-filters ros-noetic-grid-map-core"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath gtest gtest-dev ros-noetic-catkin ros-noetic-cv-bridge ros-noetic-filters ros-noetic-grid-map-core"
+depends="ros-noetic-cv-bridge ros-noetic-filters ros-noetic-grid-map-core"
+makedepends="chrpath gtest gtest-dev py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-cv-bridge ros-noetic-cv-bridge-dev ros-noetic-filters ros-noetic-filters-dev ros-noetic-grid-map-core ros-noetic-grid-map-core-dev"
+depends_dev="ros-noetic-cv-bridge ros-noetic-cv-bridge-dev ros-noetic-filters ros-noetic-filters-dev ros-noetic-grid-map-core ros-noetic-grid-map-core-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-grid-map-msgs/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-grid-map-msgs/APKBUILD
@@ -7,10 +7,11 @@ url="http://github.com/anybotics/grid_map"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-geometry-msgs ros-noetic-message-generation ros-noetic-message-runtime ros-noetic-roscpp ros-noetic-std-msgs ros-noetic-geometry-msgs ros-noetic-message-generation ros-noetic-roscpp ros-noetic-std-msgs"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin ros-noetic-geometry-msgs ros-noetic-message-generation ros-noetic-roscpp ros-noetic-std-msgs"
+depends="ros-noetic-geometry-msgs ros-noetic-message-generation ros-noetic-message-runtime ros-noetic-roscpp ros-noetic-std-msgs"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-geometry-msgs ros-noetic-geometry-msgs-dev ros-noetic-message-generation ros-noetic-message-generation-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev"
+depends_dev="ros-noetic-geometry-msgs ros-noetic-geometry-msgs-dev ros-noetic-message-generation ros-noetic-message-generation-dev ros-noetic-message-runtime-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-grid-map-ros/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-grid-map-ros/APKBUILD
@@ -7,10 +7,11 @@ url="http://github.com/anybotics/grid_map"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-cv-bridge ros-noetic-geometry-msgs ros-noetic-grid-map-core ros-noetic-grid-map-cv ros-noetic-grid-map-msgs ros-noetic-nav-msgs ros-noetic-rosbag ros-noetic-roscpp ros-noetic-sensor-msgs ros-noetic-std-msgs ros-noetic-tf ros-noetic-visualization-msgs ros-noetic-cv-bridge ros-noetic-geometry-msgs ros-noetic-grid-map-core ros-noetic-grid-map-cv ros-noetic-grid-map-msgs ros-noetic-nav-msgs ros-noetic-rosbag ros-noetic-roscpp ros-noetic-sensor-msgs ros-noetic-std-msgs ros-noetic-tf ros-noetic-visualization-msgs"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath gtest gtest-dev ros-noetic-catkin ros-noetic-cv-bridge ros-noetic-geometry-msgs ros-noetic-grid-map-core ros-noetic-grid-map-cv ros-noetic-grid-map-msgs ros-noetic-nav-msgs ros-noetic-rosbag ros-noetic-roscpp ros-noetic-sensor-msgs ros-noetic-std-msgs ros-noetic-tf ros-noetic-visualization-msgs"
+depends="ros-noetic-cv-bridge ros-noetic-geometry-msgs ros-noetic-grid-map-core ros-noetic-grid-map-cv ros-noetic-grid-map-msgs ros-noetic-nav-msgs ros-noetic-rosbag ros-noetic-roscpp ros-noetic-sensor-msgs ros-noetic-std-msgs ros-noetic-tf ros-noetic-visualization-msgs"
+makedepends="chrpath gtest gtest-dev py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-cv-bridge ros-noetic-cv-bridge-dev ros-noetic-geometry-msgs ros-noetic-geometry-msgs-dev ros-noetic-grid-map-core ros-noetic-grid-map-core-dev ros-noetic-grid-map-cv ros-noetic-grid-map-cv-dev ros-noetic-grid-map-msgs ros-noetic-grid-map-msgs-dev ros-noetic-nav-msgs ros-noetic-nav-msgs-dev ros-noetic-rosbag ros-noetic-rosbag-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-sensor-msgs ros-noetic-sensor-msgs-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev ros-noetic-tf ros-noetic-tf-dev ros-noetic-visualization-msgs ros-noetic-visualization-msgs-dev"
+depends_dev="ros-noetic-cv-bridge ros-noetic-cv-bridge-dev ros-noetic-geometry-msgs ros-noetic-geometry-msgs-dev ros-noetic-grid-map-core ros-noetic-grid-map-core-dev ros-noetic-grid-map-cv ros-noetic-grid-map-cv-dev ros-noetic-grid-map-msgs ros-noetic-grid-map-msgs-dev ros-noetic-nav-msgs ros-noetic-nav-msgs-dev ros-noetic-rosbag ros-noetic-rosbag-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-sensor-msgs ros-noetic-sensor-msgs-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev ros-noetic-tf ros-noetic-tf-dev ros-noetic-visualization-msgs ros-noetic-visualization-msgs-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-grid-map-rviz-plugin/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-grid-map-rviz-plugin/APKBUILD
@@ -7,10 +7,11 @@ url="http://wiki.ros.org/$_pkgname"
 arch="all"
 license="BSD"
 
-depends="qt5-qtbase-dev ros-noetic-grid-map-msgs ros-noetic-grid-map-ros ros-noetic-rviz qt5-qtbase-dev ros-noetic-grid-map-msgs ros-noetic-grid-map-ros ros-noetic-rviz"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath gtest gtest-dev qt5-qtbase-dev ros-noetic-catkin ros-noetic-grid-map-msgs ros-noetic-grid-map-ros ros-noetic-rviz"
+depends="ros-noetic-grid-map-msgs ros-noetic-grid-map-ros ros-noetic-rviz"
+makedepends="chrpath gtest gtest-dev py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool qt5-qtbase-dev ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-grid-map-msgs ros-noetic-grid-map-msgs-dev ros-noetic-grid-map-ros ros-noetic-grid-map-ros-dev ros-noetic-rviz ros-noetic-rviz-dev"
+depends_dev="qt5-qtbase-dev ros-noetic-grid-map-msgs ros-noetic-grid-map-msgs-dev ros-noetic-grid-map-ros ros-noetic-grid-map-ros-dev ros-noetic-rviz ros-noetic-rviz-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-hardware-interface/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-hardware-interface/APKBUILD
@@ -7,10 +7,11 @@ url="https://github.com/ros-controls/ros_control/wiki"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-roscpp ros-noetic-roscpp"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin ros-noetic-roscpp"
+depends="ros-noetic-roscpp"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-roscpp ros-noetic-roscpp-dev"
+depends_dev="ros-noetic-roscpp ros-noetic-roscpp-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-ifm3d-core/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-ifm3d-core/APKBUILD
@@ -7,10 +7,11 @@ url="https://github.com/ifm/ifm3d"
 arch="all"
 license="Apache"
 
-depends="curl-dev glog-dev pcl-dev ros-noetic-cv-bridge xmlrpc-c-dev"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath boost-dev cmake curl-dev glog-dev pcl-dev ros-noetic-cv-bridge xmlrpc-c-dev"
+depends="ros-noetic-cv-bridge"
+makedepends="boost-dev chrpath cmake curl-dev glog-dev pcl-dev py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-cv-bridge ros-noetic-cv-bridge-dev xmlrpc-c-dev"
+depends_dev="curl-dev glog-dev pcl-dev ros-noetic-cv-bridge-dev xmlrpc-c-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -231,6 +232,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-ifm3d/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-ifm3d/APKBUILD
@@ -7,10 +7,11 @@ url="https://github.com/lovepark/ifm3d-ros"
 arch="all"
 license="Apache 2"
 
-depends="ros-noetic-cv-bridge ros-noetic-ifm3d-core ros-noetic-image-transport ros-noetic-message-generation ros-noetic-nodelet ros-noetic-pcl-ros ros-noetic-roscpp ros-noetic-rospy ros-noetic-sensor-msgs ros-noetic-std-msgs ros-noetic-tf ros-noetic-cv-bridge ros-noetic-ifm3d-core ros-noetic-image-transport ros-noetic-message-generation ros-noetic-nodelet ros-noetic-pcl-ros ros-noetic-roscpp ros-noetic-rospy ros-noetic-sensor-msgs ros-noetic-std-msgs ros-noetic-tf"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin ros-noetic-cv-bridge ros-noetic-ifm3d-core ros-noetic-image-transport ros-noetic-message-generation ros-noetic-nodelet ros-noetic-pcl-ros ros-noetic-roscpp ros-noetic-rospy ros-noetic-rostest ros-noetic-sensor-msgs ros-noetic-std-msgs ros-noetic-tf"
+depends="ros-noetic-cv-bridge ros-noetic-ifm3d-core ros-noetic-image-transport ros-noetic-message-generation ros-noetic-nodelet ros-noetic-pcl-ros ros-noetic-roscpp ros-noetic-rospy ros-noetic-sensor-msgs ros-noetic-std-msgs ros-noetic-tf"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-cv-bridge ros-noetic-cv-bridge-dev ros-noetic-ifm3d-core ros-noetic-ifm3d-core-dev ros-noetic-image-transport ros-noetic-image-transport-dev ros-noetic-message-generation ros-noetic-message-generation-dev ros-noetic-nodelet ros-noetic-nodelet-dev ros-noetic-pcl-ros ros-noetic-pcl-ros-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-rospy ros-noetic-rospy-dev ros-noetic-rostest ros-noetic-rostest-dev ros-noetic-sensor-msgs ros-noetic-sensor-msgs-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev ros-noetic-tf ros-noetic-tf-dev"
+depends_dev="ros-noetic-cv-bridge ros-noetic-cv-bridge-dev ros-noetic-ifm3d-core ros-noetic-ifm3d-core-dev ros-noetic-image-transport ros-noetic-image-transport-dev ros-noetic-message-generation ros-noetic-message-generation-dev ros-noetic-nodelet ros-noetic-nodelet-dev ros-noetic-pcl-ros ros-noetic-pcl-ros-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-rospy ros-noetic-rospy-dev ros-noetic-sensor-msgs ros-noetic-sensor-msgs-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev ros-noetic-tf ros-noetic-tf-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-image-common/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-image-common/APKBUILD
@@ -7,10 +7,11 @@ url="http://www.ros.org/wiki/image_common"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-camera-calibration-parsers ros-noetic-camera-info-manager ros-noetic-image-transport ros-noetic-polled-camera ros-noetic-camera-calibration-parsers ros-noetic-camera-info-manager ros-noetic-image-transport ros-noetic-polled-camera"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin"
+depends="ros-noetic-camera-calibration-parsers ros-noetic-camera-info-manager ros-noetic-image-transport ros-noetic-polled-camera"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev"
+depends_dev="ros-noetic-camera-calibration-parsers ros-noetic-camera-calibration-parsers-dev ros-noetic-camera-info-manager ros-noetic-camera-info-manager-dev ros-noetic-image-transport ros-noetic-image-transport-dev ros-noetic-polled-camera ros-noetic-polled-camera-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-image-geometry/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-image-geometry/APKBUILD
@@ -7,10 +7,11 @@ url="http://www.ros.org/wiki/image_geometry"
 arch="all"
 license="BSD"
 
-depends="opencv-dev opencv-dev ros-noetic-sensor-msgs"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath opencv-dev ros-noetic-catkin ros-noetic-sensor-msgs"
+depends=""
+makedepends="chrpath opencv-dev py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-sensor-msgs ros-noetic-sensor-msgs-dev"
+depends_dev="opencv-dev ros-noetic-sensor-msgs ros-noetic-sensor-msgs-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-image-pipeline/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-image-pipeline/APKBUILD
@@ -7,10 +7,11 @@ url="http://www.ros.org/wiki/image_pipeline"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-camera-calibration ros-noetic-depth-image-proc ros-noetic-image-proc ros-noetic-image-publisher ros-noetic-image-rotate ros-noetic-image-view ros-noetic-stereo-image-proc ros-noetic-camera-calibration ros-noetic-depth-image-proc ros-noetic-image-proc ros-noetic-image-publisher ros-noetic-image-rotate ros-noetic-image-view ros-noetic-stereo-image-proc"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin"
+depends="ros-noetic-camera-calibration ros-noetic-depth-image-proc ros-noetic-image-proc ros-noetic-image-publisher ros-noetic-image-rotate ros-noetic-image-view ros-noetic-stereo-image-proc"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev"
+depends_dev="ros-noetic-camera-calibration ros-noetic-camera-calibration-dev ros-noetic-depth-image-proc ros-noetic-depth-image-proc-dev ros-noetic-image-proc ros-noetic-image-proc-dev ros-noetic-image-publisher ros-noetic-image-publisher-dev ros-noetic-image-rotate ros-noetic-image-rotate-dev ros-noetic-image-view ros-noetic-image-view-dev ros-noetic-stereo-image-proc ros-noetic-stereo-image-proc-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-image-proc/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-image-proc/APKBUILD
@@ -7,10 +7,11 @@ url="http://www.ros.org/wiki/image_proc"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-cv-bridge ros-noetic-dynamic-reconfigure ros-noetic-image-geometry ros-noetic-image-transport ros-noetic-nodelet ros-noetic-nodelet-topic-tools ros-noetic-roscpp ros-noetic-sensor-msgs ros-noetic-cv-bridge ros-noetic-dynamic-reconfigure ros-noetic-image-geometry ros-noetic-image-transport ros-noetic-nodelet ros-noetic-nodelet-topic-tools ros-noetic-roscpp ros-noetic-sensor-msgs"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath boost-dev ros-noetic-camera-calibration-parsers ros-noetic-catkin>=0.5.68 ros-noetic-cv-bridge ros-noetic-dynamic-reconfigure ros-noetic-image-geometry ros-noetic-image-transport ros-noetic-nodelet ros-noetic-nodelet-topic-tools ros-noetic-roscpp ros-noetic-rostest ros-noetic-sensor-msgs"
+depends="ros-noetic-cv-bridge ros-noetic-dynamic-reconfigure ros-noetic-image-geometry ros-noetic-image-transport ros-noetic-nodelet ros-noetic-nodelet-topic-tools ros-noetic-roscpp ros-noetic-sensor-msgs"
+makedepends="boost-dev chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-camera-calibration-parsers ros-noetic-camera-calibration-parsers-dev ros-noetic-catkin-dev>=0.5.68 ros-noetic-catkin>=0.5.68 ros-noetic-cv-bridge ros-noetic-cv-bridge-dev ros-noetic-dynamic-reconfigure ros-noetic-dynamic-reconfigure-dev ros-noetic-image-geometry ros-noetic-image-geometry-dev ros-noetic-image-transport ros-noetic-image-transport-dev ros-noetic-nodelet ros-noetic-nodelet-dev ros-noetic-nodelet-topic-tools ros-noetic-nodelet-topic-tools-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-rostest ros-noetic-rostest-dev ros-noetic-sensor-msgs ros-noetic-sensor-msgs-dev"
+depends_dev="ros-noetic-cv-bridge ros-noetic-cv-bridge-dev ros-noetic-dynamic-reconfigure ros-noetic-dynamic-reconfigure-dev ros-noetic-image-geometry ros-noetic-image-geometry-dev ros-noetic-image-transport ros-noetic-image-transport-dev ros-noetic-nodelet ros-noetic-nodelet-dev ros-noetic-nodelet-topic-tools ros-noetic-nodelet-topic-tools-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-sensor-msgs ros-noetic-sensor-msgs-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-image-publisher/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-image-publisher/APKBUILD
@@ -7,10 +7,11 @@ url="http://ros.org/wiki/image_publisher"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-camera-info-manager ros-noetic-cv-bridge ros-noetic-dynamic-reconfigure ros-noetic-image-transport ros-noetic-nodelet ros-noetic-roscpp ros-noetic-sensor-msgs ros-noetic-camera-info-manager ros-noetic-cv-bridge ros-noetic-dynamic-reconfigure ros-noetic-image-transport ros-noetic-nodelet ros-noetic-roscpp ros-noetic-sensor-msgs"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-camera-info-manager ros-noetic-catkin ros-noetic-cv-bridge ros-noetic-dynamic-reconfigure ros-noetic-image-transport ros-noetic-nodelet ros-noetic-roscpp ros-noetic-sensor-msgs"
+depends="ros-noetic-camera-info-manager ros-noetic-cv-bridge ros-noetic-dynamic-reconfigure ros-noetic-image-transport ros-noetic-nodelet ros-noetic-roscpp ros-noetic-sensor-msgs"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-camera-info-manager ros-noetic-camera-info-manager-dev ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-cv-bridge ros-noetic-cv-bridge-dev ros-noetic-dynamic-reconfigure ros-noetic-dynamic-reconfigure-dev ros-noetic-image-transport ros-noetic-image-transport-dev ros-noetic-nodelet ros-noetic-nodelet-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-sensor-msgs ros-noetic-sensor-msgs-dev"
+depends_dev="ros-noetic-camera-info-manager ros-noetic-camera-info-manager-dev ros-noetic-cv-bridge ros-noetic-cv-bridge-dev ros-noetic-dynamic-reconfigure ros-noetic-dynamic-reconfigure-dev ros-noetic-image-transport ros-noetic-image-transport-dev ros-noetic-nodelet ros-noetic-nodelet-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-sensor-msgs ros-noetic-sensor-msgs-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-image-rotate/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-image-rotate/APKBUILD
@@ -7,10 +7,11 @@ url="http://ros.org/wiki/image_rotate"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-cv-bridge ros-noetic-dynamic-reconfigure ros-noetic-image-transport ros-noetic-nodelet ros-noetic-roscpp ros-noetic-tf2 ros-noetic-tf2-geometry-msgs ros-noetic-tf2-ros ros-noetic-cv-bridge ros-noetic-dynamic-reconfigure ros-noetic-image-transport ros-noetic-nodelet ros-noetic-roscpp ros-noetic-tf2 ros-noetic-tf2-geometry-msgs ros-noetic-tf2-ros"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin ros-noetic-cmake-modules ros-noetic-cv-bridge ros-noetic-dynamic-reconfigure ros-noetic-geometry-msgs ros-noetic-image-transport ros-noetic-nodelet ros-noetic-roscpp ros-noetic-rostest ros-noetic-tf2 ros-noetic-tf2-geometry-msgs ros-noetic-tf2-ros"
+depends="ros-noetic-cv-bridge ros-noetic-dynamic-reconfigure ros-noetic-image-transport ros-noetic-nodelet ros-noetic-roscpp ros-noetic-tf2 ros-noetic-tf2-geometry-msgs ros-noetic-tf2-ros"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-cmake-modules ros-noetic-cmake-modules-dev ros-noetic-cv-bridge ros-noetic-cv-bridge-dev ros-noetic-dynamic-reconfigure ros-noetic-dynamic-reconfigure-dev ros-noetic-geometry-msgs ros-noetic-geometry-msgs-dev ros-noetic-image-transport ros-noetic-image-transport-dev ros-noetic-nodelet ros-noetic-nodelet-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-rostest ros-noetic-rostest-dev ros-noetic-tf2 ros-noetic-tf2-dev ros-noetic-tf2-geometry-msgs ros-noetic-tf2-geometry-msgs-dev ros-noetic-tf2-ros ros-noetic-tf2-ros-dev"
+depends_dev="ros-noetic-cv-bridge ros-noetic-cv-bridge-dev ros-noetic-dynamic-reconfigure ros-noetic-dynamic-reconfigure-dev ros-noetic-image-transport ros-noetic-image-transport-dev ros-noetic-nodelet ros-noetic-nodelet-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-tf2 ros-noetic-tf2-dev ros-noetic-tf2-geometry-msgs ros-noetic-tf2-geometry-msgs-dev ros-noetic-tf2-ros ros-noetic-tf2-ros-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-image-transport-plugins/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-image-transport-plugins/APKBUILD
@@ -7,10 +7,11 @@ url="http://www.ros.org/wiki/image_transport_plugins"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-compressed-depth-image-transport ros-noetic-compressed-image-transport ros-noetic-theora-image-transport ros-noetic-compressed-depth-image-transport ros-noetic-compressed-image-transport ros-noetic-theora-image-transport"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin"
+depends="ros-noetic-compressed-depth-image-transport ros-noetic-compressed-image-transport ros-noetic-theora-image-transport"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev"
+depends_dev="ros-noetic-compressed-depth-image-transport ros-noetic-compressed-depth-image-transport-dev ros-noetic-compressed-image-transport ros-noetic-compressed-image-transport-dev ros-noetic-theora-image-transport ros-noetic-theora-image-transport-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-image-transport/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-image-transport/APKBUILD
@@ -7,10 +7,11 @@ url="http://ros.org/wiki/image_transport"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-message-filters ros-noetic-pluginlib ros-noetic-rosconsole ros-noetic-roscpp ros-noetic-roslib ros-noetic-sensor-msgs ros-noetic-message-filters ros-noetic-pluginlib ros-noetic-rosconsole ros-noetic-roscpp ros-noetic-roslib ros-noetic-sensor-msgs"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin ros-noetic-message-filters ros-noetic-pluginlib ros-noetic-rosconsole ros-noetic-roscpp ros-noetic-roslib ros-noetic-sensor-msgs"
+depends="ros-noetic-message-filters ros-noetic-pluginlib ros-noetic-rosconsole ros-noetic-roscpp ros-noetic-roslib ros-noetic-sensor-msgs"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-message-filters ros-noetic-message-filters-dev ros-noetic-pluginlib ros-noetic-pluginlib-dev ros-noetic-rosconsole ros-noetic-rosconsole-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-roslib ros-noetic-roslib-dev ros-noetic-sensor-msgs ros-noetic-sensor-msgs-dev"
+depends_dev="ros-noetic-message-filters ros-noetic-message-filters-dev ros-noetic-pluginlib ros-noetic-pluginlib-dev ros-noetic-rosconsole ros-noetic-rosconsole-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-roslib ros-noetic-roslib-dev ros-noetic-sensor-msgs ros-noetic-sensor-msgs-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-image-view/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-image-view/APKBUILD
@@ -7,10 +7,11 @@ url="http://www.ros.org/wiki/image_view"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-camera-calibration-parsers ros-noetic-cv-bridge>=1.11.13 ros-noetic-dynamic-reconfigure ros-noetic-image-transport ros-noetic-message-filters ros-noetic-nodelet ros-noetic-rosconsole ros-noetic-roscpp ros-noetic-std-srvs ros-noetic-camera-calibration-parsers ros-noetic-cv-bridge>=1.11.13 ros-noetic-dynamic-reconfigure ros-noetic-image-transport ros-noetic-message-filters ros-noetic-nodelet ros-noetic-rosconsole ros-noetic-roscpp ros-noetic-std-srvs"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-camera-calibration-parsers ros-noetic-catkin ros-noetic-cv-bridge>=1.11.13 ros-noetic-dynamic-reconfigure ros-noetic-image-transport ros-noetic-message-filters ros-noetic-message-generation ros-noetic-nodelet ros-noetic-rosconsole ros-noetic-roscpp ros-noetic-rostest ros-noetic-sensor-msgs ros-noetic-std-srvs ros-noetic-stereo-msgs"
+depends="ros-noetic-camera-calibration-parsers ros-noetic-cv-bridge>=1.11.13 ros-noetic-dynamic-reconfigure ros-noetic-image-transport ros-noetic-message-filters ros-noetic-nodelet ros-noetic-rosconsole ros-noetic-roscpp ros-noetic-std-srvs"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-camera-calibration-parsers ros-noetic-camera-calibration-parsers-dev ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-cv-bridge-dev>=1.11.13 ros-noetic-cv-bridge>=1.11.13 ros-noetic-dynamic-reconfigure ros-noetic-dynamic-reconfigure-dev ros-noetic-image-transport ros-noetic-image-transport-dev ros-noetic-message-filters ros-noetic-message-filters-dev ros-noetic-message-generation ros-noetic-message-generation-dev ros-noetic-nodelet ros-noetic-nodelet-dev ros-noetic-rosconsole ros-noetic-rosconsole-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-rostest ros-noetic-rostest-dev ros-noetic-sensor-msgs ros-noetic-sensor-msgs-dev ros-noetic-std-srvs ros-noetic-std-srvs-dev ros-noetic-stereo-msgs ros-noetic-stereo-msgs-dev"
+depends_dev="ros-noetic-camera-calibration-parsers ros-noetic-camera-calibration-parsers-dev ros-noetic-cv-bridge-dev>=1.11.13 ros-noetic-cv-bridge>=1.11.13 ros-noetic-dynamic-reconfigure ros-noetic-dynamic-reconfigure-dev ros-noetic-image-transport ros-noetic-image-transport-dev ros-noetic-message-filters ros-noetic-message-filters-dev ros-noetic-nodelet ros-noetic-nodelet-dev ros-noetic-rosconsole ros-noetic-rosconsole-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-std-srvs ros-noetic-std-srvs-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-imu-complementary-filter/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-imu-complementary-filter/APKBUILD
@@ -7,10 +7,11 @@ url="http://www.mdpi.com/1424-8220/15/8/19302"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-geometry-msgs ros-noetic-message-filters ros-noetic-nodelet ros-noetic-pluginlib ros-noetic-roscpp ros-noetic-sensor-msgs ros-noetic-std-msgs ros-noetic-tf ros-noetic-geometry-msgs ros-noetic-message-filters ros-noetic-nodelet ros-noetic-pluginlib ros-noetic-roscpp ros-noetic-sensor-msgs ros-noetic-std-msgs ros-noetic-tf"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin ros-noetic-cmake-modules ros-noetic-geometry-msgs ros-noetic-message-filters ros-noetic-nodelet ros-noetic-pluginlib ros-noetic-roscpp ros-noetic-sensor-msgs ros-noetic-std-msgs ros-noetic-tf"
+depends="ros-noetic-geometry-msgs ros-noetic-message-filters ros-noetic-nodelet ros-noetic-pluginlib ros-noetic-roscpp ros-noetic-sensor-msgs ros-noetic-std-msgs ros-noetic-tf"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-cmake-modules ros-noetic-cmake-modules-dev ros-noetic-geometry-msgs ros-noetic-geometry-msgs-dev ros-noetic-message-filters ros-noetic-message-filters-dev ros-noetic-nodelet ros-noetic-nodelet-dev ros-noetic-pluginlib ros-noetic-pluginlib-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-sensor-msgs ros-noetic-sensor-msgs-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev ros-noetic-tf ros-noetic-tf-dev"
+depends_dev="ros-noetic-geometry-msgs ros-noetic-geometry-msgs-dev ros-noetic-message-filters ros-noetic-message-filters-dev ros-noetic-nodelet ros-noetic-nodelet-dev ros-noetic-pluginlib ros-noetic-pluginlib-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-sensor-msgs ros-noetic-sensor-msgs-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev ros-noetic-tf ros-noetic-tf-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-imu-filter-madgwick/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-imu-filter-madgwick/APKBUILD
@@ -7,10 +7,11 @@ url="http://ros.org/wiki/imu_filter_madgwick"
 arch="all"
 license="GPL"
 
-depends="ros-noetic-dynamic-reconfigure ros-noetic-geometry-msgs ros-noetic-message-filters ros-noetic-nodelet ros-noetic-pluginlib ros-noetic-roscpp ros-noetic-sensor-msgs ros-noetic-tf2 ros-noetic-tf2-geometry-msgs ros-noetic-tf2-ros ros-noetic-dynamic-reconfigure ros-noetic-geometry-msgs ros-noetic-message-filters ros-noetic-nodelet ros-noetic-pluginlib ros-noetic-roscpp ros-noetic-sensor-msgs ros-noetic-tf2 ros-noetic-tf2-geometry-msgs ros-noetic-tf2-ros"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin ros-noetic-dynamic-reconfigure ros-noetic-geometry-msgs ros-noetic-message-filters ros-noetic-nodelet ros-noetic-pluginlib ros-noetic-roscpp ros-noetic-rosunit ros-noetic-sensor-msgs ros-noetic-tf2 ros-noetic-tf2-geometry-msgs ros-noetic-tf2-ros"
+depends="ros-noetic-dynamic-reconfigure ros-noetic-geometry-msgs ros-noetic-message-filters ros-noetic-nodelet ros-noetic-pluginlib ros-noetic-roscpp ros-noetic-sensor-msgs ros-noetic-tf2 ros-noetic-tf2-geometry-msgs ros-noetic-tf2-ros"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-dynamic-reconfigure ros-noetic-dynamic-reconfigure-dev ros-noetic-geometry-msgs ros-noetic-geometry-msgs-dev ros-noetic-message-filters ros-noetic-message-filters-dev ros-noetic-nodelet ros-noetic-nodelet-dev ros-noetic-pluginlib ros-noetic-pluginlib-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-rosunit ros-noetic-rosunit-dev ros-noetic-sensor-msgs ros-noetic-sensor-msgs-dev ros-noetic-tf2 ros-noetic-tf2-dev ros-noetic-tf2-geometry-msgs ros-noetic-tf2-geometry-msgs-dev ros-noetic-tf2-ros ros-noetic-tf2-ros-dev"
+depends_dev="ros-noetic-dynamic-reconfigure ros-noetic-dynamic-reconfigure-dev ros-noetic-geometry-msgs ros-noetic-geometry-msgs-dev ros-noetic-message-filters ros-noetic-message-filters-dev ros-noetic-nodelet ros-noetic-nodelet-dev ros-noetic-pluginlib ros-noetic-pluginlib-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-sensor-msgs ros-noetic-sensor-msgs-dev ros-noetic-tf2 ros-noetic-tf2-dev ros-noetic-tf2-geometry-msgs ros-noetic-tf2-geometry-msgs-dev ros-noetic-tf2-ros ros-noetic-tf2-ros-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-imu-tools/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-imu-tools/APKBUILD
@@ -7,10 +7,11 @@ url="http://ros.org/wiki/imu_tools"
 arch="all"
 license="BSD, GPL"
 
-depends="ros-noetic-imu-complementary-filter ros-noetic-imu-filter-madgwick ros-noetic-rviz-imu-plugin ros-noetic-imu-complementary-filter ros-noetic-imu-filter-madgwick ros-noetic-rviz-imu-plugin"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin"
+depends="ros-noetic-imu-complementary-filter ros-noetic-imu-filter-madgwick ros-noetic-rviz-imu-plugin"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev"
+depends_dev="ros-noetic-imu-complementary-filter ros-noetic-imu-complementary-filter-dev ros-noetic-imu-filter-madgwick ros-noetic-imu-filter-madgwick-dev ros-noetic-rviz-imu-plugin ros-noetic-rviz-imu-plugin-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-interactive-markers/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-interactive-markers/APKBUILD
@@ -7,10 +7,11 @@ url="http://ros.org/wiki/interactive_markers"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-rosconsole ros-noetic-roscpp ros-noetic-rospy ros-noetic-rostest ros-noetic-std-msgs ros-noetic-tf2-geometry-msgs ros-noetic-tf2-ros ros-noetic-visualization-msgs ros-noetic-rosconsole ros-noetic-roscpp ros-noetic-rospy ros-noetic-rostest ros-noetic-std-msgs ros-noetic-tf2-geometry-msgs ros-noetic-tf2-ros ros-noetic-visualization-msgs"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin ros-noetic-rosconsole ros-noetic-roscpp ros-noetic-rospy ros-noetic-rostest ros-noetic-std-msgs ros-noetic-tf2-geometry-msgs ros-noetic-tf2-ros ros-noetic-visualization-msgs"
+depends="ros-noetic-rosconsole ros-noetic-roscpp ros-noetic-rospy ros-noetic-rostest ros-noetic-std-msgs ros-noetic-tf2-geometry-msgs ros-noetic-tf2-ros ros-noetic-visualization-msgs"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-rosconsole ros-noetic-rosconsole-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-rospy ros-noetic-rospy-dev ros-noetic-rostest ros-noetic-rostest-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev ros-noetic-tf2-geometry-msgs ros-noetic-tf2-geometry-msgs-dev ros-noetic-tf2-ros ros-noetic-tf2-ros-dev ros-noetic-visualization-msgs ros-noetic-visualization-msgs-dev"
+depends_dev="ros-noetic-rosconsole ros-noetic-rosconsole-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-rospy ros-noetic-rospy-dev ros-noetic-rostest ros-noetic-rostest-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev ros-noetic-tf2-geometry-msgs ros-noetic-tf2-geometry-msgs-dev ros-noetic-tf2-ros ros-noetic-tf2-ros-dev ros-noetic-visualization-msgs ros-noetic-visualization-msgs-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-joint-limits-interface/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-joint-limits-interface/APKBUILD
@@ -7,10 +7,11 @@ url="https://github.com/ros-controls/ros_control/wiki"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-roscpp ros-noetic-urdf ros-noetic-hardware-interface ros-noetic-roscpp ros-noetic-urdf"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin ros-noetic-hardware-interface ros-noetic-roscpp ros-noetic-rostest ros-noetic-urdf"
+depends="ros-noetic-roscpp ros-noetic-urdf"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-hardware-interface ros-noetic-hardware-interface-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-rostest ros-noetic-rostest-dev ros-noetic-urdf ros-noetic-urdf-dev"
+depends_dev="ros-noetic-hardware-interface ros-noetic-hardware-interface-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-urdf ros-noetic-urdf-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-joint-state-publisher-gui/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-joint-state-publisher-gui/APKBUILD
@@ -8,9 +8,10 @@ arch="all"
 license="BSD"
 
 depends="ros-noetic-joint-state-publisher ros-noetic-python-qt-binding ros-noetic-rospy"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev"
+depends_dev="ros-noetic-joint-state-publisher-dev ros-noetic-python-qt-binding-dev ros-noetic-rospy-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-joint-state-publisher/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-joint-state-publisher/APKBUILD
@@ -8,9 +8,10 @@ arch="all"
 license="BSD"
 
 depends="ros-noetic-rospy ros-noetic-sensor-msgs"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin ros-noetic-rostest"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-rostest ros-noetic-rostest-dev"
+depends_dev="ros-noetic-rospy-dev ros-noetic-sensor-msgs-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-joy/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-joy/APKBUILD
@@ -7,10 +7,11 @@ url="http://www.ros.org/wiki/joy"
 arch="all"
 license="BSD"
 
-depends="linux-headers linuxconsoletools ros-noetic-diagnostic-updater ros-noetic-roscpp ros-noetic-sensor-msgs linux-headers linuxconsoletools ros-noetic-diagnostic-updater ros-noetic-roscpp ros-noetic-sensor-msgs"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath linux-headers linuxconsoletools ros-noetic-catkin ros-noetic-diagnostic-updater ros-noetic-rosbag ros-noetic-roscpp ros-noetic-roslint ros-noetic-sensor-msgs"
+depends="linux-headers linuxconsoletools ros-noetic-diagnostic-updater ros-noetic-roscpp ros-noetic-sensor-msgs"
+makedepends="chrpath linux-headers linuxconsoletools py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-diagnostic-updater ros-noetic-diagnostic-updater-dev ros-noetic-rosbag ros-noetic-rosbag-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-roslint ros-noetic-roslint-dev ros-noetic-sensor-msgs ros-noetic-sensor-msgs-dev"
+depends_dev="linux-headers linuxconsoletools ros-noetic-diagnostic-updater ros-noetic-diagnostic-updater-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-sensor-msgs ros-noetic-sensor-msgs-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-joystick-interrupt/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-joystick-interrupt/APKBUILD
@@ -7,10 +7,11 @@ url="http://wiki.ros.org/$_pkgname"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-geometry-msgs ros-noetic-neonavigation-common ros-noetic-roscpp ros-noetic-sensor-msgs ros-noetic-topic-tools ros-noetic-geometry-msgs ros-noetic-neonavigation-common ros-noetic-roscpp ros-noetic-sensor-msgs ros-noetic-topic-tools"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin ros-noetic-geometry-msgs ros-noetic-neonavigation-common ros-noetic-roscpp ros-noetic-roslint ros-noetic-rostest ros-noetic-sensor-msgs ros-noetic-topic-tools"
+depends="ros-noetic-geometry-msgs ros-noetic-neonavigation-common ros-noetic-roscpp ros-noetic-sensor-msgs ros-noetic-topic-tools"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-geometry-msgs ros-noetic-geometry-msgs-dev ros-noetic-neonavigation-common ros-noetic-neonavigation-common-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-roslint ros-noetic-roslint-dev ros-noetic-rostest ros-noetic-rostest-dev ros-noetic-sensor-msgs ros-noetic-sensor-msgs-dev ros-noetic-topic-tools ros-noetic-topic-tools-dev"
+depends_dev="ros-noetic-geometry-msgs ros-noetic-geometry-msgs-dev ros-noetic-neonavigation-common ros-noetic-neonavigation-common-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-sensor-msgs ros-noetic-sensor-msgs-dev ros-noetic-topic-tools ros-noetic-topic-tools-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-kdl-conversions/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-kdl-conversions/APKBUILD
@@ -7,10 +7,11 @@ url="http://ros.org/wiki/kdl_conversions"
 arch="all"
 license="BSD"
 
-depends="orocos-kdl ros-noetic-geometry-msgs orocos-kdl-dev"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath orocos-kdl-dev ros-noetic-catkin ros-noetic-geometry-msgs"
+depends="orocos-kdl ros-noetic-geometry-msgs"
+makedepends="chrpath orocos-kdl-dev py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-geometry-msgs ros-noetic-geometry-msgs-dev"
+depends_dev="orocos-kdl-dev ros-noetic-geometry-msgs-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-kdl-parser/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-kdl-parser/APKBUILD
@@ -7,10 +7,11 @@ url="http://ros.org/wiki/kdl_parser"
 arch="all"
 license="BSD"
 
-depends="orocos-kdl-dev>=1.3.0 ros-noetic-rosconsole ros-noetic-urdf tinyxml-dev tinyxml2-dev orocos-kdl-dev>=1.3.0 ros-noetic-urdf tinyxml-dev tinyxml2-dev urdfdom_headers"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath orocos-kdl-dev>=1.3.0 ros-noetic-catkin>=0.5.68 ros-noetic-cmake-modules ros-noetic-rosconsole ros-noetic-roscpp ros-noetic-rostest ros-noetic-urdf tinyxml-dev tinyxml2-dev urdfdom_headers"
+depends="ros-noetic-rosconsole ros-noetic-urdf"
+makedepends="chrpath orocos-kdl-dev>=1.3.0 py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin-dev>=0.5.68 ros-noetic-catkin>=0.5.68 ros-noetic-cmake-modules ros-noetic-cmake-modules-dev ros-noetic-rosconsole ros-noetic-rosconsole-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-rostest ros-noetic-rostest-dev ros-noetic-urdf ros-noetic-urdf-dev tinyxml-dev tinyxml2-dev urdfdom_headers"
+depends_dev="orocos-kdl-dev>=1.3.0 ros-noetic-rosconsole-dev ros-noetic-urdf ros-noetic-urdf-dev tinyxml-dev tinyxml2-dev urdfdom_headers"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-laser-assembler/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-laser-assembler/APKBUILD
@@ -7,10 +7,11 @@ url="http://ros.org/wiki/laser_assembler"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-filters ros-noetic-laser-geometry ros-noetic-message-filters ros-noetic-message-runtime ros-noetic-pluginlib ros-noetic-roscpp ros-noetic-sensor-msgs ros-noetic-tf ros-noetic-filters ros-noetic-laser-geometry ros-noetic-message-filters ros-noetic-message-runtime ros-noetic-pluginlib ros-noetic-roscpp ros-noetic-sensor-msgs ros-noetic-tf"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin>=0.5.68 ros-noetic-filters ros-noetic-laser-geometry ros-noetic-message-filters ros-noetic-message-generation ros-noetic-pluginlib ros-noetic-roscpp ros-noetic-rostest ros-noetic-sensor-msgs ros-noetic-tf"
+depends="ros-noetic-filters ros-noetic-laser-geometry ros-noetic-message-filters ros-noetic-message-runtime ros-noetic-pluginlib ros-noetic-roscpp ros-noetic-sensor-msgs ros-noetic-tf"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin-dev>=0.5.68 ros-noetic-catkin>=0.5.68 ros-noetic-filters ros-noetic-filters-dev ros-noetic-laser-geometry ros-noetic-laser-geometry-dev ros-noetic-message-filters ros-noetic-message-filters-dev ros-noetic-message-generation ros-noetic-message-generation-dev ros-noetic-pluginlib ros-noetic-pluginlib-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-rostest ros-noetic-rostest-dev ros-noetic-sensor-msgs ros-noetic-sensor-msgs-dev ros-noetic-tf ros-noetic-tf-dev"
+depends_dev="ros-noetic-filters ros-noetic-filters-dev ros-noetic-laser-geometry ros-noetic-laser-geometry-dev ros-noetic-message-filters ros-noetic-message-filters-dev ros-noetic-message-runtime ros-noetic-message-runtime-dev ros-noetic-pluginlib ros-noetic-pluginlib-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-sensor-msgs ros-noetic-sensor-msgs-dev ros-noetic-tf ros-noetic-tf-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-laser-filters/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-laser-filters/APKBUILD
@@ -7,10 +7,11 @@ url="http://ros.org/wiki/laser_filters"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-angles ros-noetic-dynamic-reconfigure ros-noetic-filters ros-noetic-laser-geometry ros-noetic-message-filters ros-noetic-nodelet ros-noetic-pluginlib ros-noetic-roscpp ros-noetic-sensor-msgs ros-noetic-tf ros-noetic-angles ros-noetic-dynamic-reconfigure ros-noetic-filters ros-noetic-laser-geometry ros-noetic-message-filters ros-noetic-nodelet ros-noetic-pluginlib ros-noetic-roscpp ros-noetic-sensor-msgs ros-noetic-tf"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-angles ros-noetic-catkin ros-noetic-dynamic-reconfigure ros-noetic-filters ros-noetic-laser-geometry ros-noetic-message-filters ros-noetic-nodelet ros-noetic-pluginlib ros-noetic-roscpp ros-noetic-rostest ros-noetic-sensor-msgs ros-noetic-tf"
+depends="ros-noetic-angles ros-noetic-dynamic-reconfigure ros-noetic-filters ros-noetic-laser-geometry ros-noetic-message-filters ros-noetic-nodelet ros-noetic-pluginlib ros-noetic-roscpp ros-noetic-sensor-msgs ros-noetic-tf"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-angles ros-noetic-angles-dev ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-dynamic-reconfigure ros-noetic-dynamic-reconfigure-dev ros-noetic-filters ros-noetic-filters-dev ros-noetic-laser-geometry ros-noetic-laser-geometry-dev ros-noetic-message-filters ros-noetic-message-filters-dev ros-noetic-nodelet ros-noetic-nodelet-dev ros-noetic-pluginlib ros-noetic-pluginlib-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-rostest ros-noetic-rostest-dev ros-noetic-sensor-msgs ros-noetic-sensor-msgs-dev ros-noetic-tf ros-noetic-tf-dev"
+depends_dev="ros-noetic-angles ros-noetic-angles-dev ros-noetic-dynamic-reconfigure ros-noetic-dynamic-reconfigure-dev ros-noetic-filters ros-noetic-filters-dev ros-noetic-laser-geometry ros-noetic-laser-geometry-dev ros-noetic-message-filters ros-noetic-message-filters-dev ros-noetic-nodelet ros-noetic-nodelet-dev ros-noetic-pluginlib ros-noetic-pluginlib-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-sensor-msgs ros-noetic-sensor-msgs-dev ros-noetic-tf ros-noetic-tf-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-laser-geometry/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-laser-geometry/APKBUILD
@@ -7,10 +7,11 @@ url="http://ros.org/wiki/laser_geometry"
 arch="all"
 license="BSD"
 
-depends="boost-dev eigen-dev py3-numpy py3-numpy-dev ros-noetic-angles ros-noetic-roscpp ros-noetic-sensor-msgs ros-noetic-tf ros-noetic-tf2 boost-dev eigen-dev ros-noetic-angles ros-noetic-roscpp ros-noetic-sensor-msgs ros-noetic-tf ros-noetic-tf2"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath boost-dev eigen-dev ros-noetic-angles ros-noetic-catkin>=0.5.68 ros-noetic-roscpp ros-noetic-rosunit ros-noetic-sensor-msgs ros-noetic-tf ros-noetic-tf2 ros-noetic-tf2-geometry-msgs"
+depends="py3-numpy ros-noetic-angles ros-noetic-roscpp ros-noetic-sensor-msgs ros-noetic-tf ros-noetic-tf2"
+makedepends="boost-dev chrpath eigen-dev py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-angles ros-noetic-angles-dev ros-noetic-catkin-dev>=0.5.68 ros-noetic-catkin>=0.5.68 ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-rosunit ros-noetic-rosunit-dev ros-noetic-sensor-msgs ros-noetic-sensor-msgs-dev ros-noetic-tf ros-noetic-tf-dev ros-noetic-tf2 ros-noetic-tf2-dev ros-noetic-tf2-geometry-msgs ros-noetic-tf2-geometry-msgs-dev"
+depends_dev="boost-dev eigen-dev py3-numpy-dev ros-noetic-angles ros-noetic-angles-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-sensor-msgs ros-noetic-sensor-msgs-dev ros-noetic-tf ros-noetic-tf-dev ros-noetic-tf2 ros-noetic-tf2-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-laser-pipeline/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-laser-pipeline/APKBUILD
@@ -7,10 +7,11 @@ url="http://www.ros.org/wiki/laser_pipeline"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-laser-assembler ros-noetic-laser-filters ros-noetic-laser-geometry ros-noetic-laser-assembler ros-noetic-laser-filters ros-noetic-laser-geometry"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin"
+depends="ros-noetic-laser-assembler ros-noetic-laser-filters ros-noetic-laser-geometry"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev"
+depends_dev="ros-noetic-laser-assembler ros-noetic-laser-assembler-dev ros-noetic-laser-filters ros-noetic-laser-filters-dev ros-noetic-laser-geometry ros-noetic-laser-geometry-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-laser-proc/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-laser-proc/APKBUILD
@@ -7,10 +7,11 @@ url="http://ros.org/wiki/laser_proc"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-nodelet ros-noetic-pluginlib ros-noetic-rosconsole ros-noetic-roscpp ros-noetic-sensor-msgs ros-noetic-nodelet ros-noetic-pluginlib ros-noetic-rosconsole ros-noetic-roscpp ros-noetic-sensor-msgs"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin ros-noetic-nodelet ros-noetic-pluginlib ros-noetic-rosconsole ros-noetic-roscpp ros-noetic-sensor-msgs"
+depends="ros-noetic-nodelet ros-noetic-pluginlib ros-noetic-rosconsole ros-noetic-roscpp ros-noetic-sensor-msgs"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-nodelet ros-noetic-nodelet-dev ros-noetic-pluginlib ros-noetic-pluginlib-dev ros-noetic-rosconsole ros-noetic-rosconsole-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-sensor-msgs ros-noetic-sensor-msgs-dev"
+depends_dev="ros-noetic-nodelet ros-noetic-nodelet-dev ros-noetic-pluginlib ros-noetic-pluginlib-dev ros-noetic-rosconsole ros-noetic-rosconsole-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-sensor-msgs ros-noetic-sensor-msgs-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-map-msgs/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-map-msgs/APKBUILD
@@ -7,10 +7,11 @@ url="http://ros.org/wiki/map_msgs"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-message-runtime ros-noetic-nav-msgs ros-noetic-sensor-msgs ros-noetic-std-msgs ros-noetic-message-runtime ros-noetic-nav-msgs ros-noetic-sensor-msgs ros-noetic-std-msgs"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin ros-noetic-message-generation ros-noetic-nav-msgs ros-noetic-sensor-msgs ros-noetic-std-msgs"
+depends="ros-noetic-message-runtime ros-noetic-nav-msgs ros-noetic-sensor-msgs ros-noetic-std-msgs"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-message-generation ros-noetic-message-generation-dev ros-noetic-nav-msgs ros-noetic-nav-msgs-dev ros-noetic-sensor-msgs ros-noetic-sensor-msgs-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev"
+depends_dev="ros-noetic-message-runtime ros-noetic-message-runtime-dev ros-noetic-nav-msgs ros-noetic-nav-msgs-dev ros-noetic-sensor-msgs ros-noetic-sensor-msgs-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-map-organizer-msgs/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-map-organizer-msgs/APKBUILD
@@ -7,10 +7,11 @@ url="http://wiki.ros.org/$_pkgname"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-message-runtime ros-noetic-nav-msgs ros-noetic-message-runtime ros-noetic-nav-msgs"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin ros-noetic-message-generation ros-noetic-nav-msgs"
+depends="ros-noetic-message-runtime ros-noetic-nav-msgs"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-message-generation ros-noetic-message-generation-dev ros-noetic-nav-msgs ros-noetic-nav-msgs-dev"
+depends_dev="ros-noetic-message-runtime ros-noetic-message-runtime-dev ros-noetic-nav-msgs ros-noetic-nav-msgs-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-map-organizer/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-map-organizer/APKBUILD
@@ -7,10 +7,11 @@ url="http://wiki.ros.org/$_pkgname"
 arch="all"
 license="BSD"
 
-depends="eigen-dev pcl ros-noetic-geometry-msgs ros-noetic-map-organizer-msgs ros-noetic-map-server ros-noetic-nav-msgs ros-noetic-neonavigation-common ros-noetic-pcl-conversions ros-noetic-roscpp ros-noetic-sensor-msgs ros-noetic-tf2 ros-noetic-tf2-geometry-msgs ros-noetic-tf2-ros eigen-dev ros-noetic-geometry-msgs ros-noetic-map-organizer-msgs ros-noetic-map-server ros-noetic-nav-msgs ros-noetic-neonavigation-common ros-noetic-pcl-conversions ros-noetic-roscpp ros-noetic-sensor-msgs ros-noetic-tf2 ros-noetic-tf2-geometry-msgs ros-noetic-tf2-ros"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath eigen-dev pcl-dev ros-noetic-catkin ros-noetic-geometry-msgs ros-noetic-map-organizer-msgs ros-noetic-map-server ros-noetic-nav-msgs ros-noetic-neonavigation-common ros-noetic-pcl-conversions ros-noetic-roscpp ros-noetic-roslint ros-noetic-rostest ros-noetic-sensor-msgs ros-noetic-tf2 ros-noetic-tf2-geometry-msgs ros-noetic-tf2-ros"
+depends="pcl ros-noetic-geometry-msgs ros-noetic-map-organizer-msgs ros-noetic-map-server ros-noetic-nav-msgs ros-noetic-neonavigation-common ros-noetic-pcl-conversions ros-noetic-roscpp ros-noetic-sensor-msgs ros-noetic-tf2 ros-noetic-tf2-geometry-msgs ros-noetic-tf2-ros"
+makedepends="chrpath eigen-dev pcl-dev py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-geometry-msgs ros-noetic-geometry-msgs-dev ros-noetic-map-organizer-msgs ros-noetic-map-organizer-msgs-dev ros-noetic-map-server ros-noetic-map-server-dev ros-noetic-nav-msgs ros-noetic-nav-msgs-dev ros-noetic-neonavigation-common ros-noetic-neonavigation-common-dev ros-noetic-pcl-conversions ros-noetic-pcl-conversions-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-roslint ros-noetic-roslint-dev ros-noetic-rostest ros-noetic-rostest-dev ros-noetic-sensor-msgs ros-noetic-sensor-msgs-dev ros-noetic-tf2 ros-noetic-tf2-dev ros-noetic-tf2-geometry-msgs ros-noetic-tf2-geometry-msgs-dev ros-noetic-tf2-ros ros-noetic-tf2-ros-dev"
+depends_dev="eigen-dev ros-noetic-geometry-msgs ros-noetic-geometry-msgs-dev ros-noetic-map-organizer-msgs ros-noetic-map-organizer-msgs-dev ros-noetic-map-server ros-noetic-map-server-dev ros-noetic-nav-msgs ros-noetic-nav-msgs-dev ros-noetic-neonavigation-common ros-noetic-neonavigation-common-dev ros-noetic-pcl-conversions ros-noetic-pcl-conversions-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-sensor-msgs ros-noetic-sensor-msgs-dev ros-noetic-tf2 ros-noetic-tf2-dev ros-noetic-tf2-geometry-msgs ros-noetic-tf2-geometry-msgs-dev ros-noetic-tf2-ros ros-noetic-tf2-ros-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-map-server/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-map-server/APKBUILD
@@ -7,10 +7,11 @@ url="http://wiki.ros.org/map_server"
 arch="all"
 license="BSD"
 
-depends="bullet3-dev libpng ros-noetic-nav-msgs ros-noetic-roscpp ros-noetic-tf2 sdl-dev sdl_image-dev yaml-cpp-dev bullet3-dev libpng ros-noetic-nav-msgs ros-noetic-roscpp ros-noetic-tf2 sdl-dev sdl_image-dev yaml-cpp-dev"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath bullet3-dev libpng ros-noetic-catkin>=0.5.68 ros-noetic-nav-msgs ros-noetic-roscpp ros-noetic-roslib ros-noetic-rospy ros-noetic-rostest ros-noetic-rosunit ros-noetic-tf2 sdl-dev sdl_image-dev yaml-cpp-dev"
+depends="libpng ros-noetic-nav-msgs ros-noetic-roscpp ros-noetic-tf2"
+makedepends="bullet3-dev chrpath libpng py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin-dev>=0.5.68 ros-noetic-catkin>=0.5.68 ros-noetic-nav-msgs ros-noetic-nav-msgs-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-roslib ros-noetic-roslib-dev ros-noetic-rospy ros-noetic-rospy-dev ros-noetic-rostest ros-noetic-rostest-dev ros-noetic-rosunit ros-noetic-rosunit-dev ros-noetic-tf2 ros-noetic-tf2-dev sdl-dev sdl_image-dev yaml-cpp-dev"
+depends_dev="bullet3-dev libpng ros-noetic-nav-msgs ros-noetic-nav-msgs-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-tf2 ros-noetic-tf2-dev sdl-dev sdl_image-dev yaml-cpp-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-mcl-3dl-msgs/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-mcl-3dl-msgs/APKBUILD
@@ -7,10 +7,11 @@ url="http://wiki.ros.org/$_pkgname"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-message-runtime ros-noetic-std-msgs ros-noetic-message-runtime ros-noetic-std-msgs"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin ros-noetic-message-generation ros-noetic-std-msgs"
+depends="ros-noetic-message-runtime ros-noetic-std-msgs"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-message-generation ros-noetic-message-generation-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev"
+depends_dev="ros-noetic-message-runtime ros-noetic-message-runtime-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-mcl-3dl/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-mcl-3dl/APKBUILD
@@ -7,10 +7,11 @@ url="http://wiki.ros.org/$_pkgname"
 arch="all"
 license="BSD"
 
-depends="eigen-dev ros-noetic-diagnostic-updater ros-noetic-geometry-msgs ros-noetic-mcl-3dl-msgs ros-noetic-nav-msgs ros-noetic-pcl-ros ros-noetic-roscpp ros-noetic-sensor-msgs ros-noetic-std-msgs ros-noetic-std-srvs ros-noetic-tf2 ros-noetic-tf2-geometry-msgs ros-noetic-tf2-ros ros-noetic-tf2-sensor-msgs ros-noetic-visualization-msgs eigen-dev ros-noetic-diagnostic-updater ros-noetic-geometry-msgs ros-noetic-mcl-3dl-msgs ros-noetic-nav-msgs ros-noetic-pcl-ros ros-noetic-roscpp ros-noetic-sensor-msgs ros-noetic-std-msgs ros-noetic-std-srvs ros-noetic-tf2 ros-noetic-tf2-geometry-msgs ros-noetic-tf2-ros ros-noetic-tf2-sensor-msgs ros-noetic-visualization-msgs"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath eigen-dev ros-noetic-catkin ros-noetic-diagnostic-updater ros-noetic-geometry-msgs ros-noetic-mcl-3dl-msgs ros-noetic-nav-msgs ros-noetic-pcl-ros ros-noetic-roscpp ros-noetic-roslint ros-noetic-rostest ros-noetic-rosunit ros-noetic-sensor-msgs ros-noetic-std-msgs ros-noetic-std-srvs ros-noetic-tf2 ros-noetic-tf2-geometry-msgs ros-noetic-tf2-ros ros-noetic-tf2-sensor-msgs ros-noetic-visualization-msgs"
+depends="ros-noetic-diagnostic-updater ros-noetic-geometry-msgs ros-noetic-mcl-3dl-msgs ros-noetic-nav-msgs ros-noetic-pcl-ros ros-noetic-roscpp ros-noetic-sensor-msgs ros-noetic-std-msgs ros-noetic-std-srvs ros-noetic-tf2 ros-noetic-tf2-geometry-msgs ros-noetic-tf2-ros ros-noetic-tf2-sensor-msgs ros-noetic-visualization-msgs"
+makedepends="chrpath eigen-dev py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-diagnostic-updater ros-noetic-diagnostic-updater-dev ros-noetic-geometry-msgs ros-noetic-geometry-msgs-dev ros-noetic-mcl-3dl-msgs ros-noetic-mcl-3dl-msgs-dev ros-noetic-nav-msgs ros-noetic-nav-msgs-dev ros-noetic-pcl-ros ros-noetic-pcl-ros-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-roslint ros-noetic-roslint-dev ros-noetic-rostest ros-noetic-rostest-dev ros-noetic-rosunit ros-noetic-rosunit-dev ros-noetic-sensor-msgs ros-noetic-sensor-msgs-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev ros-noetic-std-srvs ros-noetic-std-srvs-dev ros-noetic-tf2 ros-noetic-tf2-dev ros-noetic-tf2-geometry-msgs ros-noetic-tf2-geometry-msgs-dev ros-noetic-tf2-ros ros-noetic-tf2-ros-dev ros-noetic-tf2-sensor-msgs ros-noetic-tf2-sensor-msgs-dev ros-noetic-visualization-msgs ros-noetic-visualization-msgs-dev"
+depends_dev="eigen-dev ros-noetic-diagnostic-updater ros-noetic-diagnostic-updater-dev ros-noetic-geometry-msgs ros-noetic-geometry-msgs-dev ros-noetic-mcl-3dl-msgs ros-noetic-mcl-3dl-msgs-dev ros-noetic-nav-msgs ros-noetic-nav-msgs-dev ros-noetic-pcl-ros ros-noetic-pcl-ros-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-sensor-msgs ros-noetic-sensor-msgs-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev ros-noetic-std-srvs ros-noetic-std-srvs-dev ros-noetic-tf2 ros-noetic-tf2-dev ros-noetic-tf2-geometry-msgs ros-noetic-tf2-geometry-msgs-dev ros-noetic-tf2-ros ros-noetic-tf2-ros-dev ros-noetic-tf2-sensor-msgs ros-noetic-tf2-sensor-msgs-dev ros-noetic-visualization-msgs ros-noetic-visualization-msgs-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-media-export/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-media-export/APKBUILD
@@ -8,9 +8,10 @@ arch="all"
 license="BSD"
 
 depends=""
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev"
+depends_dev=""
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-message-filters/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-message-filters/APKBUILD
@@ -7,10 +7,11 @@ url="http://ros.org/wiki/message_filters"
 arch="all"
 license="BSD"
 
-depends="boost-dev ros-noetic-rosconsole ros-noetic-roscpp boost-dev ros-noetic-rosconsole ros-noetic-roscpp"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath boost-dev ros-noetic-catkin>=0.5.68 ros-noetic-rosconsole ros-noetic-roscpp ros-noetic-rostest ros-noetic-rosunit"
+depends="ros-noetic-rosconsole ros-noetic-roscpp"
+makedepends="boost-dev chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin-dev>=0.5.68 ros-noetic-catkin>=0.5.68 ros-noetic-rosconsole ros-noetic-rosconsole-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-rostest ros-noetic-rostest-dev ros-noetic-rosunit ros-noetic-rosunit-dev"
+depends_dev="boost-dev ros-noetic-rosconsole ros-noetic-rosconsole-dev ros-noetic-roscpp ros-noetic-roscpp-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-message-generation/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-message-generation/APKBUILD
@@ -7,10 +7,11 @@ url="http://ros.org/wiki/message_generation"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-gencpp ros-noetic-geneus ros-noetic-genlisp ros-noetic-genmsg ros-noetic-gennodejs ros-noetic-genpy ros-noetic-gencpp ros-noetic-geneus ros-noetic-genlisp ros-noetic-genmsg ros-noetic-gennodejs ros-noetic-genpy"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin"
+depends="ros-noetic-gencpp ros-noetic-geneus ros-noetic-genlisp ros-noetic-genmsg ros-noetic-gennodejs ros-noetic-genpy"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev"
+depends_dev="ros-noetic-gencpp ros-noetic-gencpp-dev ros-noetic-geneus ros-noetic-geneus-dev ros-noetic-genlisp ros-noetic-genlisp-dev ros-noetic-genmsg ros-noetic-genmsg-dev ros-noetic-gennodejs ros-noetic-gennodejs-dev ros-noetic-genpy ros-noetic-genpy-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-message-runtime/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-message-runtime/APKBUILD
@@ -7,10 +7,11 @@ url="http://ros.org/wiki/message_runtime"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-cpp-common ros-noetic-genpy ros-noetic-roscpp-serialization ros-noetic-roscpp-traits ros-noetic-rostime ros-noetic-cpp-common ros-noetic-genpy ros-noetic-roscpp-serialization ros-noetic-roscpp-traits ros-noetic-rostime"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin"
+depends="ros-noetic-cpp-common ros-noetic-genpy ros-noetic-roscpp-serialization ros-noetic-roscpp-traits ros-noetic-rostime"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev"
+depends_dev="ros-noetic-cpp-common ros-noetic-cpp-common-dev ros-noetic-genpy ros-noetic-genpy-dev ros-noetic-roscpp-serialization ros-noetic-roscpp-serialization-dev ros-noetic-roscpp-traits ros-noetic-roscpp-traits-dev ros-noetic-rostime ros-noetic-rostime-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-mk/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-mk/APKBUILD
@@ -7,10 +7,11 @@ url="http://www.ros.org/wiki/ROS"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-rosbuild ros-noetic-rospack ros-noetic-rosbuild ros-noetic-rospack"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin>=0.5.69"
+depends="ros-noetic-rosbuild ros-noetic-rospack"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin-dev>=0.5.69 ros-noetic-catkin>=0.5.69"
+depends_dev="ros-noetic-rosbuild ros-noetic-rosbuild-dev ros-noetic-rospack ros-noetic-rospack-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-move-base-msgs/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-move-base-msgs/APKBUILD
@@ -7,10 +7,11 @@ url="http://wiki.ros.org/move_base_msgs"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-actionlib-msgs ros-noetic-geometry-msgs ros-noetic-message-runtime ros-noetic-actionlib-msgs ros-noetic-geometry-msgs ros-noetic-message-runtime"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-actionlib-msgs ros-noetic-catkin ros-noetic-geometry-msgs ros-noetic-message-generation"
+depends="ros-noetic-actionlib-msgs ros-noetic-geometry-msgs ros-noetic-message-runtime"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-actionlib-msgs ros-noetic-actionlib-msgs-dev ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-geometry-msgs ros-noetic-geometry-msgs-dev ros-noetic-message-generation ros-noetic-message-generation-dev"
+depends_dev="ros-noetic-actionlib-msgs ros-noetic-actionlib-msgs-dev ros-noetic-geometry-msgs ros-noetic-geometry-msgs-dev ros-noetic-message-runtime ros-noetic-message-runtime-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-move-base/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-move-base/APKBUILD
@@ -7,10 +7,11 @@ url="http://wiki.ros.org/move_base"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-actionlib ros-noetic-base-local-planner ros-noetic-clear-costmap-recovery ros-noetic-costmap-2d ros-noetic-dynamic-reconfigure ros-noetic-geometry-msgs ros-noetic-message-runtime ros-noetic-move-base-msgs ros-noetic-nav-core ros-noetic-nav-msgs ros-noetic-navfn ros-noetic-pluginlib ros-noetic-roscpp ros-noetic-rospy ros-noetic-rotate-recovery ros-noetic-std-srvs ros-noetic-tf2-ros ros-noetic-visualization-msgs ros-noetic-actionlib ros-noetic-base-local-planner ros-noetic-clear-costmap-recovery ros-noetic-costmap-2d ros-noetic-dynamic-reconfigure ros-noetic-geometry-msgs ros-noetic-move-base-msgs ros-noetic-nav-core ros-noetic-nav-msgs ros-noetic-navfn ros-noetic-pluginlib ros-noetic-roscpp ros-noetic-rospy ros-noetic-rotate-recovery ros-noetic-std-srvs ros-noetic-tf2-ros ros-noetic-visualization-msgs"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-actionlib ros-noetic-base-local-planner ros-noetic-catkin ros-noetic-clear-costmap-recovery ros-noetic-cmake-modules ros-noetic-costmap-2d ros-noetic-dynamic-reconfigure ros-noetic-geometry-msgs ros-noetic-message-generation ros-noetic-move-base-msgs ros-noetic-nav-core ros-noetic-nav-msgs ros-noetic-navfn ros-noetic-pluginlib ros-noetic-roscpp ros-noetic-rospy ros-noetic-rotate-recovery ros-noetic-std-srvs ros-noetic-tf2-geometry-msgs ros-noetic-tf2-ros ros-noetic-visualization-msgs"
+depends="ros-noetic-actionlib ros-noetic-base-local-planner ros-noetic-clear-costmap-recovery ros-noetic-costmap-2d ros-noetic-dynamic-reconfigure ros-noetic-geometry-msgs ros-noetic-message-runtime ros-noetic-move-base-msgs ros-noetic-nav-core ros-noetic-nav-msgs ros-noetic-navfn ros-noetic-pluginlib ros-noetic-roscpp ros-noetic-rospy ros-noetic-rotate-recovery ros-noetic-std-srvs ros-noetic-tf2-ros ros-noetic-visualization-msgs"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-actionlib ros-noetic-actionlib-dev ros-noetic-base-local-planner ros-noetic-base-local-planner-dev ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-clear-costmap-recovery ros-noetic-clear-costmap-recovery-dev ros-noetic-cmake-modules ros-noetic-cmake-modules-dev ros-noetic-costmap-2d ros-noetic-costmap-2d-dev ros-noetic-dynamic-reconfigure ros-noetic-dynamic-reconfigure-dev ros-noetic-geometry-msgs ros-noetic-geometry-msgs-dev ros-noetic-message-generation ros-noetic-message-generation-dev ros-noetic-move-base-msgs ros-noetic-move-base-msgs-dev ros-noetic-nav-core ros-noetic-nav-core-dev ros-noetic-nav-msgs ros-noetic-nav-msgs-dev ros-noetic-navfn ros-noetic-navfn-dev ros-noetic-pluginlib ros-noetic-pluginlib-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-rospy ros-noetic-rospy-dev ros-noetic-rotate-recovery ros-noetic-rotate-recovery-dev ros-noetic-std-srvs ros-noetic-std-srvs-dev ros-noetic-tf2-geometry-msgs ros-noetic-tf2-geometry-msgs-dev ros-noetic-tf2-ros ros-noetic-tf2-ros-dev ros-noetic-visualization-msgs ros-noetic-visualization-msgs-dev"
+depends_dev="ros-noetic-actionlib ros-noetic-actionlib-dev ros-noetic-base-local-planner ros-noetic-base-local-planner-dev ros-noetic-clear-costmap-recovery ros-noetic-clear-costmap-recovery-dev ros-noetic-costmap-2d ros-noetic-costmap-2d-dev ros-noetic-dynamic-reconfigure ros-noetic-dynamic-reconfigure-dev ros-noetic-geometry-msgs ros-noetic-geometry-msgs-dev ros-noetic-message-runtime-dev ros-noetic-move-base-msgs ros-noetic-move-base-msgs-dev ros-noetic-nav-core ros-noetic-nav-core-dev ros-noetic-nav-msgs ros-noetic-nav-msgs-dev ros-noetic-navfn ros-noetic-navfn-dev ros-noetic-pluginlib ros-noetic-pluginlib-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-rospy ros-noetic-rospy-dev ros-noetic-rotate-recovery ros-noetic-rotate-recovery-dev ros-noetic-std-srvs ros-noetic-std-srvs-dev ros-noetic-tf2-ros ros-noetic-tf2-ros-dev ros-noetic-visualization-msgs ros-noetic-visualization-msgs-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-move-slow-and-clear/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-move-slow-and-clear/APKBUILD
@@ -7,10 +7,11 @@ url="http://wiki.ros.org/move_slow_and_clear"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-costmap-2d ros-noetic-geometry-msgs ros-noetic-nav-core ros-noetic-pluginlib ros-noetic-roscpp ros-noetic-costmap-2d ros-noetic-geometry-msgs ros-noetic-nav-core ros-noetic-pluginlib ros-noetic-roscpp"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin ros-noetic-cmake-modules ros-noetic-costmap-2d ros-noetic-geometry-msgs ros-noetic-nav-core ros-noetic-pluginlib ros-noetic-roscpp"
+depends="ros-noetic-costmap-2d ros-noetic-geometry-msgs ros-noetic-nav-core ros-noetic-pluginlib ros-noetic-roscpp"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-cmake-modules ros-noetic-cmake-modules-dev ros-noetic-costmap-2d ros-noetic-costmap-2d-dev ros-noetic-geometry-msgs ros-noetic-geometry-msgs-dev ros-noetic-nav-core ros-noetic-nav-core-dev ros-noetic-pluginlib ros-noetic-pluginlib-dev ros-noetic-roscpp ros-noetic-roscpp-dev"
+depends_dev="ros-noetic-costmap-2d ros-noetic-costmap-2d-dev ros-noetic-geometry-msgs ros-noetic-geometry-msgs-dev ros-noetic-nav-core ros-noetic-nav-core-dev ros-noetic-pluginlib ros-noetic-pluginlib-dev ros-noetic-roscpp ros-noetic-roscpp-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-nav-core/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-nav-core/APKBUILD
@@ -7,10 +7,11 @@ url="http://wiki.ros.org/nav_core"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-costmap-2d ros-noetic-geometry-msgs ros-noetic-std-msgs ros-noetic-tf2-ros ros-noetic-costmap-2d ros-noetic-geometry-msgs ros-noetic-std-msgs ros-noetic-tf2-ros"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin ros-noetic-costmap-2d ros-noetic-geometry-msgs ros-noetic-std-msgs ros-noetic-tf2-ros"
+depends="ros-noetic-costmap-2d ros-noetic-geometry-msgs ros-noetic-std-msgs ros-noetic-tf2-ros"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-costmap-2d ros-noetic-costmap-2d-dev ros-noetic-geometry-msgs ros-noetic-geometry-msgs-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev ros-noetic-tf2-ros ros-noetic-tf2-ros-dev"
+depends_dev="ros-noetic-costmap-2d ros-noetic-costmap-2d-dev ros-noetic-geometry-msgs ros-noetic-geometry-msgs-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev ros-noetic-tf2-ros ros-noetic-tf2-ros-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-nav-msgs/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-nav-msgs/APKBUILD
@@ -7,10 +7,11 @@ url="http://wiki.ros.org/nav_msgs"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-actionlib-msgs ros-noetic-geometry-msgs ros-noetic-message-runtime ros-noetic-std-msgs ros-noetic-actionlib-msgs ros-noetic-geometry-msgs ros-noetic-message-runtime ros-noetic-std-msgs"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-actionlib-msgs ros-noetic-catkin ros-noetic-geometry-msgs ros-noetic-message-generation ros-noetic-std-msgs"
+depends="ros-noetic-actionlib-msgs ros-noetic-geometry-msgs ros-noetic-message-runtime ros-noetic-std-msgs"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-actionlib-msgs ros-noetic-actionlib-msgs-dev ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-geometry-msgs ros-noetic-geometry-msgs-dev ros-noetic-message-generation ros-noetic-message-generation-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev"
+depends_dev="ros-noetic-actionlib-msgs ros-noetic-actionlib-msgs-dev ros-noetic-geometry-msgs ros-noetic-geometry-msgs-dev ros-noetic-message-runtime ros-noetic-message-runtime-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-navfn/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-navfn/APKBUILD
@@ -7,10 +7,11 @@ url="http://wiki.ros.org/navfn"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-costmap-2d ros-noetic-geometry-msgs ros-noetic-message-runtime ros-noetic-nav-core ros-noetic-nav-msgs ros-noetic-pluginlib ros-noetic-rosconsole ros-noetic-roscpp ros-noetic-sensor-msgs ros-noetic-tf2-ros ros-noetic-visualization-msgs ros-noetic-costmap-2d ros-noetic-geometry-msgs ros-noetic-nav-core ros-noetic-nav-msgs ros-noetic-pluginlib ros-noetic-rosconsole ros-noetic-roscpp ros-noetic-sensor-msgs ros-noetic-tf2-ros ros-noetic-visualization-msgs"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath libnetpbm-dev ros-noetic-catkin>=0.5.68 ros-noetic-cmake-modules ros-noetic-costmap-2d ros-noetic-geometry-msgs ros-noetic-message-generation ros-noetic-nav-core ros-noetic-nav-msgs ros-noetic-pluginlib ros-noetic-rosconsole ros-noetic-roscpp ros-noetic-rosunit ros-noetic-sensor-msgs ros-noetic-tf2-ros ros-noetic-visualization-msgs"
+depends="ros-noetic-costmap-2d ros-noetic-geometry-msgs ros-noetic-message-runtime ros-noetic-nav-core ros-noetic-nav-msgs ros-noetic-pluginlib ros-noetic-rosconsole ros-noetic-roscpp ros-noetic-sensor-msgs ros-noetic-tf2-ros ros-noetic-visualization-msgs"
+makedepends="chrpath libnetpbm-dev py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin-dev>=0.5.68 ros-noetic-catkin>=0.5.68 ros-noetic-cmake-modules ros-noetic-cmake-modules-dev ros-noetic-costmap-2d ros-noetic-costmap-2d-dev ros-noetic-geometry-msgs ros-noetic-geometry-msgs-dev ros-noetic-message-generation ros-noetic-message-generation-dev ros-noetic-nav-core ros-noetic-nav-core-dev ros-noetic-nav-msgs ros-noetic-nav-msgs-dev ros-noetic-pluginlib ros-noetic-pluginlib-dev ros-noetic-rosconsole ros-noetic-rosconsole-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-rosunit ros-noetic-rosunit-dev ros-noetic-sensor-msgs ros-noetic-sensor-msgs-dev ros-noetic-tf2-ros ros-noetic-tf2-ros-dev ros-noetic-visualization-msgs ros-noetic-visualization-msgs-dev"
+depends_dev="ros-noetic-costmap-2d ros-noetic-costmap-2d-dev ros-noetic-geometry-msgs ros-noetic-geometry-msgs-dev ros-noetic-message-runtime-dev ros-noetic-nav-core ros-noetic-nav-core-dev ros-noetic-nav-msgs ros-noetic-nav-msgs-dev ros-noetic-pluginlib ros-noetic-pluginlib-dev ros-noetic-rosconsole ros-noetic-rosconsole-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-sensor-msgs ros-noetic-sensor-msgs-dev ros-noetic-tf2-ros ros-noetic-tf2-ros-dev ros-noetic-visualization-msgs ros-noetic-visualization-msgs-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-navigation/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-navigation/APKBUILD
@@ -8,9 +8,10 @@ arch="all"
 license="BSD,LGPL,LGPL (amcl)"
 
 depends="ros-noetic-amcl ros-noetic-base-local-planner ros-noetic-carrot-planner ros-noetic-clear-costmap-recovery ros-noetic-costmap-2d ros-noetic-dwa-local-planner ros-noetic-fake-localization ros-noetic-global-planner ros-noetic-map-server ros-noetic-move-base ros-noetic-move-base-msgs ros-noetic-move-slow-and-clear ros-noetic-nav-core ros-noetic-navfn ros-noetic-rotate-recovery ros-noetic-voxel-grid"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev"
+depends_dev="ros-noetic-amcl-dev ros-noetic-base-local-planner-dev ros-noetic-carrot-planner-dev ros-noetic-clear-costmap-recovery-dev ros-noetic-costmap-2d-dev ros-noetic-dwa-local-planner-dev ros-noetic-fake-localization-dev ros-noetic-global-planner-dev ros-noetic-map-server-dev ros-noetic-move-base-dev ros-noetic-move-base-msgs-dev ros-noetic-move-slow-and-clear-dev ros-noetic-nav-core-dev ros-noetic-navfn-dev ros-noetic-rotate-recovery-dev ros-noetic-voxel-grid-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-neonavigation-common/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-neonavigation-common/APKBUILD
@@ -7,10 +7,11 @@ url="http://wiki.ros.org/$_pkgname"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-roscpp ros-noetic-roscpp"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin ros-noetic-roscpp ros-noetic-roslint ros-noetic-rostest ros-noetic-std-msgs ros-noetic-std-srvs"
+depends="ros-noetic-roscpp"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-roslint ros-noetic-roslint-dev ros-noetic-rostest ros-noetic-rostest-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev ros-noetic-std-srvs ros-noetic-std-srvs-dev"
+depends_dev="ros-noetic-roscpp ros-noetic-roscpp-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-neonavigation-launch/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-neonavigation-launch/APKBUILD
@@ -8,9 +8,10 @@ arch="all"
 license="BSD"
 
 depends="ros-noetic-costmap-cspace ros-noetic-map-server ros-noetic-planner-cspace ros-noetic-safety-limiter ros-noetic-tf2-ros ros-noetic-trajectory-tracker ros-noetic-trajectory-tracker-rviz-plugins"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev"
+depends_dev="ros-noetic-costmap-cspace-dev ros-noetic-map-server-dev ros-noetic-planner-cspace-dev ros-noetic-safety-limiter-dev ros-noetic-tf2-ros-dev ros-noetic-trajectory-tracker-dev ros-noetic-trajectory-tracker-rviz-plugins-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-neonavigation-metrics-msgs/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-neonavigation-metrics-msgs/APKBUILD
@@ -7,10 +7,11 @@ url="http://wiki.ros.org/$_pkgname"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-message-runtime ros-noetic-std-msgs ros-noetic-message-runtime ros-noetic-std-msgs"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin ros-noetic-message-generation ros-noetic-roslint ros-noetic-std-msgs"
+depends="ros-noetic-message-runtime ros-noetic-std-msgs"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-message-generation ros-noetic-message-generation-dev ros-noetic-roslint ros-noetic-roslint-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev"
+depends_dev="ros-noetic-message-runtime ros-noetic-message-runtime-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-neonavigation-msgs/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-neonavigation-msgs/APKBUILD
@@ -8,9 +8,10 @@ arch="all"
 license="BSD"
 
 depends="ros-noetic-costmap-cspace-msgs ros-noetic-map-organizer-msgs ros-noetic-neonavigation-metrics-msgs ros-noetic-planner-cspace-msgs ros-noetic-safety-limiter-msgs ros-noetic-trajectory-tracker-msgs"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev"
+depends_dev="ros-noetic-costmap-cspace-msgs-dev ros-noetic-map-organizer-msgs-dev ros-noetic-neonavigation-metrics-msgs-dev ros-noetic-planner-cspace-msgs-dev ros-noetic-safety-limiter-msgs-dev ros-noetic-trajectory-tracker-msgs-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-neonavigation-rviz-plugins/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-neonavigation-rviz-plugins/APKBUILD
@@ -8,9 +8,10 @@ arch="all"
 license="BSD"
 
 depends="ros-noetic-costmap-cspace-rviz-plugins ros-noetic-trajectory-tracker-rviz-plugins"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev"
+depends_dev="ros-noetic-costmap-cspace-rviz-plugins-dev ros-noetic-trajectory-tracker-rviz-plugins-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-neonavigation/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-neonavigation/APKBUILD
@@ -8,9 +8,10 @@ arch="all"
 license="BSD"
 
 depends="ros-noetic-costmap-cspace ros-noetic-joystick-interrupt ros-noetic-map-organizer ros-noetic-neonavigation-common ros-noetic-neonavigation-launch ros-noetic-obj-to-pointcloud ros-noetic-planner-cspace ros-noetic-safety-limiter ros-noetic-track-odometry ros-noetic-trajectory-tracker"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin>=0.7.22"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin-dev>=0.7.22 ros-noetic-catkin>=0.7.22"
+depends_dev="ros-noetic-costmap-cspace-dev ros-noetic-joystick-interrupt-dev ros-noetic-map-organizer-dev ros-noetic-neonavigation-common-dev ros-noetic-neonavigation-launch-dev ros-noetic-obj-to-pointcloud-dev ros-noetic-planner-cspace-dev ros-noetic-safety-limiter-dev ros-noetic-track-odometry-dev ros-noetic-trajectory-tracker-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-nodelet-core/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-nodelet-core/APKBUILD
@@ -8,9 +8,10 @@ arch="all"
 license="BSD"
 
 depends="ros-noetic-nodelet ros-noetic-nodelet-topic-tools"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev"
+depends_dev="ros-noetic-nodelet-dev ros-noetic-nodelet-topic-tools-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-nodelet-topic-tools/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-nodelet-topic-tools/APKBUILD
@@ -7,10 +7,11 @@ url="http://ros.org/wiki/nodelet_topic_tools"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-dynamic-reconfigure boost-dev ros-noetic-dynamic-reconfigure ros-noetic-message-filters ros-noetic-nodelet ros-noetic-pluginlib ros-noetic-roscpp"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath boost-dev ros-noetic-catkin ros-noetic-dynamic-reconfigure"
+depends="ros-noetic-dynamic-reconfigure"
+makedepends="boost-dev chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-dynamic-reconfigure ros-noetic-dynamic-reconfigure-dev"
+depends_dev="boost-dev ros-noetic-dynamic-reconfigure ros-noetic-dynamic-reconfigure-dev ros-noetic-message-filters ros-noetic-message-filters-dev ros-noetic-nodelet ros-noetic-nodelet-dev ros-noetic-pluginlib ros-noetic-pluginlib-dev ros-noetic-roscpp ros-noetic-roscpp-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-nodelet/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-nodelet/APKBUILD
@@ -7,10 +7,11 @@ url="http://ros.org/wiki/nodelet"
 arch="all"
 license="BSD"
 
-depends="boost-thread ros-noetic-bondcpp ros-noetic-message-runtime ros-noetic-pluginlib>=1.10.0 ros-noetic-rosconsole ros-noetic-roscpp ros-noetic-rospy ros-noetic-std-msgs util-linux-dev ros-noetic-bondcpp ros-noetic-pluginlib>=1.10.0 ros-noetic-rosconsole ros-noetic-roscpp ros-noetic-std-msgs util-linux-dev"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath boost-dev ros-noetic-bondcpp ros-noetic-catkin ros-noetic-cmake-modules>=0.3.2 ros-noetic-message-generation ros-noetic-pluginlib>=1.10.0 ros-noetic-rosconsole ros-noetic-roscpp ros-noetic-std-msgs util-linux-dev"
+depends="boost-thread ros-noetic-bondcpp ros-noetic-message-runtime ros-noetic-pluginlib>=1.10.0 ros-noetic-rosconsole ros-noetic-roscpp ros-noetic-rospy ros-noetic-std-msgs"
+makedepends="boost-dev chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-bondcpp ros-noetic-bondcpp-dev ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-cmake-modules-dev>=0.3.2 ros-noetic-cmake-modules>=0.3.2 ros-noetic-message-generation ros-noetic-message-generation-dev ros-noetic-pluginlib-dev>=1.10.0 ros-noetic-pluginlib>=1.10.0 ros-noetic-rosconsole ros-noetic-rosconsole-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev util-linux-dev"
+depends_dev="ros-noetic-bondcpp ros-noetic-bondcpp-dev ros-noetic-message-runtime-dev ros-noetic-pluginlib-dev>=1.10.0 ros-noetic-pluginlib>=1.10.0 ros-noetic-rosconsole ros-noetic-rosconsole-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-rospy-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev util-linux-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-obj-to-pointcloud/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-obj-to-pointcloud/APKBUILD
@@ -7,10 +7,11 @@ url="http://wiki.ros.org/$_pkgname"
 arch="all"
 license="BSD"
 
-depends="eigen-dev pcl ros-noetic-geometry-msgs ros-noetic-neonavigation-common ros-noetic-pcl-conversions ros-noetic-roscpp ros-noetic-sensor-msgs eigen-dev ros-noetic-geometry-msgs ros-noetic-neonavigation-common ros-noetic-pcl-conversions ros-noetic-roscpp ros-noetic-sensor-msgs"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath eigen-dev pcl-dev ros-noetic-catkin ros-noetic-geometry-msgs ros-noetic-neonavigation-common ros-noetic-pcl-conversions ros-noetic-roscpp ros-noetic-roslint ros-noetic-rostest ros-noetic-sensor-msgs"
+depends="pcl ros-noetic-geometry-msgs ros-noetic-neonavigation-common ros-noetic-pcl-conversions ros-noetic-roscpp ros-noetic-sensor-msgs"
+makedepends="chrpath eigen-dev pcl-dev py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-geometry-msgs ros-noetic-geometry-msgs-dev ros-noetic-neonavigation-common ros-noetic-neonavigation-common-dev ros-noetic-pcl-conversions ros-noetic-pcl-conversions-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-roslint ros-noetic-roslint-dev ros-noetic-rostest ros-noetic-rostest-dev ros-noetic-sensor-msgs ros-noetic-sensor-msgs-dev"
+depends_dev="eigen-dev ros-noetic-geometry-msgs ros-noetic-geometry-msgs-dev ros-noetic-neonavigation-common ros-noetic-neonavigation-common-dev ros-noetic-pcl-conversions ros-noetic-pcl-conversions-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-sensor-msgs ros-noetic-sensor-msgs-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-octomap-msgs/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-octomap-msgs/APKBUILD
@@ -7,10 +7,11 @@ url="http://ros.org/wiki/octomap_msgs"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-geometry-msgs ros-noetic-message-runtime ros-noetic-std-msgs ros-noetic-geometry-msgs ros-noetic-message-runtime ros-noetic-std-msgs"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin ros-noetic-geometry-msgs ros-noetic-message-generation ros-noetic-std-msgs"
+depends="ros-noetic-geometry-msgs ros-noetic-message-runtime ros-noetic-std-msgs"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-geometry-msgs ros-noetic-geometry-msgs-dev ros-noetic-message-generation ros-noetic-message-generation-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev"
+depends_dev="ros-noetic-geometry-msgs ros-noetic-geometry-msgs-dev ros-noetic-message-runtime ros-noetic-message-runtime-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-octomap-ros/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-octomap-ros/APKBUILD
@@ -7,10 +7,11 @@ url="http://ros.org/wiki/octomap_ros"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-octomap ros-noetic-octomap-msgs ros-noetic-sensor-msgs ros-noetic-tf ros-noetic-octomap ros-noetic-octomap-msgs ros-noetic-sensor-msgs ros-noetic-tf"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin ros-noetic-octomap ros-noetic-octomap-msgs ros-noetic-sensor-msgs ros-noetic-tf"
+depends="ros-noetic-octomap ros-noetic-octomap-msgs ros-noetic-sensor-msgs ros-noetic-tf"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-octomap ros-noetic-octomap-dev ros-noetic-octomap-msgs ros-noetic-octomap-msgs-dev ros-noetic-sensor-msgs ros-noetic-sensor-msgs-dev ros-noetic-tf ros-noetic-tf-dev"
+depends_dev="ros-noetic-octomap ros-noetic-octomap-dev ros-noetic-octomap-msgs ros-noetic-octomap-msgs-dev ros-noetic-sensor-msgs ros-noetic-sensor-msgs-dev ros-noetic-tf ros-noetic-tf-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-octomap/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-octomap/APKBUILD
@@ -8,9 +8,10 @@ arch="all"
 license="BSD"
 
 depends="ros-noetic-catkin"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath cmake"
+makedepends="chrpath cmake py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool"
+depends_dev="ros-noetic-catkin-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -231,6 +232,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-pcl-conversions/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-pcl-conversions/APKBUILD
@@ -7,10 +7,11 @@ url="http://wiki.ros.org/pcl_conversions"
 arch="all"
 license="BSD"
 
-depends="eigen-dev pcl-dev ros-noetic-pcl-msgs ros-noetic-roscpp ros-noetic-sensor-msgs ros-noetic-std-msgs"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath eigen-dev pcl-dev ros-noetic-catkin ros-noetic-pcl-msgs ros-noetic-roscpp ros-noetic-sensor-msgs ros-noetic-std-msgs"
+depends=""
+makedepends="chrpath eigen-dev pcl-dev py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-pcl-msgs ros-noetic-pcl-msgs-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-sensor-msgs ros-noetic-sensor-msgs-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev"
+depends_dev="eigen-dev pcl-dev ros-noetic-pcl-msgs ros-noetic-pcl-msgs-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-sensor-msgs ros-noetic-sensor-msgs-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-pcl-msgs/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-pcl-msgs/APKBUILD
@@ -7,10 +7,11 @@ url="http://wiki.ros.org/pcl_msgs"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-message-runtime ros-noetic-sensor-msgs ros-noetic-std-msgs ros-noetic-message-runtime ros-noetic-sensor-msgs ros-noetic-std-msgs"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin ros-noetic-message-generation ros-noetic-sensor-msgs ros-noetic-std-msgs"
+depends="ros-noetic-message-runtime ros-noetic-sensor-msgs ros-noetic-std-msgs"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-message-generation ros-noetic-message-generation-dev ros-noetic-sensor-msgs ros-noetic-sensor-msgs-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev"
+depends_dev="ros-noetic-message-runtime ros-noetic-message-runtime-dev ros-noetic-sensor-msgs ros-noetic-sensor-msgs-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-pcl-ros/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-pcl-ros/APKBUILD
@@ -7,10 +7,11 @@ url="http://ros.org/wiki/perception_pcl"
 arch="all"
 license="BSD"
 
-depends="eigen-dev pcl-dev ros-noetic-dynamic-reconfigure ros-noetic-geometry-msgs ros-noetic-message-filters ros-noetic-nodelet ros-noetic-nodelet-topic-tools ros-noetic-pcl-conversions ros-noetic-pcl-msgs ros-noetic-pluginlib ros-noetic-rosbag ros-noetic-roscpp ros-noetic-sensor-msgs ros-noetic-std-msgs ros-noetic-tf ros-noetic-tf2 ros-noetic-tf2-eigen ros-noetic-tf2-ros eigen-dev pcl-dev ros-noetic-dynamic-reconfigure ros-noetic-geometry-msgs ros-noetic-message-filters ros-noetic-nodelet ros-noetic-nodelet-topic-tools ros-noetic-pcl-conversions ros-noetic-pcl-msgs ros-noetic-pluginlib ros-noetic-rosbag ros-noetic-roscpp ros-noetic-sensor-msgs ros-noetic-std-msgs ros-noetic-tf ros-noetic-tf2 ros-noetic-tf2-eigen ros-noetic-tf2-ros"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath eigen-dev pcl-dev ros-noetic-catkin ros-noetic-dynamic-reconfigure ros-noetic-geometry-msgs ros-noetic-message-filters ros-noetic-nodelet ros-noetic-nodelet-topic-tools ros-noetic-pcl-conversions ros-noetic-pcl-msgs ros-noetic-pluginlib ros-noetic-rosbag ros-noetic-rosconsole ros-noetic-roscpp ros-noetic-roslib ros-noetic-rostest ros-noetic-sensor-msgs ros-noetic-std-msgs ros-noetic-tf ros-noetic-tf2 ros-noetic-tf2-eigen ros-noetic-tf2-ros"
+depends="ros-noetic-dynamic-reconfigure ros-noetic-geometry-msgs ros-noetic-message-filters ros-noetic-nodelet ros-noetic-nodelet-topic-tools ros-noetic-pcl-conversions ros-noetic-pcl-msgs ros-noetic-pluginlib ros-noetic-rosbag ros-noetic-roscpp ros-noetic-sensor-msgs ros-noetic-std-msgs ros-noetic-tf ros-noetic-tf2 ros-noetic-tf2-eigen ros-noetic-tf2-ros"
+makedepends="chrpath eigen-dev pcl-dev py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-dynamic-reconfigure ros-noetic-dynamic-reconfigure-dev ros-noetic-geometry-msgs ros-noetic-geometry-msgs-dev ros-noetic-message-filters ros-noetic-message-filters-dev ros-noetic-nodelet ros-noetic-nodelet-dev ros-noetic-nodelet-topic-tools ros-noetic-nodelet-topic-tools-dev ros-noetic-pcl-conversions ros-noetic-pcl-conversions-dev ros-noetic-pcl-msgs ros-noetic-pcl-msgs-dev ros-noetic-pluginlib ros-noetic-pluginlib-dev ros-noetic-rosbag ros-noetic-rosbag-dev ros-noetic-rosconsole ros-noetic-rosconsole-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-roslib ros-noetic-roslib-dev ros-noetic-rostest ros-noetic-rostest-dev ros-noetic-sensor-msgs ros-noetic-sensor-msgs-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev ros-noetic-tf ros-noetic-tf-dev ros-noetic-tf2 ros-noetic-tf2-dev ros-noetic-tf2-eigen ros-noetic-tf2-eigen-dev ros-noetic-tf2-ros ros-noetic-tf2-ros-dev"
+depends_dev="eigen-dev pcl-dev ros-noetic-dynamic-reconfigure ros-noetic-dynamic-reconfigure-dev ros-noetic-geometry-msgs ros-noetic-geometry-msgs-dev ros-noetic-message-filters ros-noetic-message-filters-dev ros-noetic-nodelet ros-noetic-nodelet-dev ros-noetic-nodelet-topic-tools ros-noetic-nodelet-topic-tools-dev ros-noetic-pcl-conversions ros-noetic-pcl-conversions-dev ros-noetic-pcl-msgs ros-noetic-pcl-msgs-dev ros-noetic-pluginlib ros-noetic-pluginlib-dev ros-noetic-rosbag ros-noetic-rosbag-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-sensor-msgs ros-noetic-sensor-msgs-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev ros-noetic-tf ros-noetic-tf-dev ros-noetic-tf2 ros-noetic-tf2-dev ros-noetic-tf2-eigen ros-noetic-tf2-eigen-dev ros-noetic-tf2-ros ros-noetic-tf2-ros-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-perception-pcl/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-perception-pcl/APKBUILD
@@ -8,9 +8,10 @@ arch="all"
 license="BSD"
 
 depends="ros-noetic-pcl-conversions ros-noetic-pcl-msgs ros-noetic-pcl-ros"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev"
+depends_dev="ros-noetic-pcl-conversions-dev ros-noetic-pcl-msgs-dev ros-noetic-pcl-ros-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-perception/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-perception/APKBUILD
@@ -8,9 +8,10 @@ arch="all"
 license="BSD"
 
 depends="ros-noetic-image-common ros-noetic-image-pipeline ros-noetic-image-transport-plugins ros-noetic-laser-pipeline ros-noetic-perception-pcl ros-noetic-ros-base ros-noetic-vision-opencv"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev"
+depends_dev="ros-noetic-image-common-dev ros-noetic-image-pipeline-dev ros-noetic-image-transport-plugins-dev ros-noetic-laser-pipeline-dev ros-noetic-perception-pcl-dev ros-noetic-ros-base-dev ros-noetic-vision-opencv-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-planner-cspace-msgs/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-planner-cspace-msgs/APKBUILD
@@ -7,10 +7,11 @@ url="http://wiki.ros.org/$_pkgname"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-actionlib-msgs ros-noetic-geometry-msgs ros-noetic-message-runtime ros-noetic-std-msgs ros-noetic-actionlib-msgs ros-noetic-geometry-msgs ros-noetic-message-runtime ros-noetic-std-msgs"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-actionlib-msgs ros-noetic-catkin ros-noetic-geometry-msgs ros-noetic-message-generation ros-noetic-std-msgs"
+depends="ros-noetic-actionlib-msgs ros-noetic-geometry-msgs ros-noetic-message-runtime ros-noetic-std-msgs"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-actionlib-msgs ros-noetic-actionlib-msgs-dev ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-geometry-msgs ros-noetic-geometry-msgs-dev ros-noetic-message-generation ros-noetic-message-generation-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev"
+depends_dev="ros-noetic-actionlib-msgs ros-noetic-actionlib-msgs-dev ros-noetic-geometry-msgs ros-noetic-geometry-msgs-dev ros-noetic-message-runtime ros-noetic-message-runtime-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-planner-cspace/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-planner-cspace/APKBUILD
@@ -7,10 +7,11 @@ url="http://wiki.ros.org/$_pkgname"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-actionlib ros-noetic-costmap-cspace ros-noetic-costmap-cspace-msgs ros-noetic-diagnostic-updater ros-noetic-dynamic-reconfigure ros-noetic-geometry-msgs ros-noetic-move-base-msgs ros-noetic-nav-msgs ros-noetic-neonavigation-common ros-noetic-neonavigation-metrics-msgs ros-noetic-planner-cspace-msgs>=0.12.0 ros-noetic-roscpp ros-noetic-sensor-msgs ros-noetic-std-srvs ros-noetic-tf2 ros-noetic-tf2-geometry-msgs ros-noetic-tf2-ros ros-noetic-trajectory-msgs ros-noetic-trajectory-tracker ros-noetic-trajectory-tracker-msgs ros-noetic-actionlib ros-noetic-costmap-cspace ros-noetic-costmap-cspace-msgs ros-noetic-diagnostic-updater ros-noetic-dynamic-reconfigure ros-noetic-geometry-msgs ros-noetic-move-base-msgs ros-noetic-nav-msgs ros-noetic-neonavigation-common ros-noetic-neonavigation-metrics-msgs ros-noetic-planner-cspace-msgs>=0.12.0 ros-noetic-roscpp ros-noetic-sensor-msgs ros-noetic-std-srvs ros-noetic-tf2 ros-noetic-tf2-geometry-msgs ros-noetic-tf2-ros ros-noetic-trajectory-msgs ros-noetic-trajectory-tracker ros-noetic-trajectory-tracker-msgs"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-actionlib ros-noetic-catkin ros-noetic-costmap-cspace ros-noetic-costmap-cspace-msgs ros-noetic-diagnostic-updater ros-noetic-dynamic-reconfigure ros-noetic-geometry-msgs ros-noetic-map-server ros-noetic-move-base-msgs ros-noetic-nav-msgs ros-noetic-neonavigation-common ros-noetic-neonavigation-metrics-msgs ros-noetic-planner-cspace-msgs>=0.12.0 ros-noetic-roscpp ros-noetic-roslint ros-noetic-rostest ros-noetic-sensor-msgs ros-noetic-std-srvs ros-noetic-tf2 ros-noetic-tf2-geometry-msgs ros-noetic-tf2-ros ros-noetic-trajectory-msgs ros-noetic-trajectory-tracker ros-noetic-trajectory-tracker-msgs"
+depends="ros-noetic-actionlib ros-noetic-costmap-cspace ros-noetic-costmap-cspace-msgs ros-noetic-diagnostic-updater ros-noetic-dynamic-reconfigure ros-noetic-geometry-msgs ros-noetic-move-base-msgs ros-noetic-nav-msgs ros-noetic-neonavigation-common ros-noetic-neonavigation-metrics-msgs ros-noetic-planner-cspace-msgs>=0.12.0 ros-noetic-roscpp ros-noetic-sensor-msgs ros-noetic-std-srvs ros-noetic-tf2 ros-noetic-tf2-geometry-msgs ros-noetic-tf2-ros ros-noetic-trajectory-msgs ros-noetic-trajectory-tracker ros-noetic-trajectory-tracker-msgs"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-actionlib ros-noetic-actionlib-dev ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-costmap-cspace ros-noetic-costmap-cspace-dev ros-noetic-costmap-cspace-msgs ros-noetic-costmap-cspace-msgs-dev ros-noetic-diagnostic-updater ros-noetic-diagnostic-updater-dev ros-noetic-dynamic-reconfigure ros-noetic-dynamic-reconfigure-dev ros-noetic-geometry-msgs ros-noetic-geometry-msgs-dev ros-noetic-map-server ros-noetic-map-server-dev ros-noetic-move-base-msgs ros-noetic-move-base-msgs-dev ros-noetic-nav-msgs ros-noetic-nav-msgs-dev ros-noetic-neonavigation-common ros-noetic-neonavigation-common-dev ros-noetic-neonavigation-metrics-msgs ros-noetic-neonavigation-metrics-msgs-dev ros-noetic-planner-cspace-msgs-dev>=0.12.0 ros-noetic-planner-cspace-msgs>=0.12.0 ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-roslint ros-noetic-roslint-dev ros-noetic-rostest ros-noetic-rostest-dev ros-noetic-sensor-msgs ros-noetic-sensor-msgs-dev ros-noetic-std-srvs ros-noetic-std-srvs-dev ros-noetic-tf2 ros-noetic-tf2-dev ros-noetic-tf2-geometry-msgs ros-noetic-tf2-geometry-msgs-dev ros-noetic-tf2-ros ros-noetic-tf2-ros-dev ros-noetic-trajectory-msgs ros-noetic-trajectory-msgs-dev ros-noetic-trajectory-tracker ros-noetic-trajectory-tracker-dev ros-noetic-trajectory-tracker-msgs ros-noetic-trajectory-tracker-msgs-dev"
+depends_dev="ros-noetic-actionlib ros-noetic-actionlib-dev ros-noetic-costmap-cspace ros-noetic-costmap-cspace-dev ros-noetic-costmap-cspace-msgs ros-noetic-costmap-cspace-msgs-dev ros-noetic-diagnostic-updater ros-noetic-diagnostic-updater-dev ros-noetic-dynamic-reconfigure ros-noetic-dynamic-reconfigure-dev ros-noetic-geometry-msgs ros-noetic-geometry-msgs-dev ros-noetic-move-base-msgs ros-noetic-move-base-msgs-dev ros-noetic-nav-msgs ros-noetic-nav-msgs-dev ros-noetic-neonavigation-common ros-noetic-neonavigation-common-dev ros-noetic-neonavigation-metrics-msgs ros-noetic-neonavigation-metrics-msgs-dev ros-noetic-planner-cspace-msgs-dev>=0.12.0 ros-noetic-planner-cspace-msgs>=0.12.0 ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-sensor-msgs ros-noetic-sensor-msgs-dev ros-noetic-std-srvs ros-noetic-std-srvs-dev ros-noetic-tf2 ros-noetic-tf2-dev ros-noetic-tf2-geometry-msgs ros-noetic-tf2-geometry-msgs-dev ros-noetic-tf2-ros ros-noetic-tf2-ros-dev ros-noetic-trajectory-msgs ros-noetic-trajectory-msgs-dev ros-noetic-trajectory-tracker ros-noetic-trajectory-tracker-dev ros-noetic-trajectory-tracker-msgs ros-noetic-trajectory-tracker-msgs-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-pluginlib/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-pluginlib/APKBUILD
@@ -7,10 +7,11 @@ url="http://www.ros.org/wiki/pluginlib"
 arch="all"
 license="BSD"
 
-depends="boost-dev ros-noetic-class-loader ros-noetic-rosconsole ros-noetic-roslib>=1.11.1 tinyxml2-dev"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath boost-dev ros-noetic-catkin>=0.5.68 ros-noetic-class-loader ros-noetic-cmake-modules ros-noetic-rosconsole ros-noetic-roslib>=1.11.1 tinyxml2-dev"
+depends=""
+makedepends="boost-dev chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin-dev>=0.5.68 ros-noetic-catkin>=0.5.68 ros-noetic-class-loader ros-noetic-class-loader-dev ros-noetic-cmake-modules ros-noetic-cmake-modules-dev ros-noetic-rosconsole ros-noetic-rosconsole-dev ros-noetic-roslib-dev>=1.11.1 ros-noetic-roslib>=1.11.1 tinyxml2-dev"
+depends_dev="boost-dev ros-noetic-class-loader ros-noetic-class-loader-dev ros-noetic-rosconsole ros-noetic-rosconsole-dev ros-noetic-roslib-dev>=1.11.1 ros-noetic-roslib>=1.11.1 tinyxml2-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-polled-camera/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-polled-camera/APKBUILD
@@ -7,10 +7,11 @@ url="http://ros.org/wiki/polled_camera"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-image-transport ros-noetic-message-runtime ros-noetic-roscpp ros-noetic-sensor-msgs ros-noetic-std-msgs ros-noetic-image-transport ros-noetic-message-runtime ros-noetic-roscpp ros-noetic-sensor-msgs ros-noetic-std-msgs"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin ros-noetic-image-transport ros-noetic-message-generation ros-noetic-roscpp ros-noetic-sensor-msgs ros-noetic-std-msgs"
+depends="ros-noetic-image-transport ros-noetic-message-runtime ros-noetic-roscpp ros-noetic-sensor-msgs ros-noetic-std-msgs"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-image-transport ros-noetic-image-transport-dev ros-noetic-message-generation ros-noetic-message-generation-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-sensor-msgs ros-noetic-sensor-msgs-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev"
+depends_dev="ros-noetic-image-transport ros-noetic-image-transport-dev ros-noetic-message-runtime ros-noetic-message-runtime-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-sensor-msgs ros-noetic-sensor-msgs-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-python-qt-binding/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-python-qt-binding/APKBUILD
@@ -7,10 +7,11 @@ url="http://ros.org/wiki/python_qt_binding"
 arch="all"
 license="BSD"
 
-depends="py3-qt5 py3-sip4 py3-sip4-dev py3-qt5 py3-sip4 py3-sip4-dev ros-noetic-catkin"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath py3-qt5 py3-sip4 py3-sip4-dev qt5-qtbase-dev ros-noetic-catkin ros-noetic-rosbuild"
+depends="py3-qt5 py3-sip4"
+makedepends="chrpath py3-qt5 py3-rosdep py3-rosinstall-generator py3-setuptools py3-sip4 py3-sip4-dev py3-vcstool qt5-qtbase-dev ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-rosbuild ros-noetic-rosbuild-dev"
+depends_dev="py3-qt5 py3-sip4 py3-sip4-dev ros-noetic-catkin ros-noetic-catkin-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-qt-dotgraph/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-qt-dotgraph/APKBUILD
@@ -8,9 +8,10 @@ arch="all"
 license="BSD"
 
 depends="py3-pydot ros-noetic-python-qt-binding>=0.3.0"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath py3-pygraphviz py3-setuptools ros-noetic-catkin"
+makedepends="chrpath py3-pygraphviz py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev"
+depends_dev="ros-noetic-python-qt-binding-dev>=0.3.0"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-qt-gui-cpp/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-qt-gui-cpp/APKBUILD
@@ -7,10 +7,11 @@ url="http://ros.org/wiki/qt_gui_cpp"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-pluginlib>=1.9.23 ros-noetic-qt-gui>=0.3.0 tinyxml-dev"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath pkgconf py3-setuptools qt5-qtbase-dev ros-noetic-catkin ros-noetic-cmake-modules ros-noetic-pluginlib>=1.9.23 ros-noetic-python-qt-binding>=0.3.0 tinyxml-dev"
+depends="ros-noetic-pluginlib>=1.9.23 ros-noetic-qt-gui>=0.3.0"
+makedepends="chrpath pkgconf py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool qt5-qtbase-dev ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-cmake-modules ros-noetic-cmake-modules-dev ros-noetic-pluginlib-dev>=1.9.23 ros-noetic-pluginlib>=1.9.23 ros-noetic-python-qt-binding-dev>=0.3.0 ros-noetic-python-qt-binding>=0.3.0 tinyxml-dev"
+depends_dev="ros-noetic-pluginlib-dev>=1.9.23 ros-noetic-qt-gui-dev>=0.3.0 tinyxml-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-qt-gui-py-common/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-qt-gui-py-common/APKBUILD
@@ -8,9 +8,10 @@ arch="all"
 license="BSD"
 
 depends="py3-rospkg ros-noetic-python-qt-binding>=0.3.0"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath py3-setuptools ros-noetic-catkin"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev"
+depends_dev="ros-noetic-python-qt-binding-dev>=0.3.0"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-qt-gui/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-qt-gui/APKBUILD
@@ -8,9 +8,10 @@ arch="all"
 license="BSD"
 
 depends="py3-rospkg ros-noetic-python-qt-binding>=0.3.0 tango-icon-theme"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath py3-qt5 py3-setuptools py3-sip4 py3-sip4-dev qt5-qtbase-dev ros-noetic-catkin"
+makedepends="chrpath py3-qt5 py3-rosdep py3-rosinstall-generator py3-setuptools py3-sip4 py3-sip4-dev py3-vcstool qt5-qtbase-dev ros-noetic-catkin ros-noetic-catkin-dev"
+depends_dev="ros-noetic-python-qt-binding-dev>=0.3.0"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-qwt-dependency/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-qwt-dependency/APKBUILD
@@ -8,9 +8,10 @@ arch="all"
 license="BSD"
 
 depends=""
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev"
+depends_dev=""
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-realtime-tools/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-realtime-tools/APKBUILD
@@ -7,10 +7,11 @@ url="http://ros.org/wiki/realtime_tools"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-roscpp ros-noetic-actionlib ros-noetic-roscpp"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-actionlib ros-noetic-catkin ros-noetic-roscpp ros-noetic-rostest ros-noetic-rosunit"
+depends="ros-noetic-roscpp"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-actionlib ros-noetic-actionlib-dev ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-rostest ros-noetic-rostest-dev ros-noetic-rosunit ros-noetic-rosunit-dev"
+depends_dev="ros-noetic-actionlib ros-noetic-actionlib-dev ros-noetic-roscpp ros-noetic-roscpp-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-resource-retriever/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-resource-retriever/APKBUILD
@@ -7,10 +7,11 @@ url="http://ros.org/wiki/resource_retriever"
 arch="all"
 license="BSD"
 
-depends="boost-dev libcurl py3-rospkg ros-noetic-rosconsole ros-noetic-roslib boost-dev ros-noetic-rosconsole ros-noetic-roslib"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath boost-dev curl-dev ros-noetic-catkin>=0.5.68 ros-noetic-rosconsole ros-noetic-roslib"
+depends="libcurl py3-rospkg ros-noetic-rosconsole ros-noetic-roslib"
+makedepends="boost-dev chrpath curl-dev py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin-dev>=0.5.68 ros-noetic-catkin>=0.5.68 ros-noetic-rosconsole ros-noetic-rosconsole-dev ros-noetic-roslib ros-noetic-roslib-dev"
+depends_dev="boost-dev ros-noetic-rosconsole ros-noetic-rosconsole-dev ros-noetic-roslib ros-noetic-roslib-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-robot-state-publisher/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-robot-state-publisher/APKBUILD
@@ -7,10 +7,11 @@ url="http://wiki.ros.org/robot_state_publisher"
 arch="all"
 license="BSD"
 
-depends="orocos-kdl ros-noetic-kdl-parser ros-noetic-rosconsole ros-noetic-roscpp ros-noetic-rostime ros-noetic-sensor-msgs ros-noetic-tf ros-noetic-tf2-kdl ros-noetic-tf2-ros orocos-kdl-dev ros-noetic-kdl-parser ros-noetic-rosconsole ros-noetic-roscpp ros-noetic-rostime ros-noetic-sensor-msgs ros-noetic-tf ros-noetic-tf2-kdl ros-noetic-tf2-ros"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath eigen-dev orocos-kdl-dev ros-noetic-catkin ros-noetic-kdl-parser ros-noetic-rosbag ros-noetic-rosconsole ros-noetic-roscpp ros-noetic-rostest ros-noetic-rostime ros-noetic-sensor-msgs ros-noetic-tf ros-noetic-tf2-kdl ros-noetic-tf2-ros urdfdom_headers"
+depends="orocos-kdl ros-noetic-kdl-parser ros-noetic-rosconsole ros-noetic-roscpp ros-noetic-rostime ros-noetic-sensor-msgs ros-noetic-tf ros-noetic-tf2-kdl ros-noetic-tf2-ros"
+makedepends="chrpath eigen-dev orocos-kdl-dev py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-kdl-parser ros-noetic-kdl-parser-dev ros-noetic-rosbag ros-noetic-rosbag-dev ros-noetic-rosconsole ros-noetic-rosconsole-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-rostest ros-noetic-rostest-dev ros-noetic-rostime ros-noetic-rostime-dev ros-noetic-sensor-msgs ros-noetic-sensor-msgs-dev ros-noetic-tf ros-noetic-tf-dev ros-noetic-tf2-kdl ros-noetic-tf2-kdl-dev ros-noetic-tf2-ros ros-noetic-tf2-ros-dev urdfdom_headers"
+depends_dev="orocos-kdl-dev ros-noetic-kdl-parser ros-noetic-kdl-parser-dev ros-noetic-rosconsole ros-noetic-rosconsole-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-rostime ros-noetic-rostime-dev ros-noetic-sensor-msgs ros-noetic-sensor-msgs-dev ros-noetic-tf ros-noetic-tf-dev ros-noetic-tf2-kdl ros-noetic-tf2-kdl-dev ros-noetic-tf2-ros ros-noetic-tf2-ros-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-robot/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-robot/APKBUILD
@@ -8,9 +8,10 @@ arch="all"
 license="BSD"
 
 depends="ros-noetic-control-msgs ros-noetic-diagnostics ros-noetic-executive-smach ros-noetic-filters ros-noetic-geometry ros-noetic-joint-state-publisher ros-noetic-kdl-parser ros-noetic-robot-state-publisher ros-noetic-ros-base ros-noetic-urdf ros-noetic-urdf-parser-plugin ros-noetic-xacro"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev"
+depends_dev="ros-noetic-control-msgs-dev ros-noetic-diagnostics-dev ros-noetic-executive-smach-dev ros-noetic-filters-dev ros-noetic-geometry-dev ros-noetic-joint-state-publisher-dev ros-noetic-kdl-parser-dev ros-noetic-robot-state-publisher-dev ros-noetic-ros-base-dev ros-noetic-urdf-dev ros-noetic-urdf-parser-plugin-dev ros-noetic-xacro-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-ros-base/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-ros-base/APKBUILD
@@ -8,9 +8,10 @@ arch="all"
 license="BSD"
 
 depends="ros-noetic-actionlib ros-noetic-bond-core ros-noetic-dynamic-reconfigure ros-noetic-nodelet-core ros-noetic-ros-core"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev"
+depends_dev="ros-noetic-actionlib-dev ros-noetic-bond-core-dev ros-noetic-dynamic-reconfigure-dev ros-noetic-nodelet-core-dev ros-noetic-ros-core-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-ros-comm/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-ros-comm/APKBUILD
@@ -7,10 +7,11 @@ url="http://wiki.ros.org/ros_comm"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-message-filters ros-noetic-ros ros-noetic-rosbag ros-noetic-rosconsole ros-noetic-roscpp ros-noetic-rosgraph ros-noetic-rosgraph-msgs ros-noetic-roslaunch ros-noetic-roslisp ros-noetic-rosmaster ros-noetic-rosmsg ros-noetic-rosnode ros-noetic-rosout ros-noetic-rosparam ros-noetic-rospy ros-noetic-rosservice ros-noetic-rostest ros-noetic-rostopic ros-noetic-roswtf ros-noetic-std-srvs ros-noetic-topic-tools ros-noetic-xmlrpcpp ros-noetic-message-filters ros-noetic-ros ros-noetic-rosbag ros-noetic-rosconsole ros-noetic-roscpp ros-noetic-rosgraph ros-noetic-rosgraph-msgs ros-noetic-roslaunch ros-noetic-roslisp ros-noetic-rosmaster ros-noetic-rosmsg ros-noetic-rosnode ros-noetic-rosout ros-noetic-rosparam ros-noetic-rospy ros-noetic-rosservice ros-noetic-rostest ros-noetic-rostopic ros-noetic-roswtf ros-noetic-std-srvs ros-noetic-topic-tools ros-noetic-xmlrpcpp"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin"
+depends="ros-noetic-message-filters ros-noetic-ros ros-noetic-rosbag ros-noetic-rosconsole ros-noetic-roscpp ros-noetic-rosgraph ros-noetic-rosgraph-msgs ros-noetic-roslaunch ros-noetic-roslisp ros-noetic-rosmaster ros-noetic-rosmsg ros-noetic-rosnode ros-noetic-rosout ros-noetic-rosparam ros-noetic-rospy ros-noetic-rosservice ros-noetic-rostest ros-noetic-rostopic ros-noetic-roswtf ros-noetic-std-srvs ros-noetic-topic-tools ros-noetic-xmlrpcpp"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev"
+depends_dev="ros-noetic-message-filters ros-noetic-message-filters-dev ros-noetic-ros ros-noetic-ros-dev ros-noetic-rosbag ros-noetic-rosbag-dev ros-noetic-rosconsole ros-noetic-rosconsole-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-rosgraph ros-noetic-rosgraph-dev ros-noetic-rosgraph-msgs ros-noetic-rosgraph-msgs-dev ros-noetic-roslaunch ros-noetic-roslaunch-dev ros-noetic-roslisp ros-noetic-roslisp-dev ros-noetic-rosmaster ros-noetic-rosmaster-dev ros-noetic-rosmsg ros-noetic-rosmsg-dev ros-noetic-rosnode ros-noetic-rosnode-dev ros-noetic-rosout ros-noetic-rosout-dev ros-noetic-rosparam ros-noetic-rosparam-dev ros-noetic-rospy ros-noetic-rospy-dev ros-noetic-rosservice ros-noetic-rosservice-dev ros-noetic-rostest ros-noetic-rostest-dev ros-noetic-rostopic ros-noetic-rostopic-dev ros-noetic-roswtf ros-noetic-roswtf-dev ros-noetic-std-srvs ros-noetic-std-srvs-dev ros-noetic-topic-tools ros-noetic-topic-tools-dev ros-noetic-xmlrpcpp ros-noetic-xmlrpcpp-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-ros-control/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-ros-control/APKBUILD
@@ -8,9 +8,10 @@ arch="all"
 license="BSD"
 
 depends="ros-noetic-combined-robot-hw ros-noetic-controller-interface ros-noetic-controller-manager ros-noetic-controller-manager-msgs ros-noetic-hardware-interface ros-noetic-joint-limits-interface ros-noetic-realtime-tools ros-noetic-transmission-interface"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev"
+depends_dev="ros-noetic-combined-robot-hw-dev ros-noetic-controller-interface-dev ros-noetic-controller-manager-dev ros-noetic-controller-manager-msgs-dev ros-noetic-hardware-interface-dev ros-noetic-joint-limits-interface-dev ros-noetic-realtime-tools-dev ros-noetic-transmission-interface-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-ros-core/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-ros-core/APKBUILD
@@ -8,9 +8,10 @@ arch="all"
 license="BSD"
 
 depends="ros-noetic-catkin ros-noetic-class-loader ros-noetic-cmake-modules ros-noetic-common-msgs ros-noetic-gencpp ros-noetic-geneus ros-noetic-genlisp ros-noetic-genmsg ros-noetic-gennodejs ros-noetic-genpy ros-noetic-message-generation ros-noetic-message-runtime ros-noetic-pluginlib ros-noetic-ros ros-noetic-ros-comm ros-noetic-rosbag-migration-rule ros-noetic-rosconsole ros-noetic-rosconsole-bridge ros-noetic-roscpp-core ros-noetic-rosgraph-msgs ros-noetic-roslisp ros-noetic-rospack ros-noetic-std-msgs ros-noetic-std-srvs"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev"
+depends_dev="ros-noetic-catkin-dev ros-noetic-class-loader-dev ros-noetic-cmake-modules-dev ros-noetic-common-msgs-dev ros-noetic-gencpp-dev ros-noetic-geneus-dev ros-noetic-genlisp-dev ros-noetic-genmsg-dev ros-noetic-gennodejs-dev ros-noetic-genpy-dev ros-noetic-message-generation-dev ros-noetic-message-runtime-dev ros-noetic-pluginlib-dev ros-noetic-ros-comm-dev ros-noetic-ros-dev ros-noetic-rosbag-migration-rule-dev ros-noetic-rosconsole-bridge-dev ros-noetic-rosconsole-dev ros-noetic-roscpp-core-dev ros-noetic-rosgraph-msgs-dev ros-noetic-roslisp-dev ros-noetic-rospack-dev ros-noetic-std-msgs-dev ros-noetic-std-srvs-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-ros-environment/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-ros-environment/APKBUILD
@@ -8,9 +8,10 @@ arch="all"
 license="Apache License 2.0"
 
 depends=""
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev"
+depends_dev=""
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-ros-tutorials/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-ros-tutorials/APKBUILD
@@ -7,10 +7,11 @@ url="http://www.ros.org/wiki/ros_tutorials"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-roscpp-tutorials ros-noetic-rospy-tutorials ros-noetic-turtlesim ros-noetic-roscpp-tutorials ros-noetic-rospy-tutorials ros-noetic-turtlesim"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin"
+depends="ros-noetic-roscpp-tutorials ros-noetic-rospy-tutorials ros-noetic-turtlesim"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev"
+depends_dev="ros-noetic-roscpp-tutorials ros-noetic-roscpp-tutorials-dev ros-noetic-rospy-tutorials ros-noetic-rospy-tutorials-dev ros-noetic-turtlesim ros-noetic-turtlesim-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-ros/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-ros/APKBUILD
@@ -7,10 +7,11 @@ url="http://www.ros.org/wiki/ROS"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-catkin ros-noetic-mk ros-noetic-rosbash ros-noetic-rosboost-cfg ros-noetic-rosbuild ros-noetic-rosclean ros-noetic-roscreate ros-noetic-roslang ros-noetic-roslib ros-noetic-rosmake ros-noetic-rosunit ros-noetic-catkin ros-noetic-mk ros-noetic-rosbash ros-noetic-rosboost-cfg ros-noetic-rosbuild ros-noetic-rosclean ros-noetic-roscreate ros-noetic-roslang ros-noetic-roslib ros-noetic-rosmake ros-noetic-rosunit"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin"
+depends="ros-noetic-catkin ros-noetic-mk ros-noetic-rosbash ros-noetic-rosboost-cfg ros-noetic-rosbuild ros-noetic-rosclean ros-noetic-roscreate ros-noetic-roslang ros-noetic-roslib ros-noetic-rosmake ros-noetic-rosunit"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev"
+depends_dev="ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-mk ros-noetic-mk-dev ros-noetic-rosbash ros-noetic-rosbash-dev ros-noetic-rosboost-cfg ros-noetic-rosboost-cfg-dev ros-noetic-rosbuild ros-noetic-rosbuild-dev ros-noetic-rosclean ros-noetic-rosclean-dev ros-noetic-roscreate ros-noetic-roscreate-dev ros-noetic-roslang ros-noetic-roslang-dev ros-noetic-roslib ros-noetic-roslib-dev ros-noetic-rosmake ros-noetic-rosmake-dev ros-noetic-rosunit ros-noetic-rosunit-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-rosapi/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-rosapi/APKBUILD
@@ -8,9 +8,10 @@ arch="all"
 license="BSD"
 
 depends="ros-noetic-message-runtime ros-noetic-rosbridge-library ros-noetic-rosgraph ros-noetic-rosnode ros-noetic-rospy"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath py3-setuptools ros-noetic-catkin ros-noetic-message-generation"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-message-generation ros-noetic-message-generation-dev"
+depends_dev="ros-noetic-message-runtime-dev ros-noetic-rosbridge-library-dev ros-noetic-rosgraph-dev ros-noetic-rosnode-dev ros-noetic-rospy-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-rosauth/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-rosauth/APKBUILD
@@ -8,9 +8,10 @@ arch="all"
 license="BSD"
 
 depends="ros-noetic-message-runtime ros-noetic-roscpp"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath openssl-dev ros-noetic-catkin ros-noetic-message-generation ros-noetic-roscpp ros-noetic-rostest"
+makedepends="chrpath openssl-dev py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-message-generation ros-noetic-message-generation-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-rostest ros-noetic-rostest-dev"
+depends_dev="ros-noetic-message-runtime-dev ros-noetic-roscpp-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-rosbag-migration-rule/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-rosbag-migration-rule/APKBUILD
@@ -8,9 +8,10 @@ arch="all"
 license="BSD"
 
 depends=""
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev"
+depends_dev=""
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-rosbag-snapshot-msgs/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-rosbag-snapshot-msgs/APKBUILD
@@ -7,10 +7,11 @@ url="http://wiki.ros.org/$_pkgname"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-message-runtime ros-noetic-rosgraph-msgs ros-noetic-message-runtime ros-noetic-rosgraph-msgs"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin ros-noetic-message-generation ros-noetic-rosgraph-msgs"
+depends="ros-noetic-message-runtime ros-noetic-rosgraph-msgs"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-message-generation ros-noetic-message-generation-dev ros-noetic-rosgraph-msgs ros-noetic-rosgraph-msgs-dev"
+depends_dev="ros-noetic-message-runtime ros-noetic-message-runtime-dev ros-noetic-rosgraph-msgs ros-noetic-rosgraph-msgs-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-rosbag-snapshot/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-rosbag-snapshot/APKBUILD
@@ -7,10 +7,11 @@ url="http://wiki.ros.org/$_pkgname"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-rosbag ros-noetic-rosbag-snapshot-msgs ros-noetic-roscpp ros-noetic-rosgraph-msgs ros-noetic-std-srvs ros-noetic-topic-tools ros-noetic-rosbag ros-noetic-rosbag-snapshot-msgs ros-noetic-roscpp ros-noetic-rosgraph-msgs ros-noetic-std-srvs ros-noetic-topic-tools"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin ros-noetic-rosbag ros-noetic-rosbag-snapshot-msgs ros-noetic-roscpp ros-noetic-rosgraph-msgs ros-noetic-roslint ros-noetic-rospy ros-noetic-rostest ros-noetic-rostopic ros-noetic-std-msgs ros-noetic-std-srvs ros-noetic-topic-tools"
+depends="ros-noetic-rosbag ros-noetic-rosbag-snapshot-msgs ros-noetic-roscpp ros-noetic-rosgraph-msgs ros-noetic-std-srvs ros-noetic-topic-tools"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-rosbag ros-noetic-rosbag-dev ros-noetic-rosbag-snapshot-msgs ros-noetic-rosbag-snapshot-msgs-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-rosgraph-msgs ros-noetic-rosgraph-msgs-dev ros-noetic-roslint ros-noetic-roslint-dev ros-noetic-rospy ros-noetic-rospy-dev ros-noetic-rostest ros-noetic-rostest-dev ros-noetic-rostopic ros-noetic-rostopic-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev ros-noetic-std-srvs ros-noetic-std-srvs-dev ros-noetic-topic-tools ros-noetic-topic-tools-dev"
+depends_dev="ros-noetic-rosbag ros-noetic-rosbag-dev ros-noetic-rosbag-snapshot-msgs ros-noetic-rosbag-snapshot-msgs-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-rosgraph-msgs ros-noetic-rosgraph-msgs-dev ros-noetic-std-srvs ros-noetic-std-srvs-dev ros-noetic-topic-tools ros-noetic-topic-tools-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-rosbag-storage/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-rosbag-storage/APKBUILD
@@ -7,10 +7,11 @@ url="http://wiki.ros.org/$_pkgname"
 arch="all"
 license="BSD"
 
-depends="boost-dev bzip2-dev console_bridge-dev gpgme-dev openssl-dev ros-noetic-cpp-common>=0.3.17 ros-noetic-pluginlib ros-noetic-roscpp-serialization ros-noetic-roscpp-traits>=0.3.17 ros-noetic-roslz4 ros-noetic-rostime boost-dev bzip2-dev console_bridge-dev gpgme-dev openssl-dev ros-noetic-cpp-common>=0.3.17 ros-noetic-pluginlib ros-noetic-roscpp-serialization ros-noetic-roscpp-traits>=0.3.17 ros-noetic-roslz4 ros-noetic-rostime"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath boost-dev bzip2-dev console_bridge-dev gpgme-dev openssl-dev ros-noetic-catkin ros-noetic-cpp-common>=0.3.17 ros-noetic-pluginlib ros-noetic-roscpp-serialization ros-noetic-roscpp-traits>=0.3.17 ros-noetic-roslz4 ros-noetic-rostest ros-noetic-rostime ros-noetic-std-msgs"
+depends="ros-noetic-cpp-common>=0.3.17 ros-noetic-pluginlib ros-noetic-roscpp-serialization ros-noetic-roscpp-traits>=0.3.17 ros-noetic-roslz4 ros-noetic-rostime"
+makedepends="boost-dev bzip2-dev chrpath console_bridge-dev gpgme-dev openssl-dev py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-cpp-common-dev>=0.3.17 ros-noetic-cpp-common>=0.3.17 ros-noetic-pluginlib ros-noetic-pluginlib-dev ros-noetic-roscpp-serialization ros-noetic-roscpp-serialization-dev ros-noetic-roscpp-traits-dev>=0.3.17 ros-noetic-roscpp-traits>=0.3.17 ros-noetic-roslz4 ros-noetic-roslz4-dev ros-noetic-rostest ros-noetic-rostest-dev ros-noetic-rostime ros-noetic-rostime-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev"
+depends_dev="boost-dev bzip2-dev console_bridge-dev gpgme-dev openssl-dev ros-noetic-cpp-common-dev>=0.3.17 ros-noetic-cpp-common>=0.3.17 ros-noetic-pluginlib ros-noetic-pluginlib-dev ros-noetic-roscpp-serialization ros-noetic-roscpp-serialization-dev ros-noetic-roscpp-traits-dev>=0.3.17 ros-noetic-roscpp-traits>=0.3.17 ros-noetic-roslz4 ros-noetic-roslz4-dev ros-noetic-rostime ros-noetic-rostime-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-rosbag/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-rosbag/APKBUILD
@@ -7,10 +7,11 @@ url="http://wiki.ros.org/rosbag"
 arch="all"
 license="BSD"
 
-depends="boost-dev py3-gnupg py3-pycryptodomex py3-rospkg ros-noetic-genmsg ros-noetic-genpy ros-noetic-rosbag-storage ros-noetic-rosconsole ros-noetic-roscpp ros-noetic-roslib ros-noetic-rospy ros-noetic-std-srvs ros-noetic-topic-tools ros-noetic-xmlrpcpp boost-dev ros-noetic-rosbag-storage ros-noetic-rosconsole ros-noetic-roscpp ros-noetic-std-srvs ros-noetic-xmlrpcpp"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath boost-dev py3-pillow ros-noetic-catkin>=0.5.78 ros-noetic-cpp-common ros-noetic-rosbag-storage ros-noetic-rosconsole ros-noetic-roscpp ros-noetic-roscpp-serialization ros-noetic-std-srvs ros-noetic-topic-tools ros-noetic-xmlrpcpp"
+depends="py3-gnupg py3-pycryptodomex py3-rospkg ros-noetic-genmsg ros-noetic-genpy ros-noetic-rosbag-storage ros-noetic-rosconsole ros-noetic-roscpp ros-noetic-roslib ros-noetic-rospy ros-noetic-std-srvs ros-noetic-topic-tools ros-noetic-xmlrpcpp"
+makedepends="boost-dev chrpath py3-pillow py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin-dev>=0.5.78 ros-noetic-catkin>=0.5.78 ros-noetic-cpp-common ros-noetic-cpp-common-dev ros-noetic-rosbag-storage ros-noetic-rosbag-storage-dev ros-noetic-rosconsole ros-noetic-rosconsole-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-roscpp-serialization ros-noetic-roscpp-serialization-dev ros-noetic-std-srvs ros-noetic-std-srvs-dev ros-noetic-topic-tools ros-noetic-topic-tools-dev ros-noetic-xmlrpcpp ros-noetic-xmlrpcpp-dev"
+depends_dev="boost-dev ros-noetic-genmsg-dev ros-noetic-genpy-dev ros-noetic-rosbag-storage ros-noetic-rosbag-storage-dev ros-noetic-rosconsole ros-noetic-rosconsole-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-roslib-dev ros-noetic-rospy-dev ros-noetic-std-srvs ros-noetic-std-srvs-dev ros-noetic-topic-tools-dev ros-noetic-xmlrpcpp ros-noetic-xmlrpcpp-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-rosbash/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-rosbash/APKBUILD
@@ -7,10 +7,11 @@ url="http://www.ros.org/wiki/rosbash"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-catkin ros-noetic-rospack ros-noetic-catkin ros-noetic-rospack"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin>=0.7.15"
+depends="ros-noetic-catkin ros-noetic-rospack"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin-dev>=0.7.15 ros-noetic-catkin>=0.7.15"
+depends_dev="ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-rospack ros-noetic-rospack-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-rosboost-cfg/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-rosboost-cfg/APKBUILD
@@ -8,9 +8,10 @@ arch="all"
 license="BSD"
 
 depends=""
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath py3-setuptools ros-noetic-catkin"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev"
+depends_dev=""
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-rosbridge-library/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-rosbridge-library/APKBUILD
@@ -8,9 +8,10 @@ arch="all"
 license="BSD"
 
 depends="py3-mongo py3-pillow ros-noetic-geometry-msgs ros-noetic-message-runtime ros-noetic-roscpp ros-noetic-rosgraph ros-noetic-rospy ros-noetic-rosservice ros-noetic-rostopic ros-noetic-std-msgs"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath py3-mongo py3-pillow py3-setuptools ros-noetic-actionlib-msgs ros-noetic-catkin ros-noetic-diagnostic-msgs ros-noetic-geometry-msgs ros-noetic-message-generation ros-noetic-nav-msgs ros-noetic-rospy-tutorials ros-noetic-rostest ros-noetic-rosunit ros-noetic-sensor-msgs ros-noetic-std-msgs ros-noetic-std-srvs ros-noetic-stereo-msgs ros-noetic-tf2-msgs ros-noetic-trajectory-msgs ros-noetic-visualization-msgs"
+makedepends="chrpath py3-mongo py3-pillow py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-actionlib-msgs ros-noetic-actionlib-msgs-dev ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-diagnostic-msgs ros-noetic-diagnostic-msgs-dev ros-noetic-geometry-msgs ros-noetic-geometry-msgs-dev ros-noetic-message-generation ros-noetic-message-generation-dev ros-noetic-nav-msgs ros-noetic-nav-msgs-dev ros-noetic-rospy-tutorials ros-noetic-rospy-tutorials-dev ros-noetic-rostest ros-noetic-rostest-dev ros-noetic-rosunit ros-noetic-rosunit-dev ros-noetic-sensor-msgs ros-noetic-sensor-msgs-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev ros-noetic-std-srvs ros-noetic-std-srvs-dev ros-noetic-stereo-msgs ros-noetic-stereo-msgs-dev ros-noetic-tf2-msgs ros-noetic-tf2-msgs-dev ros-noetic-trajectory-msgs ros-noetic-trajectory-msgs-dev ros-noetic-visualization-msgs ros-noetic-visualization-msgs-dev"
+depends_dev="ros-noetic-geometry-msgs-dev ros-noetic-message-runtime-dev ros-noetic-roscpp-dev ros-noetic-rosgraph-dev ros-noetic-rospy-dev ros-noetic-rosservice-dev ros-noetic-rostopic-dev ros-noetic-std-msgs-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-rosbridge-msgs/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-rosbridge-msgs/APKBUILD
@@ -7,10 +7,11 @@ url="http://wiki.ros.org/$_pkgname"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-message-runtime ros-noetic-std-msgs ros-noetic-message-runtime ros-noetic-std-msgs"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin ros-noetic-message-generation ros-noetic-std-msgs"
+depends="ros-noetic-message-runtime ros-noetic-std-msgs"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-message-generation ros-noetic-message-generation-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev"
+depends_dev="ros-noetic-message-runtime ros-noetic-message-runtime-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-rosbridge-server/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-rosbridge-server/APKBUILD
@@ -8,9 +8,10 @@ arch="all"
 license="BSD"
 
 depends="py3-autobahn py3-openssl py3-pynacl py3-service_identity py3-tornado py3-twisted py3-zope-interface ros-noetic-rosapi ros-noetic-rosauth ros-noetic-rosbridge-library ros-noetic-rosbridge-msgs ros-noetic-rospy"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath py3-setuptools ros-noetic-catkin ros-noetic-rostest"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-rostest ros-noetic-rostest-dev"
+depends_dev="ros-noetic-rosapi-dev ros-noetic-rosauth-dev ros-noetic-rosbridge-library-dev ros-noetic-rosbridge-msgs-dev ros-noetic-rospy-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-rosbridge-suite/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-rosbridge-suite/APKBUILD
@@ -8,9 +8,10 @@ arch="all"
 license="BSD"
 
 depends="ros-noetic-rosapi ros-noetic-rosbridge-library ros-noetic-rosbridge-server"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev"
+depends_dev="ros-noetic-rosapi-dev ros-noetic-rosbridge-library-dev ros-noetic-rosbridge-server-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-rosbuild/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-rosbuild/APKBUILD
@@ -7,10 +7,11 @@ url="http://ros.org/wiki/rosbuild"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-catkin ros-noetic-message-generation ros-noetic-message-runtime ros-noetic-catkin ros-noetic-message-generation ros-noetic-message-runtime"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath pkgconf ros-noetic-catkin>=0.5.78"
+depends="ros-noetic-catkin ros-noetic-message-generation ros-noetic-message-runtime"
+makedepends="chrpath pkgconf py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin-dev>=0.5.78 ros-noetic-catkin>=0.5.78"
+depends_dev="ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-message-generation ros-noetic-message-generation-dev ros-noetic-message-runtime ros-noetic-message-runtime-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-rosclean/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-rosclean/APKBUILD
@@ -8,9 +8,10 @@ arch="all"
 license="BSD"
 
 depends="py3-rospkg"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath py3-setuptools ros-noetic-catkin>=0.5.68"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin-dev>=0.5.68 ros-noetic-catkin>=0.5.68"
+depends_dev=""
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-rosconsole-bridge/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-rosconsole-bridge/APKBUILD
@@ -7,10 +7,11 @@ url="http://www.ros.org/wiki/rosconsole_bridge"
 arch="all"
 license="BSD"
 
-depends="console_bridge-dev ros-noetic-cpp-common ros-noetic-rosconsole console_bridge-dev ros-noetic-cpp-common ros-noetic-rosconsole"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath console_bridge-dev ros-noetic-catkin ros-noetic-cpp-common ros-noetic-rosconsole>=1.11.5"
+depends="ros-noetic-cpp-common ros-noetic-rosconsole"
+makedepends="chrpath console_bridge-dev py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-cpp-common ros-noetic-cpp-common-dev ros-noetic-rosconsole-dev>=1.11.5 ros-noetic-rosconsole>=1.11.5"
+depends_dev="console_bridge-dev ros-noetic-cpp-common ros-noetic-cpp-common-dev ros-noetic-rosconsole ros-noetic-rosconsole-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-rosconsole/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-rosconsole/APKBUILD
@@ -7,10 +7,11 @@ url="http://www.ros.org/wiki/rosconsole"
 arch="all"
 license="BSD"
 
-depends="apr apr-util boost-dev log4cxx-dev ros-noetic-cpp-common ros-noetic-rosbuild ros-noetic-rostime apr apr-util boost-dev log4cxx-dev ros-noetic-cpp-common ros-noetic-rosbuild ros-noetic-rostime"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath apr apr-util boost-dev log4cxx-dev ros-noetic-catkin ros-noetic-cpp-common ros-noetic-rostime ros-noetic-rosunit"
+depends="apr apr-util ros-noetic-cpp-common ros-noetic-rosbuild ros-noetic-rostime"
+makedepends="apr apr-util boost-dev chrpath log4cxx-dev py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-cpp-common ros-noetic-cpp-common-dev ros-noetic-rostime ros-noetic-rostime-dev ros-noetic-rosunit ros-noetic-rosunit-dev"
+depends_dev="apr apr-util boost-dev log4cxx-dev ros-noetic-cpp-common ros-noetic-cpp-common-dev ros-noetic-rosbuild ros-noetic-rosbuild-dev ros-noetic-rostime ros-noetic-rostime-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-roscpp-core/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-roscpp-core/APKBUILD
@@ -7,10 +7,11 @@ url="http://www.ros.org/wiki/roscpp_core"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-cpp-common ros-noetic-roscpp-serialization ros-noetic-roscpp-traits ros-noetic-rostime ros-noetic-cpp-common ros-noetic-roscpp-serialization ros-noetic-roscpp-traits ros-noetic-rostime"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin"
+depends="ros-noetic-cpp-common ros-noetic-roscpp-serialization ros-noetic-roscpp-traits ros-noetic-rostime"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev"
+depends_dev="ros-noetic-cpp-common ros-noetic-cpp-common-dev ros-noetic-roscpp-serialization ros-noetic-roscpp-serialization-dev ros-noetic-roscpp-traits ros-noetic-roscpp-traits-dev ros-noetic-rostime ros-noetic-rostime-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-roscpp-serialization/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-roscpp-serialization/APKBUILD
@@ -7,10 +7,11 @@ url="http://ros.org/wiki/roscpp_serialization"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-cpp-common ros-noetic-roscpp-traits ros-noetic-rostime ros-noetic-cpp-common ros-noetic-roscpp-traits ros-noetic-rostime"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin ros-noetic-cpp-common ros-noetic-roscpp-traits ros-noetic-rostime"
+depends="ros-noetic-cpp-common ros-noetic-roscpp-traits ros-noetic-rostime"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-cpp-common ros-noetic-cpp-common-dev ros-noetic-roscpp-traits ros-noetic-roscpp-traits-dev ros-noetic-rostime ros-noetic-rostime-dev"
+depends_dev="ros-noetic-cpp-common ros-noetic-cpp-common-dev ros-noetic-roscpp-traits ros-noetic-roscpp-traits-dev ros-noetic-rostime ros-noetic-rostime-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-roscpp-traits/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-roscpp-traits/APKBUILD
@@ -7,10 +7,11 @@ url="http://ros.org/wiki/roscpp_traits"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-cpp-common ros-noetic-rostime ros-noetic-cpp-common ros-noetic-rostime"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin"
+depends="ros-noetic-cpp-common ros-noetic-rostime"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev"
+depends_dev="ros-noetic-cpp-common ros-noetic-cpp-common-dev ros-noetic-rostime ros-noetic-rostime-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-roscpp-tutorials/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-roscpp-tutorials/APKBUILD
@@ -7,10 +7,11 @@ url="http://www.ros.org/wiki/roscpp_tutorials"
 arch="all"
 license="BSD"
 
-depends="boost-dev ros-noetic-message-runtime ros-noetic-rosconsole ros-noetic-roscpp ros-noetic-roscpp-serialization ros-noetic-rostime ros-noetic-std-msgs boost-dev ros-noetic-message-runtime ros-noetic-rosconsole ros-noetic-roscpp ros-noetic-roscpp-serialization ros-noetic-rostime ros-noetic-std-msgs"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath boost-dev ros-noetic-catkin ros-noetic-message-generation ros-noetic-rosconsole ros-noetic-roscpp ros-noetic-roscpp-serialization ros-noetic-rostime ros-noetic-std-msgs"
+depends="ros-noetic-message-runtime ros-noetic-rosconsole ros-noetic-roscpp ros-noetic-roscpp-serialization ros-noetic-rostime ros-noetic-std-msgs"
+makedepends="boost-dev chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-message-generation ros-noetic-message-generation-dev ros-noetic-rosconsole ros-noetic-rosconsole-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-roscpp-serialization ros-noetic-roscpp-serialization-dev ros-noetic-rostime ros-noetic-rostime-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev"
+depends_dev="boost-dev ros-noetic-message-runtime ros-noetic-message-runtime-dev ros-noetic-rosconsole ros-noetic-rosconsole-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-roscpp-serialization ros-noetic-roscpp-serialization-dev ros-noetic-rostime ros-noetic-rostime-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-roscpp/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-roscpp/APKBUILD
@@ -7,10 +7,11 @@ url="http://ros.org/wiki/roscpp"
 arch="all"
 license="BSD"
 
-depends="boost-dev ros-noetic-cpp-common>=0.3.17 ros-noetic-message-runtime ros-noetic-rosconsole ros-noetic-roscpp-serialization ros-noetic-roscpp-traits>=0.3.17 ros-noetic-rosgraph-msgs>=1.10.3 ros-noetic-rostime>=0.6.4 ros-noetic-std-msgs ros-noetic-xmlrpcpp boost-dev ros-noetic-cpp-common>=0.3.17 ros-noetic-message-runtime ros-noetic-rosconsole ros-noetic-roscpp-serialization ros-noetic-roscpp-traits>=0.3.17 ros-noetic-rosgraph-msgs>=1.10.3 ros-noetic-rostime>=0.6.4 ros-noetic-std-msgs ros-noetic-xmlrpcpp"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath boost-dev pkgconf ros-noetic-catkin>=0.5.78 ros-noetic-cpp-common>=0.3.17 ros-noetic-message-generation ros-noetic-rosconsole ros-noetic-roscpp-serialization ros-noetic-roscpp-traits>=0.3.17 ros-noetic-rosgraph-msgs>=1.10.3 ros-noetic-roslang ros-noetic-rostime>=0.6.4 ros-noetic-std-msgs ros-noetic-xmlrpcpp"
+depends="ros-noetic-cpp-common>=0.3.17 ros-noetic-message-runtime ros-noetic-rosconsole ros-noetic-roscpp-serialization ros-noetic-roscpp-traits>=0.3.17 ros-noetic-rosgraph-msgs>=1.10.3 ros-noetic-rostime>=0.6.4 ros-noetic-std-msgs ros-noetic-xmlrpcpp"
+makedepends="boost-dev chrpath pkgconf py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin-dev>=0.5.78 ros-noetic-catkin>=0.5.78 ros-noetic-cpp-common-dev>=0.3.17 ros-noetic-cpp-common>=0.3.17 ros-noetic-message-generation ros-noetic-message-generation-dev ros-noetic-rosconsole ros-noetic-rosconsole-dev ros-noetic-roscpp-serialization ros-noetic-roscpp-serialization-dev ros-noetic-roscpp-traits-dev>=0.3.17 ros-noetic-roscpp-traits>=0.3.17 ros-noetic-rosgraph-msgs-dev>=1.10.3 ros-noetic-rosgraph-msgs>=1.10.3 ros-noetic-roslang ros-noetic-roslang-dev ros-noetic-rostime-dev>=0.6.4 ros-noetic-rostime>=0.6.4 ros-noetic-std-msgs ros-noetic-std-msgs-dev ros-noetic-xmlrpcpp ros-noetic-xmlrpcpp-dev"
+depends_dev="boost-dev ros-noetic-cpp-common-dev>=0.3.17 ros-noetic-cpp-common>=0.3.17 ros-noetic-message-runtime ros-noetic-message-runtime-dev ros-noetic-rosconsole ros-noetic-rosconsole-dev ros-noetic-roscpp-serialization ros-noetic-roscpp-serialization-dev ros-noetic-roscpp-traits-dev>=0.3.17 ros-noetic-roscpp-traits>=0.3.17 ros-noetic-rosgraph-msgs-dev>=1.10.3 ros-noetic-rosgraph-msgs>=1.10.3 ros-noetic-rostime-dev>=0.6.4 ros-noetic-rostime>=0.6.4 ros-noetic-std-msgs ros-noetic-std-msgs-dev ros-noetic-xmlrpcpp ros-noetic-xmlrpcpp-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-roscreate/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-roscreate/APKBUILD
@@ -8,9 +8,10 @@ arch="all"
 license="BSD"
 
 depends="py3-rospkg ros-noetic-roslib"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath py3-setuptools ros-noetic-catkin>=0.5.68"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin-dev>=0.5.68 ros-noetic-catkin>=0.5.68"
+depends_dev="ros-noetic-roslib-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-rosgraph-msgs/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-rosgraph-msgs/APKBUILD
@@ -7,10 +7,11 @@ url="http://ros.org/wiki/rosgraph_msgs"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-message-runtime ros-noetic-std-msgs ros-noetic-message-runtime ros-noetic-std-msgs"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin ros-noetic-message-generation ros-noetic-std-msgs"
+depends="ros-noetic-message-runtime ros-noetic-std-msgs"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-message-generation ros-noetic-message-generation-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev"
+depends_dev="ros-noetic-message-runtime ros-noetic-message-runtime-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-rosgraph/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-rosgraph/APKBUILD
@@ -8,9 +8,10 @@ arch="all"
 license="BSD"
 
 depends="py3-netifaces py3-rospkg py3-yaml"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath py3-mock ros-noetic-catkin>=0.5.78"
+makedepends="chrpath py3-mock py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin-dev>=0.5.78 ros-noetic-catkin>=0.5.78"
+depends_dev=""
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-roslang/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-roslang/APKBUILD
@@ -7,10 +7,11 @@ url="http://ros.org/wiki/roslang"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-catkin ros-noetic-genmsg ros-noetic-catkin ros-noetic-genmsg"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin"
+depends="ros-noetic-catkin ros-noetic-genmsg"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev"
+depends_dev="ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-genmsg ros-noetic-genmsg-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-roslaunch/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-roslaunch/APKBUILD
@@ -8,9 +8,10 @@ arch="all"
 license="BSD"
 
 depends="py3-paramiko py3-rospkg>=1.0.37 py3-yaml ros-noetic-rosclean ros-noetic-rosgraph-msgs ros-noetic-roslib ros-noetic-rosmaster>=1.11.16 ros-noetic-rosout ros-noetic-rosparam ros-noetic-rosunit>=1.13.3"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin>=0.5.78 ros-noetic-rosbuild"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin-dev>=0.5.78 ros-noetic-catkin>=0.5.78 ros-noetic-rosbuild ros-noetic-rosbuild-dev"
+depends_dev="ros-noetic-rosclean-dev ros-noetic-rosgraph-msgs-dev ros-noetic-roslib-dev ros-noetic-rosmaster-dev>=1.11.16 ros-noetic-rosout-dev ros-noetic-rosparam-dev ros-noetic-rosunit-dev>=1.13.3"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-roslib/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-roslib/APKBUILD
@@ -7,10 +7,11 @@ url="http://wiki.ros.org/roslib"
 arch="all"
 license="BSD"
 
-depends="py3-rospkg>=1.0.37 ros-noetic-catkin ros-noetic-ros-environment ros-noetic-rospack ros-noetic-rospack"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath boost-dev py3-setuptools ros-noetic-catkin>=0.6.7 ros-noetic-rosmake ros-noetic-rospack"
+depends="py3-rospkg>=1.0.37 ros-noetic-catkin ros-noetic-ros-environment ros-noetic-rospack"
+makedepends="boost-dev chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin-dev>=0.6.7 ros-noetic-catkin>=0.6.7 ros-noetic-rosmake ros-noetic-rosmake-dev ros-noetic-rospack ros-noetic-rospack-dev"
+depends_dev="ros-noetic-catkin-dev ros-noetic-ros-environment-dev ros-noetic-rospack ros-noetic-rospack-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-roslint/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-roslint/APKBUILD
@@ -8,9 +8,10 @@ arch="all"
 license="BSD"
 
 depends=""
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev"
+depends_dev=""
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-roslisp/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-roslisp/APKBUILD
@@ -7,10 +7,11 @@ url="http://ros.org/wiki/roslisp"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-ros-environment ros-noetic-rosgraph-msgs ros-noetic-roslang ros-noetic-rospack ros-noetic-std-srvs sbcl ros-noetic-ros-environment ros-noetic-rosgraph-msgs ros-noetic-roslang ros-noetic-rospack ros-noetic-std-srvs sbcl"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin"
+depends="ros-noetic-ros-environment ros-noetic-rosgraph-msgs ros-noetic-roslang ros-noetic-rospack ros-noetic-std-srvs sbcl"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev"
+depends_dev="ros-noetic-ros-environment ros-noetic-ros-environment-dev ros-noetic-rosgraph-msgs ros-noetic-rosgraph-msgs-dev ros-noetic-roslang ros-noetic-roslang-dev ros-noetic-rospack ros-noetic-rospack-dev ros-noetic-std-srvs ros-noetic-std-srvs-dev sbcl"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-roslz4/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-roslz4/APKBUILD
@@ -7,10 +7,11 @@ url="http://wiki.ros.org/$_pkgname"
 arch="all"
 license="BSD"
 
-depends="lz4-dev lz4-dev"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath lz4-dev ros-noetic-catkin ros-noetic-cpp-common ros-noetic-rosunit"
+depends=""
+makedepends="chrpath lz4-dev py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-cpp-common ros-noetic-cpp-common-dev ros-noetic-rosunit ros-noetic-rosunit-dev"
+depends_dev="lz4-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-rosmake/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-rosmake/APKBUILD
@@ -8,9 +8,10 @@ arch="all"
 license="BSD"
 
 depends="py3-rospkg ros-noetic-catkin"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath py3-setuptools ros-noetic-catkin>=0.5.68"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin-dev>=0.5.68 ros-noetic-catkin>=0.5.68"
+depends_dev="ros-noetic-catkin-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-rosmaster/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-rosmaster/APKBUILD
@@ -8,9 +8,10 @@ arch="all"
 license="BSD"
 
 depends="py3-defusedxml ros-noetic-rosgraph"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin>=0.5.68"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin-dev>=0.5.68 ros-noetic-catkin>=0.5.68"
+depends_dev="ros-noetic-rosgraph-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-rosmsg/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-rosmsg/APKBUILD
@@ -8,9 +8,10 @@ arch="all"
 license="BSD"
 
 depends="py3-rospkg ros-noetic-catkin>=0.6.4 ros-noetic-genmsg ros-noetic-genpy>=0.6.5 ros-noetic-rosbag ros-noetic-roslib"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin ros-noetic-diagnostic-msgs ros-noetic-rostest ros-noetic-std-msgs ros-noetic-std-srvs"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-diagnostic-msgs ros-noetic-diagnostic-msgs-dev ros-noetic-rostest ros-noetic-rostest-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev ros-noetic-std-srvs ros-noetic-std-srvs-dev"
+depends_dev="ros-noetic-catkin-dev>=0.6.4 ros-noetic-genmsg-dev ros-noetic-genpy-dev>=0.6.5 ros-noetic-rosbag-dev ros-noetic-roslib-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-rosnode/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-rosnode/APKBUILD
@@ -7,10 +7,11 @@ url="http://ros.org/wiki/rosnode"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-rosgraph ros-noetic-rostopic ros-noetic-rosgraph ros-noetic-rostopic"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin>=0.5.68 ros-noetic-rostest"
+depends="ros-noetic-rosgraph ros-noetic-rostopic"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin-dev>=0.5.68 ros-noetic-catkin>=0.5.68 ros-noetic-rostest ros-noetic-rostest-dev"
+depends_dev="ros-noetic-rosgraph ros-noetic-rosgraph-dev ros-noetic-rostopic ros-noetic-rostopic-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-rosout/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-rosout/APKBUILD
@@ -7,10 +7,11 @@ url="http://ros.org/wiki/rosout"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-roscpp ros-noetic-rosgraph-msgs ros-noetic-roscpp ros-noetic-rosgraph-msgs"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin ros-noetic-roscpp ros-noetic-rosgraph-msgs"
+depends="ros-noetic-roscpp ros-noetic-rosgraph-msgs"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-rosgraph-msgs ros-noetic-rosgraph-msgs-dev"
+depends_dev="ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-rosgraph-msgs ros-noetic-rosgraph-msgs-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-rospack/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-rospack/APKBUILD
@@ -7,10 +7,11 @@ url="http://wiki.ros.org/rospack"
 arch="all"
 license="BSD"
 
-depends="boost-dev pkgconf py3-catkin-pkg py3-rosdep python3-dev ros-noetic-ros-environment tinyxml2-dev boost-dev pkgconf python3-dev tinyxml2-dev"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath boost-dev gtest gtest-dev pkgconf py3-coverage python3-dev ros-noetic-catkin>=0.5.68 ros-noetic-cmake-modules tinyxml2-dev"
+depends="pkgconf py3-catkin-pkg py3-rosdep ros-noetic-ros-environment"
+makedepends="boost-dev chrpath gtest gtest-dev pkgconf py3-coverage py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool python3-dev ros-noetic-catkin-dev>=0.5.68 ros-noetic-catkin>=0.5.68 ros-noetic-cmake-modules ros-noetic-cmake-modules-dev tinyxml2-dev"
+depends_dev="boost-dev pkgconf python3-dev ros-noetic-ros-environment-dev tinyxml2-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-rosparam/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-rosparam/APKBUILD
@@ -8,9 +8,10 @@ arch="all"
 license="BSD"
 
 depends="py3-yaml ros-noetic-rosgraph"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev"
+depends_dev="ros-noetic-rosgraph-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-rospy-tutorials/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-rospy-tutorials/APKBUILD
@@ -7,10 +7,11 @@ url="http://www.ros.org/wiki/rospy_tutorials"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-message-runtime ros-noetic-rospy ros-noetic-std-msgs ros-noetic-message-runtime ros-noetic-rospy ros-noetic-std-msgs"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin>=0.5.68 ros-noetic-message-generation ros-noetic-roscpp-tutorials ros-noetic-rostest ros-noetic-std-msgs"
+depends="ros-noetic-message-runtime ros-noetic-rospy ros-noetic-std-msgs"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin-dev>=0.5.68 ros-noetic-catkin>=0.5.68 ros-noetic-message-generation ros-noetic-message-generation-dev ros-noetic-roscpp-tutorials ros-noetic-roscpp-tutorials-dev ros-noetic-rostest ros-noetic-rostest-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev"
+depends_dev="ros-noetic-message-runtime ros-noetic-message-runtime-dev ros-noetic-rospy ros-noetic-rospy-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-rospy/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-rospy/APKBUILD
@@ -7,10 +7,11 @@ url="http://wiki.ros.org/rospy"
 arch="all"
 license="BSD"
 
-depends="py3-numpy py3-numpy-dev py3-rospkg py3-yaml ros-noetic-genpy ros-noetic-roscpp ros-noetic-rosgraph ros-noetic-rosgraph-msgs>=1.10.3 ros-noetic-roslib ros-noetic-std-msgs"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin>=0.5.78"
+depends="py3-numpy py3-rospkg py3-yaml ros-noetic-genpy ros-noetic-roscpp ros-noetic-rosgraph ros-noetic-rosgraph-msgs>=1.10.3 ros-noetic-roslib ros-noetic-std-msgs"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin-dev>=0.5.78 ros-noetic-catkin>=0.5.78"
+depends_dev="py3-numpy-dev ros-noetic-genpy-dev ros-noetic-roscpp-dev ros-noetic-rosgraph-dev ros-noetic-rosgraph-msgs-dev>=1.10.3 ros-noetic-roslib-dev ros-noetic-std-msgs-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-rosserial-client/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-rosserial-client/APKBUILD
@@ -7,10 +7,11 @@ url="http://ros.org/wiki/rosserial_client"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-rospy ros-noetic-rosserial-msgs ros-noetic-std-msgs ros-noetic-tf ros-noetic-rosbash"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin ros-noetic-rosserial-msgs ros-noetic-rosunit"
+depends="ros-noetic-rospy ros-noetic-rosserial-msgs ros-noetic-std-msgs ros-noetic-tf"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-rosserial-msgs ros-noetic-rosserial-msgs-dev ros-noetic-rosunit ros-noetic-rosunit-dev"
+depends_dev="ros-noetic-rosbash ros-noetic-rosbash-dev ros-noetic-rospy-dev ros-noetic-rosserial-msgs-dev ros-noetic-std-msgs-dev ros-noetic-tf-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-rosserial-msgs/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-rosserial-msgs/APKBUILD
@@ -7,10 +7,11 @@ url="http://ros.org/wiki/rosserial_msgs"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-message-runtime ros-noetic-message-runtime"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin ros-noetic-message-generation"
+depends="ros-noetic-message-runtime"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-message-generation ros-noetic-message-generation-dev"
+depends_dev="ros-noetic-message-runtime ros-noetic-message-runtime-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-rosserial-python/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-rosserial-python/APKBUILD
@@ -7,10 +7,11 @@ url="http://ros.org/wiki/rosserial_python"
 arch="all"
 license="BSD"
 
-depends="py3-pyserial ros-noetic-diagnostic-msgs ros-noetic-rospy ros-noetic-rosserial-msgs py3-pyserial ros-noetic-diagnostic-msgs ros-noetic-rospy ros-noetic-rosserial-msgs"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin"
+depends="py3-pyserial ros-noetic-diagnostic-msgs ros-noetic-rospy ros-noetic-rosserial-msgs"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev"
+depends_dev="py3-pyserial ros-noetic-diagnostic-msgs ros-noetic-diagnostic-msgs-dev ros-noetic-rospy ros-noetic-rospy-dev ros-noetic-rosserial-msgs ros-noetic-rosserial-msgs-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-rosserial/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-rosserial/APKBUILD
@@ -7,10 +7,11 @@ url="http://ros.org/wiki/rosserial"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-rosserial-client ros-noetic-rosserial-msgs ros-noetic-rosserial-python ros-noetic-rosserial-client ros-noetic-rosserial-msgs ros-noetic-rosserial-python"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin"
+depends="ros-noetic-rosserial-client ros-noetic-rosserial-msgs ros-noetic-rosserial-python"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev"
+depends_dev="ros-noetic-rosserial-client ros-noetic-rosserial-client-dev ros-noetic-rosserial-msgs ros-noetic-rosserial-msgs-dev ros-noetic-rosserial-python ros-noetic-rosserial-python-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-rosservice/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-rosservice/APKBUILD
@@ -7,10 +7,11 @@ url="http://ros.org/wiki/rosservice"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-genpy ros-noetic-rosgraph ros-noetic-roslib ros-noetic-rosmsg ros-noetic-rospy ros-noetic-genpy ros-noetic-rosgraph ros-noetic-roslib ros-noetic-rosmsg ros-noetic-rospy"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin>=0.5.78"
+depends="ros-noetic-genpy ros-noetic-rosgraph ros-noetic-roslib ros-noetic-rosmsg ros-noetic-rospy"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin-dev>=0.5.78 ros-noetic-catkin>=0.5.78"
+depends_dev="ros-noetic-genpy ros-noetic-genpy-dev ros-noetic-rosgraph ros-noetic-rosgraph-dev ros-noetic-roslib ros-noetic-roslib-dev ros-noetic-rosmsg ros-noetic-rosmsg-dev ros-noetic-rospy ros-noetic-rospy-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-rostest/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-rostest/APKBUILD
@@ -7,10 +7,11 @@ url="http://ros.org/wiki/rostest"
 arch="all"
 license="BSD"
 
-depends="boost-dev ros-noetic-rosgraph ros-noetic-roslaunch ros-noetic-rosmaster ros-noetic-rospy ros-noetic-rosunit boost-dev ros-noetic-rosgraph ros-noetic-roslaunch ros-noetic-rosmaster ros-noetic-rospy ros-noetic-rosunit"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath boost-dev ros-noetic-catkin>=0.7.9 ros-noetic-rosunit"
+depends="ros-noetic-rosgraph ros-noetic-roslaunch ros-noetic-rosmaster ros-noetic-rospy ros-noetic-rosunit"
+makedepends="boost-dev chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin-dev>=0.7.9 ros-noetic-catkin>=0.7.9 ros-noetic-rosunit ros-noetic-rosunit-dev"
+depends_dev="boost-dev ros-noetic-rosgraph ros-noetic-rosgraph-dev ros-noetic-roslaunch ros-noetic-roslaunch-dev ros-noetic-rosmaster ros-noetic-rosmaster-dev ros-noetic-rospy ros-noetic-rospy-dev ros-noetic-rosunit ros-noetic-rosunit-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-rostime/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-rostime/APKBUILD
@@ -7,10 +7,11 @@ url="http://ros.org/wiki/rostime"
 arch="all"
 license="BSD"
 
-depends="boost-dev ros-noetic-cpp-common boost-dev ros-noetic-cpp-common"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath boost-dev ros-noetic-catkin>=0.5.68 ros-noetic-cpp-common"
+depends="ros-noetic-cpp-common"
+makedepends="boost-dev chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin-dev>=0.5.68 ros-noetic-catkin>=0.5.68 ros-noetic-cpp-common ros-noetic-cpp-common-dev"
+depends_dev="boost-dev ros-noetic-cpp-common ros-noetic-cpp-common-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-rostopic/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-rostopic/APKBUILD
@@ -7,10 +7,11 @@ url="http://ros.org/wiki/rostopic"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-genpy>=0.5.4 ros-noetic-rosbag ros-noetic-rospy ros-noetic-genpy>=0.5.4 ros-noetic-rosbag ros-noetic-rospy"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin>=0.5.78 ros-noetic-rostest"
+depends="ros-noetic-genpy>=0.5.4 ros-noetic-rosbag ros-noetic-rospy"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin-dev>=0.5.78 ros-noetic-catkin>=0.5.78 ros-noetic-rostest ros-noetic-rostest-dev"
+depends_dev="ros-noetic-genpy-dev>=0.5.4 ros-noetic-genpy>=0.5.4 ros-noetic-rosbag ros-noetic-rosbag-dev ros-noetic-rospy ros-noetic-rospy-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-rosunit/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-rosunit/APKBUILD
@@ -8,9 +8,10 @@ arch="all"
 license="BSD"
 
 depends="py3-rospkg ros-noetic-roslib"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath py3-setuptools ros-noetic-catkin>=0.5.78"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin-dev>=0.5.78 ros-noetic-catkin>=0.5.78"
+depends_dev="ros-noetic-roslib-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-roswtf/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-roswtf/APKBUILD
@@ -8,9 +8,10 @@ arch="all"
 license="BSD"
 
 depends="py3-paramiko py3-rospkg ros-noetic-rosbuild ros-noetic-rosgraph ros-noetic-roslaunch ros-noetic-roslib ros-noetic-rosnode ros-noetic-rosservice"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin>=0.5.68 ros-noetic-cmake-modules ros-noetic-rosbag ros-noetic-roslang ros-noetic-rostest ros-noetic-std-srvs"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin-dev>=0.5.68 ros-noetic-catkin>=0.5.68 ros-noetic-cmake-modules ros-noetic-cmake-modules-dev ros-noetic-rosbag ros-noetic-rosbag-dev ros-noetic-roslang ros-noetic-roslang-dev ros-noetic-rostest ros-noetic-rostest-dev ros-noetic-std-srvs ros-noetic-std-srvs-dev"
+depends_dev="ros-noetic-rosbuild-dev ros-noetic-rosgraph-dev ros-noetic-roslaunch-dev ros-noetic-roslib-dev ros-noetic-rosnode-dev ros-noetic-rosservice-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-rotate-recovery/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-rotate-recovery/APKBUILD
@@ -7,10 +7,11 @@ url="http://wiki.ros.org/rotate_recovery"
 arch="all"
 license="BSD"
 
-depends="eigen-dev ros-noetic-costmap-2d ros-noetic-geometry-msgs ros-noetic-nav-core ros-noetic-pluginlib ros-noetic-roscpp ros-noetic-tf2 ros-noetic-tf2-geometry-msgs ros-noetic-tf2-ros eigen-dev ros-noetic-costmap-2d ros-noetic-geometry-msgs ros-noetic-nav-core ros-noetic-pluginlib ros-noetic-roscpp ros-noetic-tf2 ros-noetic-tf2-geometry-msgs ros-noetic-tf2-ros"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath eigen-dev ros-noetic-angles ros-noetic-base-local-planner ros-noetic-catkin ros-noetic-cmake-modules ros-noetic-costmap-2d ros-noetic-geometry-msgs ros-noetic-nav-core ros-noetic-pluginlib ros-noetic-roscpp ros-noetic-tf2 ros-noetic-tf2-geometry-msgs ros-noetic-tf2-ros"
+depends="ros-noetic-costmap-2d ros-noetic-geometry-msgs ros-noetic-nav-core ros-noetic-pluginlib ros-noetic-roscpp ros-noetic-tf2 ros-noetic-tf2-geometry-msgs ros-noetic-tf2-ros"
+makedepends="chrpath eigen-dev py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-angles ros-noetic-angles-dev ros-noetic-base-local-planner ros-noetic-base-local-planner-dev ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-cmake-modules ros-noetic-cmake-modules-dev ros-noetic-costmap-2d ros-noetic-costmap-2d-dev ros-noetic-geometry-msgs ros-noetic-geometry-msgs-dev ros-noetic-nav-core ros-noetic-nav-core-dev ros-noetic-pluginlib ros-noetic-pluginlib-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-tf2 ros-noetic-tf2-dev ros-noetic-tf2-geometry-msgs ros-noetic-tf2-geometry-msgs-dev ros-noetic-tf2-ros ros-noetic-tf2-ros-dev"
+depends_dev="eigen-dev ros-noetic-costmap-2d ros-noetic-costmap-2d-dev ros-noetic-geometry-msgs ros-noetic-geometry-msgs-dev ros-noetic-nav-core ros-noetic-nav-core-dev ros-noetic-pluginlib ros-noetic-pluginlib-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-tf2 ros-noetic-tf2-dev ros-noetic-tf2-geometry-msgs ros-noetic-tf2-geometry-msgs-dev ros-noetic-tf2-ros ros-noetic-tf2-ros-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-rqt-action/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-rqt-action/APKBUILD
@@ -7,10 +7,11 @@ url="http://wiki.ros.org/rqt_action"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-rospy ros-noetic-rqt-msg ros-noetic-rqt-py-common ros-noetic-rospy ros-noetic-rqt-msg ros-noetic-rqt-py-common"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin"
+depends="ros-noetic-rospy ros-noetic-rqt-msg ros-noetic-rqt-py-common"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev"
+depends_dev="ros-noetic-rospy ros-noetic-rospy-dev ros-noetic-rqt-msg ros-noetic-rqt-msg-dev ros-noetic-rqt-py-common ros-noetic-rqt-py-common-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-rqt-bag-plugins/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-rqt-bag-plugins/APKBUILD
@@ -8,9 +8,10 @@ arch="all"
 license="BSD"
 
 depends="py3-cairo py3-pillow ros-noetic-geometry-msgs ros-noetic-rosbag ros-noetic-roslib ros-noetic-rospy ros-noetic-rqt-bag ros-noetic-rqt-gui ros-noetic-rqt-gui-py ros-noetic-rqt-plot ros-noetic-sensor-msgs ros-noetic-std-msgs"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev"
+depends_dev="ros-noetic-geometry-msgs-dev ros-noetic-rosbag-dev ros-noetic-roslib-dev ros-noetic-rospy-dev ros-noetic-rqt-bag-dev ros-noetic-rqt-gui-dev ros-noetic-rqt-gui-py-dev ros-noetic-rqt-plot-dev ros-noetic-sensor-msgs-dev ros-noetic-std-msgs-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-rqt-bag/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-rqt-bag/APKBUILD
@@ -8,9 +8,10 @@ arch="all"
 license="BSD"
 
 depends="py3-rospkg ros-noetic-python-qt-binding>=0.2.19 ros-noetic-rosbag ros-noetic-rosgraph-msgs ros-noetic-roslib ros-noetic-rosnode ros-noetic-rospy ros-noetic-rqt-gui-py ros-noetic-rqt-gui>=0.2.12"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev"
+depends_dev="ros-noetic-python-qt-binding-dev>=0.2.19 ros-noetic-rosbag-dev ros-noetic-rosgraph-msgs-dev ros-noetic-roslib-dev ros-noetic-rosnode-dev ros-noetic-rospy-dev ros-noetic-rqt-gui-dev>=0.2.12 ros-noetic-rqt-gui-py-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-rqt-common-plugins/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-rqt-common-plugins/APKBUILD
@@ -8,9 +8,10 @@ arch="all"
 license="BSD"
 
 depends="ros-noetic-rqt-action ros-noetic-rqt-bag ros-noetic-rqt-bag-plugins ros-noetic-rqt-console ros-noetic-rqt-dep ros-noetic-rqt-graph ros-noetic-rqt-image-view ros-noetic-rqt-launch ros-noetic-rqt-logger-level ros-noetic-rqt-msg ros-noetic-rqt-plot ros-noetic-rqt-publisher ros-noetic-rqt-py-common ros-noetic-rqt-py-console ros-noetic-rqt-reconfigure ros-noetic-rqt-service-caller ros-noetic-rqt-shell ros-noetic-rqt-srv ros-noetic-rqt-top ros-noetic-rqt-topic ros-noetic-rqt-web"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev"
+depends_dev="ros-noetic-rqt-action-dev ros-noetic-rqt-bag-dev ros-noetic-rqt-bag-plugins-dev ros-noetic-rqt-console-dev ros-noetic-rqt-dep-dev ros-noetic-rqt-graph-dev ros-noetic-rqt-image-view-dev ros-noetic-rqt-launch-dev ros-noetic-rqt-logger-level-dev ros-noetic-rqt-msg-dev ros-noetic-rqt-plot-dev ros-noetic-rqt-publisher-dev ros-noetic-rqt-py-common-dev ros-noetic-rqt-py-console-dev ros-noetic-rqt-reconfigure-dev ros-noetic-rqt-service-caller-dev ros-noetic-rqt-shell-dev ros-noetic-rqt-srv-dev ros-noetic-rqt-top-dev ros-noetic-rqt-topic-dev ros-noetic-rqt-web-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-rqt-console/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-rqt-console/APKBUILD
@@ -8,9 +8,10 @@ arch="all"
 license="BSD"
 
 depends="py3-rospkg ros-noetic-python-qt-binding>=0.2.19 ros-noetic-roslib ros-noetic-rospy ros-noetic-rqt-gui ros-noetic-rqt-gui-py ros-noetic-rqt-logger-level ros-noetic-rqt-py-common"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath py3-setuptools ros-noetic-catkin"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev"
+depends_dev="ros-noetic-python-qt-binding-dev>=0.2.19 ros-noetic-roslib-dev ros-noetic-rospy-dev ros-noetic-rqt-gui-dev ros-noetic-rqt-gui-py-dev ros-noetic-rqt-logger-level-dev ros-noetic-rqt-py-common-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-rqt-dep/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-rqt-dep/APKBUILD
@@ -8,9 +8,10 @@ arch="all"
 license="BSD"
 
 depends="py3-rospkg ros-noetic-python-qt-binding>=0.2.19 ros-noetic-qt-dotgraph ros-noetic-qt-gui ros-noetic-qt-gui-py-common ros-noetic-rqt-graph ros-noetic-rqt-gui-py"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath py3-mock ros-noetic-catkin"
+makedepends="chrpath py3-mock py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev"
+depends_dev="ros-noetic-python-qt-binding-dev>=0.2.19 ros-noetic-qt-dotgraph-dev ros-noetic-qt-gui-dev ros-noetic-qt-gui-py-common-dev ros-noetic-rqt-graph-dev ros-noetic-rqt-gui-py-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-rqt-graph/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-rqt-graph/APKBUILD
@@ -8,9 +8,10 @@ arch="all"
 license="BSD"
 
 depends="py3-rospkg ros-noetic-python-qt-binding>=0.2.19 ros-noetic-qt-dotgraph ros-noetic-rosgraph ros-noetic-rosgraph-msgs ros-noetic-roslib ros-noetic-rosnode ros-noetic-rospy ros-noetic-rosservice ros-noetic-rostopic ros-noetic-rqt-gui ros-noetic-rqt-gui-py"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev"
+depends_dev="ros-noetic-python-qt-binding-dev>=0.2.19 ros-noetic-qt-dotgraph-dev ros-noetic-rosgraph-dev ros-noetic-rosgraph-msgs-dev ros-noetic-roslib-dev ros-noetic-rosnode-dev ros-noetic-rospy-dev ros-noetic-rosservice-dev ros-noetic-rostopic-dev ros-noetic-rqt-gui-dev ros-noetic-rqt-gui-py-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-rqt-gui-cpp/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-rqt-gui-cpp/APKBUILD
@@ -7,10 +7,11 @@ url="http://ros.org/wiki/rqt_gui_cpp"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-nodelet ros-noetic-qt-gui-cpp>=0.3.0 ros-noetic-qt-gui>=0.3.0 ros-noetic-roscpp ros-noetic-nodelet ros-noetic-qt-gui-cpp>=0.3.0 ros-noetic-qt-gui>=0.3.0 ros-noetic-roscpp"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath qt5-qtbase-dev ros-noetic-catkin ros-noetic-nodelet ros-noetic-qt-gui-cpp>=0.3.0 ros-noetic-qt-gui>=0.3.0 ros-noetic-roscpp"
+depends="ros-noetic-nodelet ros-noetic-qt-gui-cpp>=0.3.0 ros-noetic-qt-gui>=0.3.0 ros-noetic-roscpp"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool qt5-qtbase-dev ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-nodelet ros-noetic-nodelet-dev ros-noetic-qt-gui-cpp-dev>=0.3.0 ros-noetic-qt-gui-cpp>=0.3.0 ros-noetic-qt-gui-dev>=0.3.0 ros-noetic-qt-gui>=0.3.0 ros-noetic-roscpp ros-noetic-roscpp-dev"
+depends_dev="ros-noetic-nodelet ros-noetic-nodelet-dev ros-noetic-qt-gui-cpp-dev>=0.3.0 ros-noetic-qt-gui-cpp>=0.3.0 ros-noetic-qt-gui-dev>=0.3.0 ros-noetic-qt-gui>=0.3.0 ros-noetic-roscpp ros-noetic-roscpp-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-rqt-gui-py/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-rqt-gui-py/APKBUILD
@@ -7,10 +7,11 @@ url="http://ros.org/wiki/rqt_gui_py"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-qt-gui>=0.3.0 ros-noetic-rospy ros-noetic-rqt-gui>=0.3.0 ros-noetic-qt-gui>=0.3.0 ros-noetic-rospy ros-noetic-rqt-gui>=0.3.0"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin ros-noetic-qt-gui>=0.3.0 ros-noetic-rospy ros-noetic-rqt-gui>=0.3.0"
+depends="ros-noetic-qt-gui>=0.3.0 ros-noetic-rospy ros-noetic-rqt-gui>=0.3.0"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-qt-gui-dev>=0.3.0 ros-noetic-qt-gui>=0.3.0 ros-noetic-rospy ros-noetic-rospy-dev ros-noetic-rqt-gui-dev>=0.3.0 ros-noetic-rqt-gui>=0.3.0"
+depends_dev="ros-noetic-qt-gui-dev>=0.3.0 ros-noetic-qt-gui>=0.3.0 ros-noetic-rospy ros-noetic-rospy-dev ros-noetic-rqt-gui-dev>=0.3.0 ros-noetic-rqt-gui>=0.3.0"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-rqt-gui/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-rqt-gui/APKBUILD
@@ -8,9 +8,10 @@ arch="all"
 license="BSD"
 
 depends="py3-rospkg ros-noetic-python-qt-binding ros-noetic-qt-gui>=0.3.0 ros-noetic-rospy"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin ros-noetic-qt-gui>=0.3.0"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-qt-gui-dev>=0.3.0 ros-noetic-qt-gui>=0.3.0"
+depends_dev="ros-noetic-python-qt-binding-dev ros-noetic-qt-gui-dev>=0.3.0 ros-noetic-rospy-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-rqt-image-view/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-rqt-image-view/APKBUILD
@@ -8,9 +8,10 @@ arch="all"
 license="BSD"
 
 depends="ros-noetic-cv-bridge ros-noetic-geometry-msgs ros-noetic-image-transport ros-noetic-rqt-gui ros-noetic-rqt-gui-cpp ros-noetic-sensor-msgs"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath py3-setuptools qt5-qtbase-dev ros-noetic-catkin ros-noetic-cv-bridge ros-noetic-geometry-msgs ros-noetic-image-transport ros-noetic-rqt-gui ros-noetic-rqt-gui-cpp ros-noetic-sensor-msgs"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool qt5-qtbase-dev ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-cv-bridge ros-noetic-cv-bridge-dev ros-noetic-geometry-msgs ros-noetic-geometry-msgs-dev ros-noetic-image-transport ros-noetic-image-transport-dev ros-noetic-rqt-gui ros-noetic-rqt-gui-cpp ros-noetic-rqt-gui-cpp-dev ros-noetic-rqt-gui-dev ros-noetic-sensor-msgs ros-noetic-sensor-msgs-dev"
+depends_dev="ros-noetic-cv-bridge-dev ros-noetic-geometry-msgs-dev ros-noetic-image-transport-dev ros-noetic-rqt-gui-cpp-dev ros-noetic-rqt-gui-dev ros-noetic-sensor-msgs-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-rqt-launch/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-rqt-launch/APKBUILD
@@ -7,10 +7,11 @@ url="http://wiki.ros.org/rqt_launch"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-python-qt-binding>=0.2.19 ros-noetic-roslaunch ros-noetic-rospy ros-noetic-rqt-console ros-noetic-rqt-gui ros-noetic-rqt-gui-py ros-noetic-rqt-py-common ros-noetic-python-qt-binding>=0.2.19 ros-noetic-roslaunch ros-noetic-rospy ros-noetic-rqt-console ros-noetic-rqt-gui ros-noetic-rqt-gui-py ros-noetic-rqt-py-common"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin ros-noetic-rqt-py-common"
+depends="ros-noetic-python-qt-binding>=0.2.19 ros-noetic-roslaunch ros-noetic-rospy ros-noetic-rqt-console ros-noetic-rqt-gui ros-noetic-rqt-gui-py ros-noetic-rqt-py-common"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-rqt-py-common ros-noetic-rqt-py-common-dev"
+depends_dev="ros-noetic-python-qt-binding-dev>=0.2.19 ros-noetic-python-qt-binding>=0.2.19 ros-noetic-roslaunch ros-noetic-roslaunch-dev ros-noetic-rospy ros-noetic-rospy-dev ros-noetic-rqt-console ros-noetic-rqt-console-dev ros-noetic-rqt-gui ros-noetic-rqt-gui-dev ros-noetic-rqt-gui-py ros-noetic-rqt-gui-py-dev ros-noetic-rqt-py-common ros-noetic-rqt-py-common-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-rqt-logger-level/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-rqt-logger-level/APKBUILD
@@ -8,9 +8,10 @@ arch="all"
 license="BSD"
 
 depends="py3-rospkg ros-noetic-python-qt-binding>=0.2.19 ros-noetic-rosnode ros-noetic-rospy ros-noetic-rosservice ros-noetic-rqt-gui ros-noetic-rqt-gui-py"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath py3-setuptools ros-noetic-catkin"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev"
+depends_dev="ros-noetic-python-qt-binding-dev>=0.2.19 ros-noetic-rosnode-dev ros-noetic-rospy-dev ros-noetic-rosservice-dev ros-noetic-rqt-gui-dev ros-noetic-rqt-gui-py-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-rqt-moveit/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-rqt-moveit/APKBUILD
@@ -8,9 +8,10 @@ arch="all"
 license="BSD"
 
 depends="ros-noetic-python-qt-binding>=0.2.19 ros-noetic-rosnode ros-noetic-rospy ros-noetic-rostopic ros-noetic-rqt-gui ros-noetic-rqt-gui-py ros-noetic-rqt-py-common ros-noetic-rqt-topic ros-noetic-sensor-msgs"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath py3-setuptools ros-noetic-catkin"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev"
+depends_dev="ros-noetic-python-qt-binding-dev>=0.2.19 ros-noetic-rosnode-dev ros-noetic-rospy-dev ros-noetic-rostopic-dev ros-noetic-rqt-gui-dev ros-noetic-rqt-gui-py-dev ros-noetic-rqt-py-common-dev ros-noetic-rqt-topic-dev ros-noetic-sensor-msgs-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-rqt-msg/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-rqt-msg/APKBUILD
@@ -8,9 +8,10 @@ arch="all"
 license="BSD"
 
 depends="py3-rospkg ros-noetic-python-qt-binding>=0.2.19 ros-noetic-roslib ros-noetic-rosmsg ros-noetic-rospy ros-noetic-rqt-console ros-noetic-rqt-gui ros-noetic-rqt-gui-py ros-noetic-rqt-py-common"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev"
+depends_dev="ros-noetic-python-qt-binding-dev>=0.2.19 ros-noetic-roslib-dev ros-noetic-rosmsg-dev ros-noetic-rospy-dev ros-noetic-rqt-console-dev ros-noetic-rqt-gui-dev ros-noetic-rqt-gui-py-dev ros-noetic-rqt-py-common-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-rqt-nav-view/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-rqt-nav-view/APKBUILD
@@ -7,10 +7,11 @@ url="http://wiki.ros.org/rqt_nav_view"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-geometry-msgs ros-noetic-nav-msgs ros-noetic-python-qt-binding>=0.2.19 ros-noetic-qt-gui ros-noetic-rospy ros-noetic-rqt-gui ros-noetic-rqt-gui-py ros-noetic-rqt-py-common ros-noetic-tf ros-noetic-geometry-msgs ros-noetic-nav-msgs ros-noetic-python-qt-binding>=0.2.19 ros-noetic-qt-gui ros-noetic-rospy ros-noetic-rqt-gui ros-noetic-rqt-gui-py ros-noetic-rqt-py-common ros-noetic-tf"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin"
+depends="ros-noetic-geometry-msgs ros-noetic-nav-msgs ros-noetic-python-qt-binding>=0.2.19 ros-noetic-qt-gui ros-noetic-rospy ros-noetic-rqt-gui ros-noetic-rqt-gui-py ros-noetic-rqt-py-common ros-noetic-tf"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev"
+depends_dev="ros-noetic-geometry-msgs ros-noetic-geometry-msgs-dev ros-noetic-nav-msgs ros-noetic-nav-msgs-dev ros-noetic-python-qt-binding-dev>=0.2.19 ros-noetic-python-qt-binding>=0.2.19 ros-noetic-qt-gui ros-noetic-qt-gui-dev ros-noetic-rospy ros-noetic-rospy-dev ros-noetic-rqt-gui ros-noetic-rqt-gui-dev ros-noetic-rqt-gui-py ros-noetic-rqt-gui-py-dev ros-noetic-rqt-py-common ros-noetic-rqt-py-common-dev ros-noetic-tf ros-noetic-tf-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-rqt-plot/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-rqt-plot/APKBUILD
@@ -7,10 +7,11 @@ url="http://wiki.ros.org/rqt_plot"
 arch="all"
 license="BSD"
 
-depends="py3-matplotlib py3-numpy py3-numpy-dev py3-rospkg ros-noetic-python-qt-binding>=0.2.19 ros-noetic-qt-gui-py-common>=0.2.25 ros-noetic-qwt-dependency ros-noetic-rosgraph ros-noetic-rostopic ros-noetic-rqt-gui ros-noetic-rqt-gui-py ros-noetic-rqt-py-common ros-noetic-std-msgs"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin"
+depends="py3-matplotlib py3-numpy py3-rospkg ros-noetic-python-qt-binding>=0.2.19 ros-noetic-qt-gui-py-common>=0.2.25 ros-noetic-qwt-dependency ros-noetic-rosgraph ros-noetic-rostopic ros-noetic-rqt-gui ros-noetic-rqt-gui-py ros-noetic-rqt-py-common ros-noetic-std-msgs"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev"
+depends_dev="py3-numpy-dev ros-noetic-python-qt-binding-dev>=0.2.19 ros-noetic-qt-gui-py-common-dev>=0.2.25 ros-noetic-qwt-dependency-dev ros-noetic-rosgraph-dev ros-noetic-rostopic-dev ros-noetic-rqt-gui-dev ros-noetic-rqt-gui-py-dev ros-noetic-rqt-py-common-dev ros-noetic-std-msgs-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-rqt-pose-view/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-rqt-pose-view/APKBUILD
@@ -8,9 +8,10 @@ arch="all"
 license="BSD"
 
 depends="py3-opengl py3-rospkg ros-noetic-geometry-msgs ros-noetic-gl-dependency ros-noetic-python-qt-binding>=0.2.19 ros-noetic-rospy ros-noetic-rostopic ros-noetic-rqt-gui ros-noetic-rqt-gui-py ros-noetic-rqt-py-common ros-noetic-tf"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev"
+depends_dev="ros-noetic-geometry-msgs-dev ros-noetic-gl-dependency-dev ros-noetic-python-qt-binding-dev>=0.2.19 ros-noetic-rospy-dev ros-noetic-rostopic-dev ros-noetic-rqt-gui-dev ros-noetic-rqt-gui-py-dev ros-noetic-rqt-py-common-dev ros-noetic-tf-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-rqt-publisher/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-rqt-publisher/APKBUILD
@@ -8,9 +8,10 @@ arch="all"
 license="BSD"
 
 depends="py3-rospkg ros-noetic-python-qt-binding>=0.2.19 ros-noetic-qt-gui-py-common ros-noetic-roslib ros-noetic-rosmsg>=1.9.49 ros-noetic-rqt-gui ros-noetic-rqt-gui-py ros-noetic-rqt-py-common"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev"
+depends_dev="ros-noetic-python-qt-binding-dev>=0.2.19 ros-noetic-qt-gui-py-common-dev ros-noetic-roslib-dev ros-noetic-rosmsg-dev>=1.9.49 ros-noetic-rqt-gui-dev ros-noetic-rqt-gui-py-dev ros-noetic-rqt-py-common-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-rqt-py-common/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-rqt-py-common/APKBUILD
@@ -7,10 +7,11 @@ url="http://ros.org/wiki/rqt_py_common"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-actionlib ros-noetic-genpy ros-noetic-python-qt-binding>=0.2.19 ros-noetic-qt-gui ros-noetic-rosbag ros-noetic-roslib ros-noetic-rospy ros-noetic-rostopic ros-noetic-actionlib ros-noetic-genpy ros-noetic-python-qt-binding>=0.2.19 ros-noetic-qt-gui ros-noetic-rosbag ros-noetic-roslib ros-noetic-rospy ros-noetic-rostopic"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin ros-noetic-genmsg ros-noetic-std-msgs"
+depends="ros-noetic-actionlib ros-noetic-genpy ros-noetic-python-qt-binding>=0.2.19 ros-noetic-qt-gui ros-noetic-rosbag ros-noetic-roslib ros-noetic-rospy ros-noetic-rostopic"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-genmsg ros-noetic-genmsg-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev"
+depends_dev="ros-noetic-actionlib ros-noetic-actionlib-dev ros-noetic-genpy ros-noetic-genpy-dev ros-noetic-python-qt-binding-dev>=0.2.19 ros-noetic-python-qt-binding>=0.2.19 ros-noetic-qt-gui ros-noetic-qt-gui-dev ros-noetic-rosbag ros-noetic-rosbag-dev ros-noetic-roslib ros-noetic-roslib-dev ros-noetic-rospy ros-noetic-rospy-dev ros-noetic-rostopic ros-noetic-rostopic-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-rqt-py-console/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-rqt-py-console/APKBUILD
@@ -8,9 +8,10 @@ arch="all"
 license="BSD"
 
 depends="py3-rospkg ros-noetic-python-qt-binding>=0.2.19 ros-noetic-qt-gui ros-noetic-qt-gui-py-common ros-noetic-rospy ros-noetic-rqt-gui ros-noetic-rqt-gui-py"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev"
+depends_dev="ros-noetic-python-qt-binding-dev>=0.2.19 ros-noetic-qt-gui-dev ros-noetic-qt-gui-py-common-dev ros-noetic-rospy-dev ros-noetic-rqt-gui-dev ros-noetic-rqt-gui-py-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-rqt-reconfigure/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-rqt-reconfigure/APKBUILD
@@ -8,9 +8,10 @@ arch="all"
 license="BSD"
 
 depends="py3-yaml ros-noetic-dynamic-reconfigure ros-noetic-python-qt-binding>=0.2.19 ros-noetic-rospy ros-noetic-rqt-console ros-noetic-rqt-gui ros-noetic-rqt-gui-py ros-noetic-rqt-py-common"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath py3-setuptools ros-noetic-catkin ros-noetic-roslint ros-noetic-rostest"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-roslint ros-noetic-roslint-dev ros-noetic-rostest ros-noetic-rostest-dev"
+depends_dev="ros-noetic-dynamic-reconfigure-dev ros-noetic-python-qt-binding-dev>=0.2.19 ros-noetic-rospy-dev ros-noetic-rqt-console-dev ros-noetic-rqt-gui-dev ros-noetic-rqt-gui-py-dev ros-noetic-rqt-py-common-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-rqt-robot-dashboard/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-rqt-robot-dashboard/APKBUILD
@@ -8,9 +8,10 @@ arch="all"
 license="BSD"
 
 depends="ros-noetic-diagnostic-msgs ros-noetic-python-qt-binding>=0.2.19 ros-noetic-qt-gui ros-noetic-rospy ros-noetic-rqt-console>=0.3.1 ros-noetic-rqt-gui ros-noetic-rqt-gui-py ros-noetic-rqt-nav-view ros-noetic-rqt-robot-monitor"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath py3-setuptools ros-noetic-catkin"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev"
+depends_dev="ros-noetic-diagnostic-msgs-dev ros-noetic-python-qt-binding-dev>=0.2.19 ros-noetic-qt-gui-dev ros-noetic-rospy-dev ros-noetic-rqt-console-dev>=0.3.1 ros-noetic-rqt-gui-dev ros-noetic-rqt-gui-py-dev ros-noetic-rqt-nav-view-dev ros-noetic-rqt-robot-monitor-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-rqt-robot-monitor/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-rqt-robot-monitor/APKBUILD
@@ -8,9 +8,10 @@ arch="all"
 license="BSD"
 
 depends="py3-rospkg ros-noetic-diagnostic-msgs ros-noetic-python-qt-binding>=0.2.19 ros-noetic-qt-gui ros-noetic-qt-gui-py-common ros-noetic-rospy ros-noetic-rqt-bag ros-noetic-rqt-gui ros-noetic-rqt-gui-py ros-noetic-rqt-py-common"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath py3-setuptools ros-noetic-catkin"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev"
+depends_dev="ros-noetic-diagnostic-msgs-dev ros-noetic-python-qt-binding-dev>=0.2.19 ros-noetic-qt-gui-dev ros-noetic-qt-gui-py-common-dev ros-noetic-rospy-dev ros-noetic-rqt-bag-dev ros-noetic-rqt-gui-dev ros-noetic-rqt-gui-py-dev ros-noetic-rqt-py-common-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-rqt-robot-plugins/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-rqt-robot-plugins/APKBUILD
@@ -7,10 +7,11 @@ url="http://ros.org/wiki/rqt_robot_plugins"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-rqt-moveit ros-noetic-rqt-nav-view ros-noetic-rqt-pose-view ros-noetic-rqt-robot-dashboard ros-noetic-rqt-robot-monitor ros-noetic-rqt-robot-steering ros-noetic-rqt-runtime-monitor ros-noetic-rqt-rviz ros-noetic-rqt-tf-tree ros-noetic-rqt-moveit ros-noetic-rqt-nav-view ros-noetic-rqt-pose-view ros-noetic-rqt-robot-dashboard ros-noetic-rqt-robot-monitor ros-noetic-rqt-robot-steering ros-noetic-rqt-runtime-monitor ros-noetic-rqt-rviz ros-noetic-rqt-tf-tree"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin"
+depends="ros-noetic-rqt-moveit ros-noetic-rqt-nav-view ros-noetic-rqt-pose-view ros-noetic-rqt-robot-dashboard ros-noetic-rqt-robot-monitor ros-noetic-rqt-robot-steering ros-noetic-rqt-runtime-monitor ros-noetic-rqt-rviz ros-noetic-rqt-tf-tree"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev"
+depends_dev="ros-noetic-rqt-moveit ros-noetic-rqt-moveit-dev ros-noetic-rqt-nav-view ros-noetic-rqt-nav-view-dev ros-noetic-rqt-pose-view ros-noetic-rqt-pose-view-dev ros-noetic-rqt-robot-dashboard ros-noetic-rqt-robot-dashboard-dev ros-noetic-rqt-robot-monitor ros-noetic-rqt-robot-monitor-dev ros-noetic-rqt-robot-steering ros-noetic-rqt-robot-steering-dev ros-noetic-rqt-runtime-monitor ros-noetic-rqt-runtime-monitor-dev ros-noetic-rqt-rviz ros-noetic-rqt-rviz-dev ros-noetic-rqt-tf-tree ros-noetic-rqt-tf-tree-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-rqt-robot-steering/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-rqt-robot-steering/APKBUILD
@@ -8,9 +8,10 @@ arch="all"
 license="BSD"
 
 depends="py3-rospkg ros-noetic-geometry-msgs ros-noetic-python-qt-binding>=0.2.19 ros-noetic-rostopic ros-noetic-rqt-gui ros-noetic-rqt-gui-py"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev"
+depends_dev="ros-noetic-geometry-msgs-dev ros-noetic-python-qt-binding-dev>=0.2.19 ros-noetic-rostopic-dev ros-noetic-rqt-gui-dev ros-noetic-rqt-gui-py-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-rqt-runtime-monitor/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-rqt-runtime-monitor/APKBUILD
@@ -8,9 +8,10 @@ arch="all"
 license="BSD"
 
 depends="py3-rospkg ros-noetic-diagnostic-msgs ros-noetic-python-qt-binding>=0.2.19 ros-noetic-qt-gui ros-noetic-rospy ros-noetic-rqt-gui ros-noetic-rqt-gui-py"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath py3-setuptools ros-noetic-catkin"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev"
+depends_dev="ros-noetic-diagnostic-msgs-dev ros-noetic-python-qt-binding-dev>=0.2.19 ros-noetic-qt-gui-dev ros-noetic-rospy-dev ros-noetic-rqt-gui-dev ros-noetic-rqt-gui-py-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-rqt-rviz/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-rqt-rviz/APKBUILD
@@ -7,10 +7,11 @@ url="http://wiki.ros.org/rqt_rviz"
 arch="all"
 license="BSD"
 
-depends="boost-dev ros-noetic-pluginlib ros-noetic-rqt-gui ros-noetic-rqt-gui-cpp ros-noetic-rviz boost-dev ros-noetic-pluginlib ros-noetic-rqt-gui ros-noetic-rqt-gui-cpp ros-noetic-rviz"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath boost-dev qt5-qtbase-dev ros-noetic-catkin ros-noetic-class-loader ros-noetic-rqt-gui ros-noetic-rqt-gui-cpp ros-noetic-rviz"
+depends="ros-noetic-pluginlib ros-noetic-rqt-gui ros-noetic-rqt-gui-cpp ros-noetic-rviz"
+makedepends="boost-dev chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool qt5-qtbase-dev ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-class-loader ros-noetic-class-loader-dev ros-noetic-rqt-gui ros-noetic-rqt-gui-cpp ros-noetic-rqt-gui-cpp-dev ros-noetic-rqt-gui-dev ros-noetic-rviz ros-noetic-rviz-dev"
+depends_dev="boost-dev ros-noetic-pluginlib ros-noetic-pluginlib-dev ros-noetic-rqt-gui ros-noetic-rqt-gui-cpp ros-noetic-rqt-gui-cpp-dev ros-noetic-rqt-gui-dev ros-noetic-rviz ros-noetic-rviz-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-rqt-service-caller/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-rqt-service-caller/APKBUILD
@@ -8,9 +8,10 @@ arch="all"
 license="BSD"
 
 depends="py3-rospkg ros-noetic-rosservice ros-noetic-rqt-gui ros-noetic-rqt-gui-py ros-noetic-rqt-py-common"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev"
+depends_dev="ros-noetic-rosservice-dev ros-noetic-rqt-gui-dev ros-noetic-rqt-gui-py-dev ros-noetic-rqt-py-common-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-rqt-shell/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-rqt-shell/APKBUILD
@@ -8,9 +8,10 @@ arch="all"
 license="BSD"
 
 depends="py3-rospkg ros-noetic-python-qt-binding>=0.2.19 ros-noetic-qt-gui ros-noetic-qt-gui-py-common ros-noetic-rqt-gui ros-noetic-rqt-gui-py"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev"
+depends_dev="ros-noetic-python-qt-binding-dev>=0.2.19 ros-noetic-qt-gui-dev ros-noetic-qt-gui-py-common-dev ros-noetic-rqt-gui-dev ros-noetic-rqt-gui-py-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-rqt-srv/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-rqt-srv/APKBUILD
@@ -7,10 +7,11 @@ url="http://wiki.ros.org/rqt_srv"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-rosmsg ros-noetic-rospy ros-noetic-rqt-gui ros-noetic-rqt-gui-py ros-noetic-rqt-msg ros-noetic-rosmsg ros-noetic-rospy ros-noetic-rqt-gui ros-noetic-rqt-gui-py ros-noetic-rqt-msg"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin"
+depends="ros-noetic-rosmsg ros-noetic-rospy ros-noetic-rqt-gui ros-noetic-rqt-gui-py ros-noetic-rqt-msg"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev"
+depends_dev="ros-noetic-rosmsg ros-noetic-rosmsg-dev ros-noetic-rospy ros-noetic-rospy-dev ros-noetic-rqt-gui ros-noetic-rqt-gui-dev ros-noetic-rqt-gui-py ros-noetic-rqt-gui-py-dev ros-noetic-rqt-msg ros-noetic-rqt-msg-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-rqt-tf-tree/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-rqt-tf-tree/APKBUILD
@@ -8,9 +8,10 @@ arch="all"
 license="BSD"
 
 depends="py3-rospkg ros-noetic-python-qt-binding>=0.2.19 ros-noetic-qt-dotgraph ros-noetic-rospy ros-noetic-rqt-graph ros-noetic-rqt-gui ros-noetic-rqt-gui-py ros-noetic-tf2-msgs ros-noetic-tf2-ros"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath py3-mock py3-setuptools ros-noetic-catkin"
+makedepends="chrpath py3-mock py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev"
+depends_dev="ros-noetic-python-qt-binding-dev>=0.2.19 ros-noetic-qt-dotgraph-dev ros-noetic-rospy-dev ros-noetic-rqt-graph-dev ros-noetic-rqt-gui-dev ros-noetic-rqt-gui-py-dev ros-noetic-tf2-msgs-dev ros-noetic-tf2-ros-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-rqt-top/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-rqt-top/APKBUILD
@@ -8,9 +8,10 @@ arch="all"
 license="BSD"
 
 depends="py3-psutil ros-noetic-python-qt-binding>=0.2.19 ros-noetic-rospy ros-noetic-rqt-gui ros-noetic-rqt-gui-py"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev"
+depends_dev="ros-noetic-python-qt-binding-dev>=0.2.19 ros-noetic-rospy-dev ros-noetic-rqt-gui-dev ros-noetic-rqt-gui-py-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-rqt-topic/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-rqt-topic/APKBUILD
@@ -8,9 +8,10 @@ arch="all"
 license="BSD"
 
 depends="py3-rospkg ros-noetic-python-qt-binding>=0.2.19 ros-noetic-rostopic ros-noetic-rqt-gui ros-noetic-rqt-gui-py ros-noetic-std-msgs"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev"
+depends_dev="ros-noetic-python-qt-binding-dev>=0.2.19 ros-noetic-rostopic-dev ros-noetic-rqt-gui-dev ros-noetic-rqt-gui-py-dev ros-noetic-std-msgs-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-rqt-web/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-rqt-web/APKBUILD
@@ -8,9 +8,10 @@ arch="all"
 license="BSD"
 
 depends="py3-rospkg ros-noetic-python-qt-binding>=0.2.19 ros-noetic-qt-gui ros-noetic-rospy ros-noetic-rqt-gui ros-noetic-rqt-gui-py ros-noetic-webkit-dependency"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev"
+depends_dev="ros-noetic-python-qt-binding-dev>=0.2.19 ros-noetic-qt-gui-dev ros-noetic-rospy-dev ros-noetic-rqt-gui-dev ros-noetic-rqt-gui-py-dev ros-noetic-webkit-dependency-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-rviz-imu-plugin/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-rviz-imu-plugin/APKBUILD
@@ -7,10 +7,11 @@ url="http://ros.org/wiki/rviz_imu_plugin"
 arch="all"
 license="BSD"
 
-depends="qt5-qtbase-dev ros-noetic-roscpp ros-noetic-rviz qt5-qtbase-dev ros-noetic-roscpp ros-noetic-rviz"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath qt5-qtbase-dev ros-noetic-catkin ros-noetic-roscpp ros-noetic-rviz"
+depends="ros-noetic-roscpp ros-noetic-rviz"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool qt5-qtbase-dev ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-rviz ros-noetic-rviz-dev"
+depends_dev="qt5-qtbase-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-rviz ros-noetic-rviz-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-rviz/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-rviz/APKBUILD
@@ -7,10 +7,11 @@ url="http://wiki.ros.org/rviz"
 arch="all"
 license="BSD"
 
-depends="assimp-dev glu-dev mesa-dev ogre qt5-qtbase-dev ros-noetic-geometry-msgs ros-noetic-image-transport ros-noetic-interactive-markers ros-noetic-laser-geometry ros-noetic-map-msgs ros-noetic-media-export ros-noetic-message-filters ros-noetic-message-runtime ros-noetic-nav-msgs ros-noetic-pluginlib ros-noetic-python-qt-binding ros-noetic-resource-retriever ros-noetic-rosconsole ros-noetic-roscpp ros-noetic-roslib ros-noetic-rospy ros-noetic-sensor-msgs ros-noetic-std-msgs ros-noetic-std-srvs ros-noetic-tf2-geometry-msgs ros-noetic-tf2-ros ros-noetic-urdf ros-noetic-visualization-msgs tinyxml2-dev yaml-cpp-dev assimp-dev glu-dev mesa-dev ogre ogre-dev ros-noetic-geometry-msgs ros-noetic-image-transport ros-noetic-interactive-markers ros-noetic-laser-geometry ros-noetic-map-msgs ros-noetic-message-filters ros-noetic-nav-msgs ros-noetic-pluginlib ros-noetic-python-qt-binding ros-noetic-resource-retriever ros-noetic-rosconsole ros-noetic-roscpp ros-noetic-roslib ros-noetic-rospy ros-noetic-sensor-msgs ros-noetic-std-msgs ros-noetic-std-srvs ros-noetic-tf2-geometry-msgs ros-noetic-tf2-ros ros-noetic-urdf ros-noetic-visualization-msgs tinyxml2-dev yaml-cpp-dev"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath assimp-dev eigen-dev glu-dev mesa-dev ogre ogre-dev qt5-qtbase-dev ros-noetic-catkin ros-noetic-cmake-modules ros-noetic-geometry-msgs ros-noetic-image-transport ros-noetic-interactive-markers ros-noetic-laser-geometry ros-noetic-map-msgs ros-noetic-message-filters ros-noetic-message-generation ros-noetic-nav-msgs ros-noetic-pluginlib ros-noetic-python-qt-binding ros-noetic-resource-retriever ros-noetic-rosconsole ros-noetic-roscpp ros-noetic-roslib ros-noetic-rospy ros-noetic-rostest ros-noetic-rosunit ros-noetic-sensor-msgs ros-noetic-std-msgs ros-noetic-std-srvs ros-noetic-tf2-geometry-msgs ros-noetic-tf2-ros ros-noetic-urdf ros-noetic-visualization-msgs tinyxml2-dev urdfdom-dev urdfdom_headers yaml-cpp-dev"
+depends="ogre ros-noetic-geometry-msgs ros-noetic-image-transport ros-noetic-interactive-markers ros-noetic-laser-geometry ros-noetic-map-msgs ros-noetic-media-export ros-noetic-message-filters ros-noetic-message-runtime ros-noetic-nav-msgs ros-noetic-pluginlib ros-noetic-python-qt-binding ros-noetic-resource-retriever ros-noetic-rosconsole ros-noetic-roscpp ros-noetic-roslib ros-noetic-rospy ros-noetic-sensor-msgs ros-noetic-std-msgs ros-noetic-std-srvs ros-noetic-tf2-geometry-msgs ros-noetic-tf2-ros ros-noetic-urdf ros-noetic-visualization-msgs"
+makedepends="assimp-dev chrpath eigen-dev glu-dev mesa-dev ogre ogre-dev py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool qt5-qtbase-dev ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-cmake-modules ros-noetic-cmake-modules-dev ros-noetic-geometry-msgs ros-noetic-geometry-msgs-dev ros-noetic-image-transport ros-noetic-image-transport-dev ros-noetic-interactive-markers ros-noetic-interactive-markers-dev ros-noetic-laser-geometry ros-noetic-laser-geometry-dev ros-noetic-map-msgs ros-noetic-map-msgs-dev ros-noetic-message-filters ros-noetic-message-filters-dev ros-noetic-message-generation ros-noetic-message-generation-dev ros-noetic-nav-msgs ros-noetic-nav-msgs-dev ros-noetic-pluginlib ros-noetic-pluginlib-dev ros-noetic-python-qt-binding ros-noetic-python-qt-binding-dev ros-noetic-resource-retriever ros-noetic-resource-retriever-dev ros-noetic-rosconsole ros-noetic-rosconsole-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-roslib ros-noetic-roslib-dev ros-noetic-rospy ros-noetic-rospy-dev ros-noetic-rostest ros-noetic-rostest-dev ros-noetic-rosunit ros-noetic-rosunit-dev ros-noetic-sensor-msgs ros-noetic-sensor-msgs-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev ros-noetic-std-srvs ros-noetic-std-srvs-dev ros-noetic-tf2-geometry-msgs ros-noetic-tf2-geometry-msgs-dev ros-noetic-tf2-ros ros-noetic-tf2-ros-dev ros-noetic-urdf ros-noetic-urdf-dev ros-noetic-visualization-msgs ros-noetic-visualization-msgs-dev tinyxml2-dev urdfdom-dev urdfdom_headers yaml-cpp-dev"
+depends_dev="assimp-dev glu-dev mesa-dev ogre ogre-dev qt5-qtbase-dev ros-noetic-geometry-msgs ros-noetic-geometry-msgs-dev ros-noetic-image-transport ros-noetic-image-transport-dev ros-noetic-interactive-markers ros-noetic-interactive-markers-dev ros-noetic-laser-geometry ros-noetic-laser-geometry-dev ros-noetic-map-msgs ros-noetic-map-msgs-dev ros-noetic-media-export-dev ros-noetic-message-filters ros-noetic-message-filters-dev ros-noetic-message-runtime-dev ros-noetic-nav-msgs ros-noetic-nav-msgs-dev ros-noetic-pluginlib ros-noetic-pluginlib-dev ros-noetic-python-qt-binding ros-noetic-python-qt-binding-dev ros-noetic-resource-retriever ros-noetic-resource-retriever-dev ros-noetic-rosconsole ros-noetic-rosconsole-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-roslib ros-noetic-roslib-dev ros-noetic-rospy ros-noetic-rospy-dev ros-noetic-sensor-msgs ros-noetic-sensor-msgs-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev ros-noetic-std-srvs ros-noetic-std-srvs-dev ros-noetic-tf2-geometry-msgs ros-noetic-tf2-geometry-msgs-dev ros-noetic-tf2-ros ros-noetic-tf2-ros-dev ros-noetic-urdf ros-noetic-urdf-dev ros-noetic-visualization-msgs ros-noetic-visualization-msgs-dev tinyxml2-dev yaml-cpp-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-safety-limiter-msgs/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-safety-limiter-msgs/APKBUILD
@@ -7,10 +7,11 @@ url="http://wiki.ros.org/$_pkgname"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-message-runtime ros-noetic-std-msgs ros-noetic-message-runtime ros-noetic-std-msgs"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin ros-noetic-message-generation ros-noetic-std-msgs"
+depends="ros-noetic-message-runtime ros-noetic-std-msgs"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-message-generation ros-noetic-message-generation-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev"
+depends_dev="ros-noetic-message-runtime ros-noetic-message-runtime-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-safety-limiter/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-safety-limiter/APKBUILD
@@ -7,10 +7,11 @@ url="http://wiki.ros.org/$_pkgname"
 arch="all"
 license="BSD"
 
-depends="eigen-dev pcl ros-noetic-diagnostic-updater ros-noetic-dynamic-reconfigure ros-noetic-geometry-msgs ros-noetic-neonavigation-common ros-noetic-pcl-conversions ros-noetic-pcl-ros ros-noetic-roscpp ros-noetic-safety-limiter-msgs ros-noetic-sensor-msgs ros-noetic-std-msgs ros-noetic-tf2-ros ros-noetic-tf2-sensor-msgs ros-noetic-xmlrpcpp eigen-dev ros-noetic-diagnostic-updater ros-noetic-dynamic-reconfigure ros-noetic-geometry-msgs ros-noetic-neonavigation-common ros-noetic-pcl-conversions ros-noetic-pcl-ros ros-noetic-roscpp ros-noetic-safety-limiter-msgs ros-noetic-sensor-msgs ros-noetic-std-msgs ros-noetic-tf2-ros ros-noetic-tf2-sensor-msgs ros-noetic-xmlrpcpp"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath eigen-dev pcl-dev ros-noetic-catkin ros-noetic-diagnostic-updater ros-noetic-dynamic-reconfigure ros-noetic-geometry-msgs ros-noetic-nav-msgs ros-noetic-neonavigation-common ros-noetic-pcl-conversions ros-noetic-pcl-ros ros-noetic-roscpp ros-noetic-roslint ros-noetic-rostest ros-noetic-safety-limiter-msgs ros-noetic-sensor-msgs ros-noetic-std-msgs ros-noetic-tf2-geometry-msgs ros-noetic-tf2-ros ros-noetic-tf2-sensor-msgs ros-noetic-xmlrpcpp"
+depends="pcl ros-noetic-diagnostic-updater ros-noetic-dynamic-reconfigure ros-noetic-geometry-msgs ros-noetic-neonavigation-common ros-noetic-pcl-conversions ros-noetic-pcl-ros ros-noetic-roscpp ros-noetic-safety-limiter-msgs ros-noetic-sensor-msgs ros-noetic-std-msgs ros-noetic-tf2-ros ros-noetic-tf2-sensor-msgs ros-noetic-xmlrpcpp"
+makedepends="chrpath eigen-dev pcl-dev py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-diagnostic-updater ros-noetic-diagnostic-updater-dev ros-noetic-dynamic-reconfigure ros-noetic-dynamic-reconfigure-dev ros-noetic-geometry-msgs ros-noetic-geometry-msgs-dev ros-noetic-nav-msgs ros-noetic-nav-msgs-dev ros-noetic-neonavigation-common ros-noetic-neonavigation-common-dev ros-noetic-pcl-conversions ros-noetic-pcl-conversions-dev ros-noetic-pcl-ros ros-noetic-pcl-ros-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-roslint ros-noetic-roslint-dev ros-noetic-rostest ros-noetic-rostest-dev ros-noetic-safety-limiter-msgs ros-noetic-safety-limiter-msgs-dev ros-noetic-sensor-msgs ros-noetic-sensor-msgs-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev ros-noetic-tf2-geometry-msgs ros-noetic-tf2-geometry-msgs-dev ros-noetic-tf2-ros ros-noetic-tf2-ros-dev ros-noetic-tf2-sensor-msgs ros-noetic-tf2-sensor-msgs-dev ros-noetic-xmlrpcpp ros-noetic-xmlrpcpp-dev"
+depends_dev="eigen-dev ros-noetic-diagnostic-updater ros-noetic-diagnostic-updater-dev ros-noetic-dynamic-reconfigure ros-noetic-dynamic-reconfigure-dev ros-noetic-geometry-msgs ros-noetic-geometry-msgs-dev ros-noetic-neonavigation-common ros-noetic-neonavigation-common-dev ros-noetic-pcl-conversions ros-noetic-pcl-conversions-dev ros-noetic-pcl-ros ros-noetic-pcl-ros-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-safety-limiter-msgs ros-noetic-safety-limiter-msgs-dev ros-noetic-sensor-msgs ros-noetic-sensor-msgs-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev ros-noetic-tf2-ros ros-noetic-tf2-ros-dev ros-noetic-tf2-sensor-msgs ros-noetic-tf2-sensor-msgs-dev ros-noetic-xmlrpcpp ros-noetic-xmlrpcpp-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-self-test/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-self-test/APKBUILD
@@ -7,10 +7,11 @@ url="http://www.ros.org/wiki/self_test"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-diagnostic-msgs ros-noetic-diagnostic-updater ros-noetic-roscpp ros-noetic-diagnostic-msgs ros-noetic-diagnostic-updater ros-noetic-roscpp"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin ros-noetic-diagnostic-msgs ros-noetic-diagnostic-updater ros-noetic-roscpp ros-noetic-rostest"
+depends="ros-noetic-diagnostic-msgs ros-noetic-diagnostic-updater ros-noetic-roscpp"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-diagnostic-msgs ros-noetic-diagnostic-msgs-dev ros-noetic-diagnostic-updater ros-noetic-diagnostic-updater-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-rostest ros-noetic-rostest-dev"
+depends_dev="ros-noetic-diagnostic-msgs ros-noetic-diagnostic-msgs-dev ros-noetic-diagnostic-updater ros-noetic-diagnostic-updater-dev ros-noetic-roscpp ros-noetic-roscpp-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-sensor-msgs/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-sensor-msgs/APKBUILD
@@ -8,9 +8,10 @@ arch="all"
 license="BSD"
 
 depends="ros-noetic-geometry-msgs ros-noetic-message-runtime ros-noetic-std-msgs"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath py3-setuptools ros-noetic-catkin ros-noetic-geometry-msgs ros-noetic-message-generation ros-noetic-rosbag ros-noetic-rosunit ros-noetic-std-msgs"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-geometry-msgs ros-noetic-geometry-msgs-dev ros-noetic-message-generation ros-noetic-message-generation-dev ros-noetic-rosbag ros-noetic-rosbag-dev ros-noetic-rosunit ros-noetic-rosunit-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev"
+depends_dev="ros-noetic-geometry-msgs-dev ros-noetic-message-runtime-dev ros-noetic-std-msgs-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-shape-msgs/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-shape-msgs/APKBUILD
@@ -7,10 +7,11 @@ url="http://wiki.ros.org/shape_msgs"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-geometry-msgs ros-noetic-message-runtime ros-noetic-std-msgs ros-noetic-geometry-msgs ros-noetic-message-runtime ros-noetic-std-msgs"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin ros-noetic-geometry-msgs ros-noetic-message-generation ros-noetic-std-msgs"
+depends="ros-noetic-geometry-msgs ros-noetic-message-runtime ros-noetic-std-msgs"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-geometry-msgs ros-noetic-geometry-msgs-dev ros-noetic-message-generation ros-noetic-message-generation-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev"
+depends_dev="ros-noetic-geometry-msgs ros-noetic-geometry-msgs-dev ros-noetic-message-runtime ros-noetic-message-runtime-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-smach-msgs/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-smach-msgs/APKBUILD
@@ -7,10 +7,11 @@ url="http://wiki.ros.org/$_pkgname"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-message-runtime ros-noetic-std-msgs ros-noetic-message-runtime ros-noetic-std-msgs"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin ros-noetic-message-generation ros-noetic-std-msgs"
+depends="ros-noetic-message-runtime ros-noetic-std-msgs"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-message-generation ros-noetic-message-generation-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev"
+depends_dev="ros-noetic-message-runtime ros-noetic-message-runtime-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-smach-ros/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-smach-ros/APKBUILD
@@ -8,9 +8,10 @@ arch="all"
 license="BSD"
 
 depends="ros-noetic-actionlib ros-noetic-actionlib-msgs ros-noetic-rospy ros-noetic-rostopic ros-noetic-smach ros-noetic-smach-msgs ros-noetic-std-msgs ros-noetic-std-srvs"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin ros-noetic-rostest"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-rostest ros-noetic-rostest-dev"
+depends_dev="ros-noetic-actionlib-dev ros-noetic-actionlib-msgs-dev ros-noetic-rospy-dev ros-noetic-rostopic-dev ros-noetic-smach-dev ros-noetic-smach-msgs-dev ros-noetic-std-msgs-dev ros-noetic-std-srvs-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-smach-viewer/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-smach-viewer/APKBUILD
@@ -7,10 +7,11 @@ url="http://ros.org/wiki/smach_viewer"
 arch="all"
 license="BSD"
 
-depends="graphviz gtk+3.0-dev py3-gobject3 py3-qt5 py3-rospkg py3-sip4 py3-sip4-dev py3-wxpython py3-xdot ros-noetic-cv-bridge ros-noetic-smach-msgs ros-noetic-smach-ros"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin ros-noetic-rostest"
+depends="graphviz py3-gobject3 py3-qt5 py3-rospkg py3-sip4 py3-wxpython py3-xdot ros-noetic-cv-bridge ros-noetic-smach-msgs ros-noetic-smach-ros"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-rostest ros-noetic-rostest-dev"
+depends_dev="gtk+3.0-dev py3-sip4-dev ros-noetic-cv-bridge-dev ros-noetic-smach-msgs-dev ros-noetic-smach-ros-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-smach/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-smach/APKBUILD
@@ -8,9 +8,10 @@ arch="all"
 license="BSD"
 
 depends=""
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev"
+depends_dev=""
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-smclib/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-smclib/APKBUILD
@@ -8,9 +8,10 @@ arch="all"
 license="Mozilla Public License Version 1.1"
 
 depends=""
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath py3-setuptools ros-noetic-catkin"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev"
+depends_dev=""
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-sound-play/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-sound-play/APKBUILD
@@ -8,9 +8,10 @@ arch="all"
 license="BSD"
 
 depends="festival festvox-kallpc16k flite gst-plugins-base gst-plugins-good gst-plugins-ugly gstreamer py3-gobject3 ros-noetic-actionlib-msgs ros-noetic-audio-common-msgs ros-noetic-diagnostic-msgs ros-noetic-message-runtime ros-noetic-resource-retriever ros-noetic-roscpp ros-noetic-roslib ros-noetic-rospy"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath py3-setuptools ros-noetic-actionlib ros-noetic-actionlib-msgs ros-noetic-audio-common-msgs ros-noetic-catkin ros-noetic-diagnostic-msgs ros-noetic-message-generation ros-noetic-roscpp ros-noetic-roslib"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-actionlib ros-noetic-actionlib-dev ros-noetic-actionlib-msgs ros-noetic-actionlib-msgs-dev ros-noetic-audio-common-msgs ros-noetic-audio-common-msgs-dev ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-diagnostic-msgs ros-noetic-diagnostic-msgs-dev ros-noetic-message-generation ros-noetic-message-generation-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-roslib ros-noetic-roslib-dev"
+depends_dev="ros-noetic-actionlib-msgs-dev ros-noetic-audio-common-msgs-dev ros-noetic-diagnostic-msgs-dev ros-noetic-message-runtime-dev ros-noetic-resource-retriever-dev ros-noetic-roscpp-dev ros-noetic-roslib-dev ros-noetic-rospy-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-std-msgs/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-std-msgs/APKBUILD
@@ -7,10 +7,11 @@ url="http://www.ros.org/wiki/std_msgs"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-message-runtime ros-noetic-message-runtime"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin ros-noetic-message-generation"
+depends="ros-noetic-message-runtime"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-message-generation ros-noetic-message-generation-dev"
+depends_dev="ros-noetic-message-runtime ros-noetic-message-runtime-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-std-srvs/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-std-srvs/APKBUILD
@@ -7,10 +7,11 @@ url="http://ros.org/wiki/std_srvs"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-message-runtime ros-noetic-message-runtime"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin ros-noetic-message-generation"
+depends="ros-noetic-message-runtime"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-message-generation ros-noetic-message-generation-dev"
+depends_dev="ros-noetic-message-runtime ros-noetic-message-runtime-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-stereo-image-proc/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-stereo-image-proc/APKBUILD
@@ -7,10 +7,11 @@ url="http://www.ros.org/wiki/stereo_image_proc"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-cv-bridge ros-noetic-dynamic-reconfigure ros-noetic-image-geometry ros-noetic-image-proc ros-noetic-image-transport ros-noetic-message-filters ros-noetic-nodelet ros-noetic-sensor-msgs ros-noetic-stereo-msgs ros-noetic-cv-bridge ros-noetic-dynamic-reconfigure ros-noetic-image-geometry ros-noetic-image-proc ros-noetic-image-transport ros-noetic-message-filters ros-noetic-nodelet ros-noetic-sensor-msgs ros-noetic-stereo-msgs"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin ros-noetic-cv-bridge ros-noetic-dynamic-reconfigure ros-noetic-image-geometry ros-noetic-image-proc ros-noetic-image-transport ros-noetic-message-filters ros-noetic-nodelet ros-noetic-rostest ros-noetic-sensor-msgs ros-noetic-stereo-msgs"
+depends="ros-noetic-cv-bridge ros-noetic-dynamic-reconfigure ros-noetic-image-geometry ros-noetic-image-proc ros-noetic-image-transport ros-noetic-message-filters ros-noetic-nodelet ros-noetic-sensor-msgs ros-noetic-stereo-msgs"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-cv-bridge ros-noetic-cv-bridge-dev ros-noetic-dynamic-reconfigure ros-noetic-dynamic-reconfigure-dev ros-noetic-image-geometry ros-noetic-image-geometry-dev ros-noetic-image-proc ros-noetic-image-proc-dev ros-noetic-image-transport ros-noetic-image-transport-dev ros-noetic-message-filters ros-noetic-message-filters-dev ros-noetic-nodelet ros-noetic-nodelet-dev ros-noetic-rostest ros-noetic-rostest-dev ros-noetic-sensor-msgs ros-noetic-sensor-msgs-dev ros-noetic-stereo-msgs ros-noetic-stereo-msgs-dev"
+depends_dev="ros-noetic-cv-bridge ros-noetic-cv-bridge-dev ros-noetic-dynamic-reconfigure ros-noetic-dynamic-reconfigure-dev ros-noetic-image-geometry ros-noetic-image-geometry-dev ros-noetic-image-proc ros-noetic-image-proc-dev ros-noetic-image-transport ros-noetic-image-transport-dev ros-noetic-message-filters ros-noetic-message-filters-dev ros-noetic-nodelet ros-noetic-nodelet-dev ros-noetic-sensor-msgs ros-noetic-sensor-msgs-dev ros-noetic-stereo-msgs ros-noetic-stereo-msgs-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-stereo-msgs/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-stereo-msgs/APKBUILD
@@ -7,10 +7,11 @@ url="http://wiki.ros.org/stereo_msgs"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-message-runtime ros-noetic-sensor-msgs ros-noetic-std-msgs ros-noetic-message-runtime ros-noetic-sensor-msgs ros-noetic-std-msgs"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin ros-noetic-message-generation ros-noetic-sensor-msgs ros-noetic-std-msgs"
+depends="ros-noetic-message-runtime ros-noetic-sensor-msgs ros-noetic-std-msgs"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-message-generation ros-noetic-message-generation-dev ros-noetic-sensor-msgs ros-noetic-sensor-msgs-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev"
+depends_dev="ros-noetic-message-runtime ros-noetic-message-runtime-dev ros-noetic-sensor-msgs ros-noetic-sensor-msgs-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-tf-conversions/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-tf-conversions/APKBUILD
@@ -7,10 +7,11 @@ url="http://www.ros.org/wiki/tf_conversions"
 arch="all"
 license="BSD"
 
-depends="eigen-dev orocos-kdl py3-kdl ros-noetic-geometry-msgs ros-noetic-kdl-conversions ros-noetic-tf orocos-kdl-dev"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath eigen-dev orocos-kdl-dev ros-noetic-catkin>=0.5.68 ros-noetic-geometry-msgs ros-noetic-kdl-conversions ros-noetic-tf"
+depends="orocos-kdl py3-kdl ros-noetic-geometry-msgs ros-noetic-kdl-conversions ros-noetic-tf"
+makedepends="chrpath eigen-dev orocos-kdl-dev py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin-dev>=0.5.68 ros-noetic-catkin>=0.5.68 ros-noetic-geometry-msgs ros-noetic-geometry-msgs-dev ros-noetic-kdl-conversions ros-noetic-kdl-conversions-dev ros-noetic-tf ros-noetic-tf-dev"
+depends_dev="eigen-dev orocos-kdl-dev ros-noetic-geometry-msgs-dev ros-noetic-kdl-conversions-dev ros-noetic-tf-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-tf/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-tf/APKBUILD
@@ -7,10 +7,11 @@ url="http://www.ros.org/wiki/tf"
 arch="all"
 license="BSD"
 
-depends="graphviz ros-noetic-geometry-msgs ros-noetic-message-filters>=1.11.1 ros-noetic-message-runtime ros-noetic-rosconsole ros-noetic-roscpp ros-noetic-roswtf ros-noetic-sensor-msgs ros-noetic-std-msgs ros-noetic-tf2-ros>=0.5.16 graphviz ros-noetic-geometry-msgs ros-noetic-message-filters>=1.11.1 ros-noetic-message-runtime ros-noetic-rosconsole ros-noetic-roscpp ros-noetic-roswtf ros-noetic-sensor-msgs ros-noetic-std-msgs ros-noetic-tf2-ros>=0.5.16"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-angles ros-noetic-catkin>=0.6.4 ros-noetic-geometry-msgs ros-noetic-message-filters ros-noetic-message-generation ros-noetic-rosconsole ros-noetic-roscpp ros-noetic-rostest ros-noetic-rostime ros-noetic-rosunit ros-noetic-sensor-msgs ros-noetic-std-msgs ros-noetic-tf2-ros>=0.5.16"
+depends="graphviz ros-noetic-geometry-msgs ros-noetic-message-filters>=1.11.1 ros-noetic-message-runtime ros-noetic-rosconsole ros-noetic-roscpp ros-noetic-roswtf ros-noetic-sensor-msgs ros-noetic-std-msgs ros-noetic-tf2-ros>=0.5.16"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-angles ros-noetic-angles-dev ros-noetic-catkin-dev>=0.6.4 ros-noetic-catkin>=0.6.4 ros-noetic-geometry-msgs ros-noetic-geometry-msgs-dev ros-noetic-message-filters ros-noetic-message-filters-dev ros-noetic-message-generation ros-noetic-message-generation-dev ros-noetic-rosconsole ros-noetic-rosconsole-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-rostest ros-noetic-rostest-dev ros-noetic-rostime ros-noetic-rostime-dev ros-noetic-rosunit ros-noetic-rosunit-dev ros-noetic-sensor-msgs ros-noetic-sensor-msgs-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev ros-noetic-tf2-ros-dev>=0.5.16 ros-noetic-tf2-ros>=0.5.16"
+depends_dev="graphviz ros-noetic-geometry-msgs ros-noetic-geometry-msgs-dev ros-noetic-message-filters-dev>=1.11.1 ros-noetic-message-filters>=1.11.1 ros-noetic-message-runtime ros-noetic-message-runtime-dev ros-noetic-rosconsole ros-noetic-rosconsole-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-roswtf ros-noetic-roswtf-dev ros-noetic-sensor-msgs ros-noetic-sensor-msgs-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev ros-noetic-tf2-ros-dev>=0.5.16 ros-noetic-tf2-ros>=0.5.16"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-tf2-eigen/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-tf2-eigen/APKBUILD
@@ -7,10 +7,11 @@ url="http://wiki.ros.org/$_pkgname"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-geometry-msgs ros-noetic-tf2 eigen-dev ros-noetic-geometry-msgs ros-noetic-tf2"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath eigen-dev ros-noetic-catkin ros-noetic-cmake-modules ros-noetic-geometry-msgs ros-noetic-tf2"
+depends="ros-noetic-geometry-msgs ros-noetic-tf2"
+makedepends="chrpath eigen-dev py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-cmake-modules ros-noetic-cmake-modules-dev ros-noetic-geometry-msgs ros-noetic-geometry-msgs-dev ros-noetic-tf2 ros-noetic-tf2-dev"
+depends_dev="eigen-dev ros-noetic-geometry-msgs ros-noetic-geometry-msgs-dev ros-noetic-tf2 ros-noetic-tf2-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-tf2-geometry-msgs/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-tf2-geometry-msgs/APKBUILD
@@ -7,10 +7,11 @@ url="http://www.ros.org/wiki/tf2_ros"
 arch="all"
 license="BSD"
 
-depends="orocos-kdl-dev py3-kdl ros-noetic-geometry-msgs ros-noetic-tf2 ros-noetic-tf2-ros orocos-kdl-dev ros-noetic-geometry-msgs ros-noetic-tf2 ros-noetic-tf2-ros"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath orocos-kdl-dev py3-kdl ros-noetic-catkin>=0.5.68 ros-noetic-geometry-msgs ros-noetic-ros-environment ros-noetic-rostest ros-noetic-tf2 ros-noetic-tf2-ros"
+depends="py3-kdl ros-noetic-geometry-msgs ros-noetic-tf2 ros-noetic-tf2-ros"
+makedepends="chrpath orocos-kdl-dev py3-kdl py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin-dev>=0.5.68 ros-noetic-catkin>=0.5.68 ros-noetic-geometry-msgs ros-noetic-geometry-msgs-dev ros-noetic-ros-environment ros-noetic-ros-environment-dev ros-noetic-rostest ros-noetic-rostest-dev ros-noetic-tf2 ros-noetic-tf2-dev ros-noetic-tf2-ros ros-noetic-tf2-ros-dev"
+depends_dev="orocos-kdl-dev ros-noetic-geometry-msgs ros-noetic-geometry-msgs-dev ros-noetic-tf2 ros-noetic-tf2-dev ros-noetic-tf2-ros ros-noetic-tf2-ros-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-tf2-kdl/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-tf2-kdl/APKBUILD
@@ -7,10 +7,11 @@ url="http://ros.org/wiki/tf2"
 arch="all"
 license="BSD"
 
-depends="orocos-kdl-dev ros-noetic-tf2 ros-noetic-tf2-ros eigen-dev orocos-kdl-dev ros-noetic-tf2 ros-noetic-tf2-ros"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath eigen-dev orocos-kdl-dev ros-noetic-catkin>=0.5.68 ros-noetic-cmake-modules ros-noetic-ros-environment ros-noetic-rostest ros-noetic-tf2 ros-noetic-tf2-ros"
+depends="ros-noetic-tf2 ros-noetic-tf2-ros"
+makedepends="chrpath eigen-dev orocos-kdl-dev py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin-dev>=0.5.68 ros-noetic-catkin>=0.5.68 ros-noetic-cmake-modules ros-noetic-cmake-modules-dev ros-noetic-ros-environment ros-noetic-ros-environment-dev ros-noetic-rostest ros-noetic-rostest-dev ros-noetic-tf2 ros-noetic-tf2-dev ros-noetic-tf2-ros ros-noetic-tf2-ros-dev"
+depends_dev="eigen-dev orocos-kdl-dev ros-noetic-tf2 ros-noetic-tf2-dev ros-noetic-tf2-ros ros-noetic-tf2-ros-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-tf2-msgs/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-tf2-msgs/APKBUILD
@@ -7,10 +7,11 @@ url="http://www.ros.org/wiki/tf2_msgs"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-actionlib-msgs ros-noetic-geometry-msgs ros-noetic-message-generation ros-noetic-actionlib-msgs ros-noetic-geometry-msgs ros-noetic-message-generation"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-actionlib-msgs ros-noetic-catkin ros-noetic-geometry-msgs ros-noetic-message-generation"
+depends="ros-noetic-actionlib-msgs ros-noetic-geometry-msgs ros-noetic-message-generation"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-actionlib-msgs ros-noetic-actionlib-msgs-dev ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-geometry-msgs ros-noetic-geometry-msgs-dev ros-noetic-message-generation ros-noetic-message-generation-dev"
+depends_dev="ros-noetic-actionlib-msgs ros-noetic-actionlib-msgs-dev ros-noetic-geometry-msgs ros-noetic-geometry-msgs-dev ros-noetic-message-generation ros-noetic-message-generation-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-tf2-py/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-tf2-py/APKBUILD
@@ -7,10 +7,11 @@ url="http://ros.org/wiki/tf2_py"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-rospy ros-noetic-tf2 ros-noetic-rospy ros-noetic-tf2"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin ros-noetic-rospy ros-noetic-tf2"
+depends="ros-noetic-rospy ros-noetic-tf2"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-rospy ros-noetic-rospy-dev ros-noetic-tf2 ros-noetic-tf2-dev"
+depends_dev="ros-noetic-rospy ros-noetic-rospy-dev ros-noetic-tf2 ros-noetic-tf2-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-tf2-ros/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-tf2-ros/APKBUILD
@@ -7,10 +7,11 @@ url="http://www.ros.org/wiki/tf2_ros"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-actionlib ros-noetic-actionlib-msgs ros-noetic-geometry-msgs ros-noetic-message-filters ros-noetic-roscpp ros-noetic-rosgraph ros-noetic-rospy ros-noetic-std-msgs ros-noetic-tf2 ros-noetic-tf2-msgs ros-noetic-tf2-py ros-noetic-xmlrpcpp ros-noetic-actionlib ros-noetic-actionlib-msgs ros-noetic-geometry-msgs ros-noetic-message-filters ros-noetic-roscpp ros-noetic-rosgraph ros-noetic-rospy ros-noetic-std-msgs ros-noetic-tf2 ros-noetic-tf2-msgs ros-noetic-tf2-py ros-noetic-xmlrpcpp"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-actionlib ros-noetic-actionlib-msgs ros-noetic-catkin>=0.5.68 ros-noetic-geometry-msgs ros-noetic-message-filters>=1.11.1 ros-noetic-roscpp ros-noetic-rosgraph ros-noetic-rospy ros-noetic-rostest ros-noetic-std-msgs ros-noetic-tf2 ros-noetic-tf2-msgs ros-noetic-tf2-py ros-noetic-xmlrpcpp"
+depends="ros-noetic-actionlib ros-noetic-actionlib-msgs ros-noetic-geometry-msgs ros-noetic-message-filters ros-noetic-roscpp ros-noetic-rosgraph ros-noetic-rospy ros-noetic-std-msgs ros-noetic-tf2 ros-noetic-tf2-msgs ros-noetic-tf2-py ros-noetic-xmlrpcpp"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-actionlib ros-noetic-actionlib-dev ros-noetic-actionlib-msgs ros-noetic-actionlib-msgs-dev ros-noetic-catkin-dev>=0.5.68 ros-noetic-catkin>=0.5.68 ros-noetic-geometry-msgs ros-noetic-geometry-msgs-dev ros-noetic-message-filters-dev>=1.11.1 ros-noetic-message-filters>=1.11.1 ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-rosgraph ros-noetic-rosgraph-dev ros-noetic-rospy ros-noetic-rospy-dev ros-noetic-rostest ros-noetic-rostest-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev ros-noetic-tf2 ros-noetic-tf2-dev ros-noetic-tf2-msgs ros-noetic-tf2-msgs-dev ros-noetic-tf2-py ros-noetic-tf2-py-dev ros-noetic-xmlrpcpp ros-noetic-xmlrpcpp-dev"
+depends_dev="ros-noetic-actionlib ros-noetic-actionlib-dev ros-noetic-actionlib-msgs ros-noetic-actionlib-msgs-dev ros-noetic-geometry-msgs ros-noetic-geometry-msgs-dev ros-noetic-message-filters ros-noetic-message-filters-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-rosgraph ros-noetic-rosgraph-dev ros-noetic-rospy ros-noetic-rospy-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev ros-noetic-tf2 ros-noetic-tf2-dev ros-noetic-tf2-msgs ros-noetic-tf2-msgs-dev ros-noetic-tf2-py ros-noetic-tf2-py-dev ros-noetic-xmlrpcpp ros-noetic-xmlrpcpp-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-tf2-sensor-msgs/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-tf2-sensor-msgs/APKBUILD
@@ -7,10 +7,11 @@ url="http://www.ros.org/wiki/tf2_ros"
 arch="all"
 license="BSD"
 
-depends="py3-kdl ros-noetic-rospy ros-noetic-sensor-msgs ros-noetic-tf2 ros-noetic-tf2-ros eigen-dev ros-noetic-sensor-msgs ros-noetic-tf2 ros-noetic-tf2-ros"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath eigen-dev ros-noetic-catkin>=0.5.6 ros-noetic-cmake-modules ros-noetic-geometry-msgs ros-noetic-rostest ros-noetic-sensor-msgs ros-noetic-tf2 ros-noetic-tf2-ros"
+depends="py3-kdl ros-noetic-rospy ros-noetic-sensor-msgs ros-noetic-tf2 ros-noetic-tf2-ros"
+makedepends="chrpath eigen-dev py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin-dev>=0.5.6 ros-noetic-catkin>=0.5.6 ros-noetic-cmake-modules ros-noetic-cmake-modules-dev ros-noetic-geometry-msgs ros-noetic-geometry-msgs-dev ros-noetic-rostest ros-noetic-rostest-dev ros-noetic-sensor-msgs ros-noetic-sensor-msgs-dev ros-noetic-tf2 ros-noetic-tf2-dev ros-noetic-tf2-ros ros-noetic-tf2-ros-dev"
+depends_dev="eigen-dev ros-noetic-rospy-dev ros-noetic-sensor-msgs ros-noetic-sensor-msgs-dev ros-noetic-tf2 ros-noetic-tf2-dev ros-noetic-tf2-ros ros-noetic-tf2-ros-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-tf2/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-tf2/APKBUILD
@@ -7,10 +7,11 @@ url="http://www.ros.org/wiki/tf2"
 arch="all"
 license="BSD"
 
-depends="console_bridge-dev ros-noetic-geometry-msgs ros-noetic-rostime ros-noetic-tf2-msgs console_bridge-dev ros-noetic-geometry-msgs ros-noetic-rostime ros-noetic-tf2-msgs"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath console_bridge-dev ros-noetic-catkin>=0.5.68 ros-noetic-geometry-msgs ros-noetic-rostime ros-noetic-tf2-msgs"
+depends="ros-noetic-geometry-msgs ros-noetic-rostime ros-noetic-tf2-msgs"
+makedepends="chrpath console_bridge-dev py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin-dev>=0.5.68 ros-noetic-catkin>=0.5.68 ros-noetic-geometry-msgs ros-noetic-geometry-msgs-dev ros-noetic-rostime ros-noetic-rostime-dev ros-noetic-tf2-msgs ros-noetic-tf2-msgs-dev"
+depends_dev="console_bridge-dev ros-noetic-geometry-msgs ros-noetic-geometry-msgs-dev ros-noetic-rostime ros-noetic-rostime-dev ros-noetic-tf2-msgs ros-noetic-tf2-msgs-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-theora-image-transport/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-theora-image-transport/APKBUILD
@@ -7,10 +7,11 @@ url="http://www.ros.org/wiki/image_transport_plugins"
 arch="all"
 license="BSD"
 
-depends="libogg-dev libtheora-dev ros-noetic-cv-bridge ros-noetic-dynamic-reconfigure ros-noetic-image-transport ros-noetic-message-runtime ros-noetic-pluginlib ros-noetic-rosbag ros-noetic-std-msgs libogg-dev libtheora-dev ros-noetic-cv-bridge ros-noetic-dynamic-reconfigure ros-noetic-image-transport ros-noetic-message-runtime ros-noetic-pluginlib ros-noetic-rosbag ros-noetic-std-msgs"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath libogg-dev libtheora-dev ros-noetic-catkin ros-noetic-cv-bridge ros-noetic-dynamic-reconfigure ros-noetic-image-transport ros-noetic-message-generation ros-noetic-pluginlib ros-noetic-rosbag ros-noetic-std-msgs"
+depends="ros-noetic-cv-bridge ros-noetic-dynamic-reconfigure ros-noetic-image-transport ros-noetic-message-runtime ros-noetic-pluginlib ros-noetic-rosbag ros-noetic-std-msgs"
+makedepends="chrpath libogg-dev libtheora-dev py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-cv-bridge ros-noetic-cv-bridge-dev ros-noetic-dynamic-reconfigure ros-noetic-dynamic-reconfigure-dev ros-noetic-image-transport ros-noetic-image-transport-dev ros-noetic-message-generation ros-noetic-message-generation-dev ros-noetic-pluginlib ros-noetic-pluginlib-dev ros-noetic-rosbag ros-noetic-rosbag-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev"
+depends_dev="libogg-dev libtheora-dev ros-noetic-cv-bridge ros-noetic-cv-bridge-dev ros-noetic-dynamic-reconfigure ros-noetic-dynamic-reconfigure-dev ros-noetic-image-transport ros-noetic-image-transport-dev ros-noetic-message-runtime ros-noetic-message-runtime-dev ros-noetic-pluginlib ros-noetic-pluginlib-dev ros-noetic-rosbag ros-noetic-rosbag-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-topic-tools/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-topic-tools/APKBUILD
@@ -7,10 +7,11 @@ url="http://ros.org/wiki/topic_tools"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-message-runtime ros-noetic-rosconsole ros-noetic-roscpp ros-noetic-rostime ros-noetic-std-msgs ros-noetic-xmlrpcpp ros-noetic-message-runtime ros-noetic-rosconsole ros-noetic-roscpp ros-noetic-rostime ros-noetic-std-msgs ros-noetic-xmlrpcpp"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin>=0.5.78 ros-noetic-cpp-common ros-noetic-message-generation ros-noetic-rosbash ros-noetic-rosconsole ros-noetic-roscpp ros-noetic-rostest ros-noetic-rostime ros-noetic-rosunit ros-noetic-std-msgs ros-noetic-xmlrpcpp"
+depends="ros-noetic-message-runtime ros-noetic-rosconsole ros-noetic-roscpp ros-noetic-rostime ros-noetic-std-msgs ros-noetic-xmlrpcpp"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin-dev>=0.5.78 ros-noetic-catkin>=0.5.78 ros-noetic-cpp-common ros-noetic-cpp-common-dev ros-noetic-message-generation ros-noetic-message-generation-dev ros-noetic-rosbash ros-noetic-rosbash-dev ros-noetic-rosconsole ros-noetic-rosconsole-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-rostest ros-noetic-rostest-dev ros-noetic-rostime ros-noetic-rostime-dev ros-noetic-rosunit ros-noetic-rosunit-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev ros-noetic-xmlrpcpp ros-noetic-xmlrpcpp-dev"
+depends_dev="ros-noetic-message-runtime ros-noetic-message-runtime-dev ros-noetic-rosconsole ros-noetic-rosconsole-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-rostime ros-noetic-rostime-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev ros-noetic-xmlrpcpp ros-noetic-xmlrpcpp-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-track-odometry/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-track-odometry/APKBUILD
@@ -7,10 +7,11 @@ url="http://wiki.ros.org/$_pkgname"
 arch="all"
 license="BSD"
 
-depends="eigen-dev ros-noetic-geometry-msgs ros-noetic-message-filters ros-noetic-nav-msgs ros-noetic-neonavigation-common ros-noetic-roscpp ros-noetic-sensor-msgs ros-noetic-std-msgs ros-noetic-tf2 ros-noetic-tf2-geometry-msgs ros-noetic-tf2-ros ros-noetic-trajectory-msgs eigen-dev ros-noetic-geometry-msgs ros-noetic-message-filters ros-noetic-nav-msgs ros-noetic-neonavigation-common ros-noetic-roscpp ros-noetic-sensor-msgs ros-noetic-std-msgs ros-noetic-tf2 ros-noetic-tf2-geometry-msgs ros-noetic-tf2-ros ros-noetic-trajectory-msgs"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath eigen-dev ros-noetic-catkin ros-noetic-geometry-msgs ros-noetic-message-filters ros-noetic-nav-msgs ros-noetic-neonavigation-common ros-noetic-roscpp ros-noetic-roslint ros-noetic-rostest ros-noetic-sensor-msgs ros-noetic-std-msgs ros-noetic-tf2 ros-noetic-tf2-geometry-msgs ros-noetic-tf2-ros ros-noetic-trajectory-msgs"
+depends="ros-noetic-geometry-msgs ros-noetic-message-filters ros-noetic-nav-msgs ros-noetic-neonavigation-common ros-noetic-roscpp ros-noetic-sensor-msgs ros-noetic-std-msgs ros-noetic-tf2 ros-noetic-tf2-geometry-msgs ros-noetic-tf2-ros ros-noetic-trajectory-msgs"
+makedepends="chrpath eigen-dev py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-geometry-msgs ros-noetic-geometry-msgs-dev ros-noetic-message-filters ros-noetic-message-filters-dev ros-noetic-nav-msgs ros-noetic-nav-msgs-dev ros-noetic-neonavigation-common ros-noetic-neonavigation-common-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-roslint ros-noetic-roslint-dev ros-noetic-rostest ros-noetic-rostest-dev ros-noetic-sensor-msgs ros-noetic-sensor-msgs-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev ros-noetic-tf2 ros-noetic-tf2-dev ros-noetic-tf2-geometry-msgs ros-noetic-tf2-geometry-msgs-dev ros-noetic-tf2-ros ros-noetic-tf2-ros-dev ros-noetic-trajectory-msgs ros-noetic-trajectory-msgs-dev"
+depends_dev="eigen-dev ros-noetic-geometry-msgs ros-noetic-geometry-msgs-dev ros-noetic-message-filters ros-noetic-message-filters-dev ros-noetic-nav-msgs ros-noetic-nav-msgs-dev ros-noetic-neonavigation-common ros-noetic-neonavigation-common-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-sensor-msgs ros-noetic-sensor-msgs-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev ros-noetic-tf2 ros-noetic-tf2-dev ros-noetic-tf2-geometry-msgs ros-noetic-tf2-geometry-msgs-dev ros-noetic-tf2-ros ros-noetic-tf2-ros-dev ros-noetic-trajectory-msgs ros-noetic-trajectory-msgs-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-trajectory-msgs/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-trajectory-msgs/APKBUILD
@@ -7,10 +7,11 @@ url="http://wiki.ros.org/trajectory_msgs"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-geometry-msgs ros-noetic-message-runtime ros-noetic-rosbag-migration-rule ros-noetic-std-msgs ros-noetic-geometry-msgs ros-noetic-message-runtime ros-noetic-rosbag-migration-rule ros-noetic-std-msgs"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin ros-noetic-geometry-msgs ros-noetic-message-generation ros-noetic-std-msgs"
+depends="ros-noetic-geometry-msgs ros-noetic-message-runtime ros-noetic-rosbag-migration-rule ros-noetic-std-msgs"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-geometry-msgs ros-noetic-geometry-msgs-dev ros-noetic-message-generation ros-noetic-message-generation-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev"
+depends_dev="ros-noetic-geometry-msgs ros-noetic-geometry-msgs-dev ros-noetic-message-runtime ros-noetic-message-runtime-dev ros-noetic-rosbag-migration-rule ros-noetic-rosbag-migration-rule-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-trajectory-tracker-msgs/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-trajectory-tracker-msgs/APKBUILD
@@ -7,10 +7,11 @@ url="http://wiki.ros.org/$_pkgname"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-geometry-msgs ros-noetic-message-runtime ros-noetic-std-msgs ros-noetic-geometry-msgs ros-noetic-message-runtime ros-noetic-std-msgs"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin ros-noetic-geometry-msgs ros-noetic-message-generation ros-noetic-nav-msgs ros-noetic-roscpp ros-noetic-roslint ros-noetic-rosunit ros-noetic-std-msgs"
+depends="ros-noetic-geometry-msgs ros-noetic-message-runtime ros-noetic-std-msgs"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-geometry-msgs ros-noetic-geometry-msgs-dev ros-noetic-message-generation ros-noetic-message-generation-dev ros-noetic-nav-msgs ros-noetic-nav-msgs-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-roslint ros-noetic-roslint-dev ros-noetic-rosunit ros-noetic-rosunit-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev"
+depends_dev="ros-noetic-geometry-msgs ros-noetic-geometry-msgs-dev ros-noetic-message-runtime ros-noetic-message-runtime-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-trajectory-tracker-rviz-plugins/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-trajectory-tracker-rviz-plugins/APKBUILD
@@ -7,10 +7,11 @@ url="http://wiki.ros.org/$_pkgname"
 arch="all"
 license="BSD"
 
-depends="qt5-qtbase-dev ros-noetic-pluginlib ros-noetic-rviz>=1.14.21 ros-noetic-trajectory-tracker-msgs ros-noetic-pluginlib ros-noetic-rviz>=1.14.21 ros-noetic-trajectory-tracker-msgs"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath qt5-qtbase-dev ros-noetic-catkin ros-noetic-pluginlib ros-noetic-rviz>=1.14.21 ros-noetic-trajectory-tracker-msgs"
+depends="ros-noetic-pluginlib ros-noetic-rviz>=1.14.21 ros-noetic-trajectory-tracker-msgs"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool qt5-qtbase-dev ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-pluginlib ros-noetic-pluginlib-dev ros-noetic-rviz-dev>=1.14.21 ros-noetic-rviz>=1.14.21 ros-noetic-trajectory-tracker-msgs ros-noetic-trajectory-tracker-msgs-dev"
+depends_dev="qt5-qtbase-dev ros-noetic-pluginlib ros-noetic-pluginlib-dev ros-noetic-rviz-dev>=1.14.21 ros-noetic-rviz>=1.14.21 ros-noetic-trajectory-tracker-msgs ros-noetic-trajectory-tracker-msgs-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-trajectory-tracker/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-trajectory-tracker/APKBUILD
@@ -7,10 +7,11 @@ url="http://wiki.ros.org/$_pkgname"
 arch="all"
 license="BSD"
 
-depends="eigen-dev ros-noetic-dynamic-reconfigure ros-noetic-geometry-msgs ros-noetic-interactive-markers ros-noetic-nav-msgs ros-noetic-neonavigation-common ros-noetic-roscpp ros-noetic-std-srvs ros-noetic-tf2 ros-noetic-tf2-geometry-msgs ros-noetic-tf2-ros ros-noetic-trajectory-tracker-msgs>=0.8.0 eigen-dev ros-noetic-dynamic-reconfigure ros-noetic-geometry-msgs ros-noetic-interactive-markers ros-noetic-nav-msgs ros-noetic-neonavigation-common ros-noetic-roscpp ros-noetic-std-srvs ros-noetic-tf2 ros-noetic-tf2-geometry-msgs ros-noetic-tf2-ros ros-noetic-trajectory-tracker-msgs>=0.8.0"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath eigen-dev ros-noetic-catkin ros-noetic-dynamic-reconfigure ros-noetic-geometry-msgs ros-noetic-interactive-markers ros-noetic-nav-msgs ros-noetic-neonavigation-common ros-noetic-roscpp ros-noetic-roslint ros-noetic-rostest ros-noetic-std-srvs ros-noetic-tf2 ros-noetic-tf2-geometry-msgs ros-noetic-tf2-ros ros-noetic-trajectory-tracker-msgs>=0.8.0"
+depends="ros-noetic-dynamic-reconfigure ros-noetic-geometry-msgs ros-noetic-interactive-markers ros-noetic-nav-msgs ros-noetic-neonavigation-common ros-noetic-roscpp ros-noetic-std-srvs ros-noetic-tf2 ros-noetic-tf2-geometry-msgs ros-noetic-tf2-ros ros-noetic-trajectory-tracker-msgs>=0.8.0"
+makedepends="chrpath eigen-dev py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-dynamic-reconfigure ros-noetic-dynamic-reconfigure-dev ros-noetic-geometry-msgs ros-noetic-geometry-msgs-dev ros-noetic-interactive-markers ros-noetic-interactive-markers-dev ros-noetic-nav-msgs ros-noetic-nav-msgs-dev ros-noetic-neonavigation-common ros-noetic-neonavigation-common-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-roslint ros-noetic-roslint-dev ros-noetic-rostest ros-noetic-rostest-dev ros-noetic-std-srvs ros-noetic-std-srvs-dev ros-noetic-tf2 ros-noetic-tf2-dev ros-noetic-tf2-geometry-msgs ros-noetic-tf2-geometry-msgs-dev ros-noetic-tf2-ros ros-noetic-tf2-ros-dev ros-noetic-trajectory-tracker-msgs-dev>=0.8.0 ros-noetic-trajectory-tracker-msgs>=0.8.0"
+depends_dev="eigen-dev ros-noetic-dynamic-reconfigure ros-noetic-dynamic-reconfigure-dev ros-noetic-geometry-msgs ros-noetic-geometry-msgs-dev ros-noetic-interactive-markers ros-noetic-interactive-markers-dev ros-noetic-nav-msgs ros-noetic-nav-msgs-dev ros-noetic-neonavigation-common ros-noetic-neonavigation-common-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-std-srvs ros-noetic-std-srvs-dev ros-noetic-tf2 ros-noetic-tf2-dev ros-noetic-tf2-geometry-msgs ros-noetic-tf2-geometry-msgs-dev ros-noetic-tf2-ros ros-noetic-tf2-ros-dev ros-noetic-trajectory-tracker-msgs-dev>=0.8.0 ros-noetic-trajectory-tracker-msgs>=0.8.0"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-transmission-interface/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-transmission-interface/APKBUILD
@@ -7,10 +7,11 @@ url="https://github.com/ros-controls/ros_control/wiki"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-roscpp tinyxml-dev ros-noetic-hardware-interface ros-noetic-pluginlib ros-noetic-roscpp tinyxml-dev"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin ros-noetic-cmake-modules ros-noetic-hardware-interface ros-noetic-pluginlib ros-noetic-resource-retriever ros-noetic-roscpp tinyxml-dev"
+depends="ros-noetic-roscpp"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-cmake-modules ros-noetic-cmake-modules-dev ros-noetic-hardware-interface ros-noetic-hardware-interface-dev ros-noetic-pluginlib ros-noetic-pluginlib-dev ros-noetic-resource-retriever ros-noetic-resource-retriever-dev ros-noetic-roscpp ros-noetic-roscpp-dev tinyxml-dev"
+depends_dev="ros-noetic-hardware-interface ros-noetic-hardware-interface-dev ros-noetic-pluginlib ros-noetic-pluginlib-dev ros-noetic-roscpp ros-noetic-roscpp-dev tinyxml-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-turtlesim/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-turtlesim/APKBUILD
@@ -7,10 +7,11 @@ url="http://www.ros.org/wiki/turtlesim"
 arch="all"
 license="BSD"
 
-depends="boost-dev qt5-qtbase-dev ros-noetic-geometry-msgs ros-noetic-message-runtime ros-noetic-rosconsole ros-noetic-roscpp ros-noetic-roscpp-serialization ros-noetic-roslib ros-noetic-rostime ros-noetic-std-msgs ros-noetic-std-srvs boost-dev qt5-qtbase-dev ros-noetic-geometry-msgs ros-noetic-message-runtime ros-noetic-rosconsole ros-noetic-roscpp ros-noetic-roscpp-serialization ros-noetic-roslib ros-noetic-rostime ros-noetic-std-msgs ros-noetic-std-srvs"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath boost-dev qt5-qtbase-dev ros-noetic-catkin ros-noetic-geometry-msgs ros-noetic-message-generation ros-noetic-rosconsole ros-noetic-roscpp ros-noetic-roscpp-serialization ros-noetic-roslib ros-noetic-rostime ros-noetic-std-msgs ros-noetic-std-srvs"
+depends="ros-noetic-geometry-msgs ros-noetic-message-runtime ros-noetic-rosconsole ros-noetic-roscpp ros-noetic-roscpp-serialization ros-noetic-roslib ros-noetic-rostime ros-noetic-std-msgs ros-noetic-std-srvs"
+makedepends="boost-dev chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool qt5-qtbase-dev ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-geometry-msgs ros-noetic-geometry-msgs-dev ros-noetic-message-generation ros-noetic-message-generation-dev ros-noetic-rosconsole ros-noetic-rosconsole-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-roscpp-serialization ros-noetic-roscpp-serialization-dev ros-noetic-roslib ros-noetic-roslib-dev ros-noetic-rostime ros-noetic-rostime-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev ros-noetic-std-srvs ros-noetic-std-srvs-dev"
+depends_dev="boost-dev qt5-qtbase-dev ros-noetic-geometry-msgs ros-noetic-geometry-msgs-dev ros-noetic-message-runtime ros-noetic-message-runtime-dev ros-noetic-rosconsole ros-noetic-rosconsole-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-roscpp-serialization ros-noetic-roscpp-serialization-dev ros-noetic-roslib ros-noetic-roslib-dev ros-noetic-rostime ros-noetic-rostime-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev ros-noetic-std-srvs ros-noetic-std-srvs-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-urdf-parser-plugin/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-urdf-parser-plugin/APKBUILD
@@ -7,10 +7,11 @@ url="http://ros.org/wiki/urdf"
 arch="all"
 license="BSD"
 
-depends="urdfdom_headers urdfdom_headers"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin urdfdom_headers"
+depends="urdfdom_headers"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev urdfdom_headers"
+depends_dev="urdfdom_headers"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-urdf/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-urdf/APKBUILD
@@ -7,10 +7,11 @@ url="http://ros.org/wiki/urdf"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-pluginlib ros-noetic-rosconsole-bridge ros-noetic-roscpp tinyxml-dev tinyxml2-dev urdfdom-dev tinyxml-dev tinyxml2-dev urdfdom_headers"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin>=0.5.68 ros-noetic-cmake-modules ros-noetic-pluginlib ros-noetic-rosconsole-bridge ros-noetic-roscpp ros-noetic-rostest ros-noetic-urdf-parser-plugin tinyxml-dev tinyxml2-dev urdfdom-dev urdfdom_headers"
+depends="ros-noetic-pluginlib ros-noetic-rosconsole-bridge ros-noetic-roscpp"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin-dev>=0.5.68 ros-noetic-catkin>=0.5.68 ros-noetic-cmake-modules ros-noetic-cmake-modules-dev ros-noetic-pluginlib ros-noetic-pluginlib-dev ros-noetic-rosconsole-bridge ros-noetic-rosconsole-bridge-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-rostest ros-noetic-rostest-dev ros-noetic-urdf-parser-plugin ros-noetic-urdf-parser-plugin-dev tinyxml-dev tinyxml2-dev urdfdom-dev urdfdom_headers"
+depends_dev="ros-noetic-pluginlib-dev ros-noetic-rosconsole-bridge-dev ros-noetic-roscpp-dev tinyxml-dev tinyxml2-dev urdfdom-dev urdfdom_headers"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-urg-c/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-urg-c/APKBUILD
@@ -8,9 +8,10 @@ arch="all"
 license="BSD"
 
 depends=""
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev"
+depends_dev=""
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-urg-node/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-urg-node/APKBUILD
@@ -7,10 +7,11 @@ url="http://ros.org/wiki/urg_node"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-diagnostic-updater ros-noetic-dynamic-reconfigure ros-noetic-laser-proc ros-noetic-message-generation ros-noetic-message-runtime ros-noetic-nodelet ros-noetic-rosconsole ros-noetic-roscpp ros-noetic-sensor-msgs ros-noetic-std-msgs ros-noetic-std-srvs ros-noetic-tf ros-noetic-urg-c ros-noetic-xacro ros-noetic-diagnostic-updater ros-noetic-dynamic-reconfigure ros-noetic-laser-proc ros-noetic-message-generation ros-noetic-nodelet ros-noetic-rosconsole ros-noetic-roscpp ros-noetic-sensor-msgs ros-noetic-std-msgs ros-noetic-std-srvs ros-noetic-tf ros-noetic-urg-c"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin ros-noetic-diagnostic-updater ros-noetic-dynamic-reconfigure ros-noetic-laser-proc ros-noetic-message-generation ros-noetic-nodelet ros-noetic-rosconsole ros-noetic-roscpp ros-noetic-roslaunch ros-noetic-roslint ros-noetic-sensor-msgs ros-noetic-std-msgs ros-noetic-std-srvs ros-noetic-tf ros-noetic-urg-c"
+depends="ros-noetic-diagnostic-updater ros-noetic-dynamic-reconfigure ros-noetic-laser-proc ros-noetic-message-generation ros-noetic-message-runtime ros-noetic-nodelet ros-noetic-rosconsole ros-noetic-roscpp ros-noetic-sensor-msgs ros-noetic-std-msgs ros-noetic-std-srvs ros-noetic-tf ros-noetic-urg-c ros-noetic-xacro"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-diagnostic-updater ros-noetic-diagnostic-updater-dev ros-noetic-dynamic-reconfigure ros-noetic-dynamic-reconfigure-dev ros-noetic-laser-proc ros-noetic-laser-proc-dev ros-noetic-message-generation ros-noetic-message-generation-dev ros-noetic-nodelet ros-noetic-nodelet-dev ros-noetic-rosconsole ros-noetic-rosconsole-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-roslaunch ros-noetic-roslaunch-dev ros-noetic-roslint ros-noetic-roslint-dev ros-noetic-sensor-msgs ros-noetic-sensor-msgs-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev ros-noetic-std-srvs ros-noetic-std-srvs-dev ros-noetic-tf ros-noetic-tf-dev ros-noetic-urg-c ros-noetic-urg-c-dev"
+depends_dev="ros-noetic-diagnostic-updater ros-noetic-diagnostic-updater-dev ros-noetic-dynamic-reconfigure ros-noetic-dynamic-reconfigure-dev ros-noetic-laser-proc ros-noetic-laser-proc-dev ros-noetic-message-generation ros-noetic-message-generation-dev ros-noetic-message-runtime-dev ros-noetic-nodelet ros-noetic-nodelet-dev ros-noetic-rosconsole ros-noetic-rosconsole-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-sensor-msgs ros-noetic-sensor-msgs-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev ros-noetic-std-srvs ros-noetic-std-srvs-dev ros-noetic-tf ros-noetic-tf-dev ros-noetic-urg-c ros-noetic-urg-c-dev ros-noetic-xacro-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-urg-stamped/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-urg-stamped/APKBUILD
@@ -7,10 +7,11 @@ url="http://wiki.ros.org/$_pkgname"
 arch="all"
 license="Apache 2.0"
 
-depends="ros-noetic-message-runtime ros-noetic-roscpp ros-noetic-sensor-msgs ros-noetic-std-msgs ros-noetic-message-runtime ros-noetic-roscpp ros-noetic-sensor-msgs ros-noetic-std-msgs"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin ros-noetic-message-generation ros-noetic-roscpp ros-noetic-roslint ros-noetic-rostest ros-noetic-rosunit ros-noetic-sensor-msgs ros-noetic-std-msgs"
+depends="ros-noetic-message-runtime ros-noetic-roscpp ros-noetic-sensor-msgs ros-noetic-std-msgs"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-message-generation ros-noetic-message-generation-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-roslint ros-noetic-roslint-dev ros-noetic-rostest ros-noetic-rostest-dev ros-noetic-rosunit ros-noetic-rosunit-dev ros-noetic-sensor-msgs ros-noetic-sensor-msgs-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev"
+depends_dev="ros-noetic-message-runtime ros-noetic-message-runtime-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-sensor-msgs ros-noetic-sensor-msgs-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-usb-cam/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-usb-cam/APKBUILD
@@ -7,10 +7,11 @@ url="http://wiki.ros.org/usb_cam"
 arch="all"
 license="BSD"
 
-depends="ffmpeg-dev ros-noetic-camera-info-manager ros-noetic-cv-bridge ros-noetic-image-transport ros-noetic-roscpp ros-noetic-sensor-msgs ros-noetic-std-msgs ros-noetic-std-srvs v4l-utils ffmpeg-dev ros-noetic-camera-info-manager ros-noetic-cv-bridge ros-noetic-image-transport ros-noetic-roscpp ros-noetic-sensor-msgs ros-noetic-std-msgs ros-noetic-std-srvs v4l-utils"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ffmpeg-dev ros-noetic-camera-info-manager ros-noetic-catkin ros-noetic-cv-bridge ros-noetic-image-transport ros-noetic-roscpp ros-noetic-sensor-msgs ros-noetic-std-msgs ros-noetic-std-srvs"
+depends="ros-noetic-camera-info-manager ros-noetic-cv-bridge ros-noetic-image-transport ros-noetic-roscpp ros-noetic-sensor-msgs ros-noetic-std-msgs ros-noetic-std-srvs v4l-utils"
+makedepends="chrpath ffmpeg-dev py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-camera-info-manager ros-noetic-camera-info-manager-dev ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-cv-bridge ros-noetic-cv-bridge-dev ros-noetic-image-transport ros-noetic-image-transport-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-sensor-msgs ros-noetic-sensor-msgs-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev ros-noetic-std-srvs ros-noetic-std-srvs-dev"
+depends_dev="ffmpeg-dev ros-noetic-camera-info-manager ros-noetic-camera-info-manager-dev ros-noetic-cv-bridge ros-noetic-cv-bridge-dev ros-noetic-image-transport ros-noetic-image-transport-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-sensor-msgs ros-noetic-sensor-msgs-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev ros-noetic-std-srvs ros-noetic-std-srvs-dev v4l-utils"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-uuid-msgs/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-uuid-msgs/APKBUILD
@@ -7,10 +7,11 @@ url="http://ros.org/wiki/uuid_msgs"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-message-runtime ros-noetic-std-msgs ros-noetic-message-runtime ros-noetic-std-msgs"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin ros-noetic-message-generation ros-noetic-std-msgs"
+depends="ros-noetic-message-runtime ros-noetic-std-msgs"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-message-generation ros-noetic-message-generation-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev"
+depends_dev="ros-noetic-message-runtime ros-noetic-message-runtime-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-velodyne-driver/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-velodyne-driver/APKBUILD
@@ -7,10 +7,11 @@ url="http://www.ros.org/wiki/velodyne_driver"
 arch="all"
 license="BSD"
 
-depends="libpcap-dev ros-noetic-diagnostic-updater ros-noetic-dynamic-reconfigure ros-noetic-nodelet ros-noetic-roscpp ros-noetic-tf ros-noetic-velodyne-msgs libpcap-dev ros-noetic-diagnostic-updater ros-noetic-dynamic-reconfigure ros-noetic-nodelet ros-noetic-roscpp ros-noetic-tf ros-noetic-velodyne-msgs"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath libpcap-dev ros-noetic-catkin ros-noetic-diagnostic-updater ros-noetic-dynamic-reconfigure ros-noetic-nodelet ros-noetic-roscpp ros-noetic-roslaunch ros-noetic-roslint ros-noetic-rostest ros-noetic-tf ros-noetic-velodyne-msgs"
+depends="ros-noetic-diagnostic-updater ros-noetic-dynamic-reconfigure ros-noetic-nodelet ros-noetic-roscpp ros-noetic-tf ros-noetic-velodyne-msgs"
+makedepends="chrpath libpcap-dev py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-diagnostic-updater ros-noetic-diagnostic-updater-dev ros-noetic-dynamic-reconfigure ros-noetic-dynamic-reconfigure-dev ros-noetic-nodelet ros-noetic-nodelet-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-roslaunch ros-noetic-roslaunch-dev ros-noetic-roslint ros-noetic-roslint-dev ros-noetic-rostest ros-noetic-rostest-dev ros-noetic-tf ros-noetic-tf-dev ros-noetic-velodyne-msgs ros-noetic-velodyne-msgs-dev"
+depends_dev="libpcap-dev ros-noetic-diagnostic-updater ros-noetic-diagnostic-updater-dev ros-noetic-dynamic-reconfigure ros-noetic-dynamic-reconfigure-dev ros-noetic-nodelet ros-noetic-nodelet-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-tf ros-noetic-tf-dev ros-noetic-velodyne-msgs ros-noetic-velodyne-msgs-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-velodyne-laserscan/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-velodyne-laserscan/APKBUILD
@@ -7,10 +7,11 @@ url="http://ros.org/wiki/velodyne_laserscan"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-dynamic-reconfigure ros-noetic-nodelet ros-noetic-roscpp ros-noetic-sensor-msgs ros-noetic-dynamic-reconfigure ros-noetic-nodelet ros-noetic-roscpp ros-noetic-sensor-msgs"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin ros-noetic-dynamic-reconfigure ros-noetic-nodelet ros-noetic-roscpp ros-noetic-roslaunch ros-noetic-roslint ros-noetic-rostest ros-noetic-sensor-msgs"
+depends="ros-noetic-dynamic-reconfigure ros-noetic-nodelet ros-noetic-roscpp ros-noetic-sensor-msgs"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-dynamic-reconfigure ros-noetic-dynamic-reconfigure-dev ros-noetic-nodelet ros-noetic-nodelet-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-roslaunch ros-noetic-roslaunch-dev ros-noetic-roslint ros-noetic-roslint-dev ros-noetic-rostest ros-noetic-rostest-dev ros-noetic-sensor-msgs ros-noetic-sensor-msgs-dev"
+depends_dev="ros-noetic-dynamic-reconfigure ros-noetic-dynamic-reconfigure-dev ros-noetic-nodelet ros-noetic-nodelet-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-sensor-msgs ros-noetic-sensor-msgs-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-velodyne-msgs/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-velodyne-msgs/APKBUILD
@@ -7,10 +7,11 @@ url="http://ros.org/wiki/velodyne_msgs"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-message-runtime ros-noetic-std-msgs ros-noetic-std-msgs"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin ros-noetic-message-generation ros-noetic-std-msgs"
+depends="ros-noetic-message-runtime ros-noetic-std-msgs"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-message-generation ros-noetic-message-generation-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev"
+depends_dev="ros-noetic-message-runtime-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-velodyne-pcl/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-velodyne-pcl/APKBUILD
@@ -7,10 +7,11 @@ url="http://wiki.ros.org/velodyne_pcl"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-pcl-ros ros-noetic-pcl-ros"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin ros-noetic-pcl-ros ros-noetic-roslint"
+depends="ros-noetic-pcl-ros"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-pcl-ros ros-noetic-pcl-ros-dev ros-noetic-roslint ros-noetic-roslint-dev"
+depends_dev="ros-noetic-pcl-ros ros-noetic-pcl-ros-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-velodyne-pointcloud/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-velodyne-pointcloud/APKBUILD
@@ -7,10 +7,11 @@ url="http://ros.org/wiki/velodyne_pointcloud"
 arch="all"
 license="BSD"
 
-depends="eigen-dev ros-noetic-angles ros-noetic-diagnostic-updater ros-noetic-dynamic-reconfigure ros-noetic-nodelet ros-noetic-roscpp ros-noetic-roslib ros-noetic-sensor-msgs ros-noetic-tf2-ros ros-noetic-velodyne-driver ros-noetic-velodyne-laserscan ros-noetic-velodyne-msgs yaml-cpp-dev eigen-dev ros-noetic-angles ros-noetic-diagnostic-updater ros-noetic-dynamic-reconfigure ros-noetic-nodelet ros-noetic-roscpp ros-noetic-roslib ros-noetic-sensor-msgs ros-noetic-tf2-ros ros-noetic-velodyne-driver ros-noetic-velodyne-msgs yaml-cpp-dev"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath eigen-dev ros-noetic-angles ros-noetic-catkin ros-noetic-diagnostic-updater ros-noetic-dynamic-reconfigure ros-noetic-nodelet ros-noetic-roscpp ros-noetic-roslaunch ros-noetic-roslib ros-noetic-roslint ros-noetic-rostest ros-noetic-rosunit ros-noetic-sensor-msgs ros-noetic-tf2-ros ros-noetic-velodyne-driver ros-noetic-velodyne-msgs yaml-cpp-dev"
+depends="ros-noetic-angles ros-noetic-diagnostic-updater ros-noetic-dynamic-reconfigure ros-noetic-nodelet ros-noetic-roscpp ros-noetic-roslib ros-noetic-sensor-msgs ros-noetic-tf2-ros ros-noetic-velodyne-driver ros-noetic-velodyne-laserscan ros-noetic-velodyne-msgs"
+makedepends="chrpath eigen-dev py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-angles ros-noetic-angles-dev ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-diagnostic-updater ros-noetic-diagnostic-updater-dev ros-noetic-dynamic-reconfigure ros-noetic-dynamic-reconfigure-dev ros-noetic-nodelet ros-noetic-nodelet-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-roslaunch ros-noetic-roslaunch-dev ros-noetic-roslib ros-noetic-roslib-dev ros-noetic-roslint ros-noetic-roslint-dev ros-noetic-rostest ros-noetic-rostest-dev ros-noetic-rosunit ros-noetic-rosunit-dev ros-noetic-sensor-msgs ros-noetic-sensor-msgs-dev ros-noetic-tf2-ros ros-noetic-tf2-ros-dev ros-noetic-velodyne-driver ros-noetic-velodyne-driver-dev ros-noetic-velodyne-msgs ros-noetic-velodyne-msgs-dev yaml-cpp-dev"
+depends_dev="eigen-dev ros-noetic-angles ros-noetic-angles-dev ros-noetic-diagnostic-updater ros-noetic-diagnostic-updater-dev ros-noetic-dynamic-reconfigure ros-noetic-dynamic-reconfigure-dev ros-noetic-nodelet ros-noetic-nodelet-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-roslib ros-noetic-roslib-dev ros-noetic-sensor-msgs ros-noetic-sensor-msgs-dev ros-noetic-tf2-ros ros-noetic-tf2-ros-dev ros-noetic-velodyne-driver ros-noetic-velodyne-driver-dev ros-noetic-velodyne-laserscan-dev ros-noetic-velodyne-msgs ros-noetic-velodyne-msgs-dev yaml-cpp-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-velodyne/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-velodyne/APKBUILD
@@ -8,9 +8,10 @@ arch="all"
 license="BSD"
 
 depends="ros-noetic-velodyne-driver ros-noetic-velodyne-laserscan ros-noetic-velodyne-msgs ros-noetic-velodyne-pointcloud"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev"
+depends_dev="ros-noetic-velodyne-driver-dev ros-noetic-velodyne-laserscan-dev ros-noetic-velodyne-msgs-dev ros-noetic-velodyne-pointcloud-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-vision-opencv/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-vision-opencv/APKBUILD
@@ -7,10 +7,11 @@ url="http://www.ros.org/wiki/vision_opencv"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-cv-bridge ros-noetic-image-geometry ros-noetic-cv-bridge ros-noetic-image-geometry"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin"
+depends="ros-noetic-cv-bridge ros-noetic-image-geometry"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev"
+depends_dev="ros-noetic-cv-bridge ros-noetic-cv-bridge-dev ros-noetic-image-geometry ros-noetic-image-geometry-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-visualization-msgs/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-visualization-msgs/APKBUILD
@@ -7,10 +7,11 @@ url="http://ros.org/wiki/visualization_msgs"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-geometry-msgs ros-noetic-message-runtime ros-noetic-std-msgs ros-noetic-geometry-msgs ros-noetic-message-runtime ros-noetic-std-msgs"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin ros-noetic-geometry-msgs ros-noetic-message-generation ros-noetic-std-msgs"
+depends="ros-noetic-geometry-msgs ros-noetic-message-runtime ros-noetic-std-msgs"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-geometry-msgs ros-noetic-geometry-msgs-dev ros-noetic-message-generation ros-noetic-message-generation-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev"
+depends_dev="ros-noetic-geometry-msgs ros-noetic-geometry-msgs-dev ros-noetic-message-runtime ros-noetic-message-runtime-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-viz/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-viz/APKBUILD
@@ -8,9 +8,10 @@ arch="all"
 license="BSD"
 
 depends="ros-noetic-ros-base ros-noetic-rqt-common-plugins ros-noetic-rqt-robot-plugins ros-noetic-rviz"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev"
+depends_dev="ros-noetic-ros-base-dev ros-noetic-rqt-common-plugins-dev ros-noetic-rqt-robot-plugins-dev ros-noetic-rviz-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-voxel-grid/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-voxel-grid/APKBUILD
@@ -7,10 +7,11 @@ url="http://wiki.ros.org/voxel_grid"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-roscpp ros-noetic-roscpp"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin>=0.5.68 ros-noetic-roscpp ros-noetic-rosunit"
+depends="ros-noetic-roscpp"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin-dev>=0.5.68 ros-noetic-catkin>=0.5.68 ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-rosunit ros-noetic-rosunit-dev"
+depends_dev="ros-noetic-roscpp ros-noetic-roscpp-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-webkit-dependency/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-webkit-dependency/APKBUILD
@@ -8,9 +8,10 @@ arch="all"
 license="BSD"
 
 depends="py3-qt5"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev"
+depends_dev=""
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-xacro/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-xacro/APKBUILD
@@ -7,10 +7,11 @@ url="http://ros.org/wiki/xacro"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-roslaunch ros-noetic-roslaunch"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin>=0.5.68 ros-noetic-roslint ros-noetic-rostest"
+depends="ros-noetic-roslaunch"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin-dev>=0.5.68 ros-noetic-catkin>=0.5.68 ros-noetic-roslint ros-noetic-roslint-dev ros-noetic-rostest ros-noetic-rostest-dev"
+depends_dev="ros-noetic-roslaunch ros-noetic-roslaunch-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-xmlrpcpp/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-xmlrpcpp/APKBUILD
@@ -7,10 +7,11 @@ url="http://xmlrpcpp.sourceforge.net"
 arch="all"
 license="LGPL-2.1"
 
-depends="ros-noetic-cpp-common ros-noetic-rostime>=0.6.9 ros-noetic-cpp-common ros-noetic-rostime>=0.6.9"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath boost-dev ros-noetic-catkin ros-noetic-cpp-common ros-noetic-rostime>=0.6.9"
+depends="ros-noetic-cpp-common ros-noetic-rostime>=0.6.9"
+makedepends="boost-dev chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-cpp-common ros-noetic-cpp-common-dev ros-noetic-rostime-dev>=0.6.9 ros-noetic-rostime>=0.6.9"
+depends_dev="ros-noetic-cpp-common ros-noetic-cpp-common-dev ros-noetic-rostime-dev>=0.6.9 ros-noetic-rostime>=0.6.9"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-ypspur-ros/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-ypspur-ros/APKBUILD
@@ -7,10 +7,11 @@ url="http://wiki.ros.org/$_pkgname"
 arch="all"
 license="BSD"
 
-depends="ros-noetic-diagnostic-msgs ros-noetic-geometry-msgs ros-noetic-message-runtime ros-noetic-nav-msgs ros-noetic-roscpp ros-noetic-sensor-msgs ros-noetic-std-msgs ros-noetic-tf2 ros-noetic-tf2-geometry-msgs ros-noetic-tf2-ros ros-noetic-trajectory-msgs ros-noetic-ypspur>=1.22.0 ros-noetic-diagnostic-msgs ros-noetic-geometry-msgs ros-noetic-message-runtime ros-noetic-nav-msgs ros-noetic-roscpp ros-noetic-sensor-msgs ros-noetic-std-msgs ros-noetic-tf2 ros-noetic-tf2-geometry-msgs ros-noetic-tf2-ros ros-noetic-trajectory-msgs ros-noetic-ypspur>=1.22.0"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath ros-noetic-catkin ros-noetic-diagnostic-msgs ros-noetic-geometry-msgs ros-noetic-message-generation ros-noetic-nav-msgs ros-noetic-roscpp ros-noetic-roslint ros-noetic-rostest ros-noetic-sensor-msgs ros-noetic-std-msgs ros-noetic-tf2 ros-noetic-tf2-geometry-msgs ros-noetic-tf2-ros ros-noetic-trajectory-msgs ros-noetic-ypspur>=1.22.0"
+depends="ros-noetic-diagnostic-msgs ros-noetic-geometry-msgs ros-noetic-message-runtime ros-noetic-nav-msgs ros-noetic-roscpp ros-noetic-sensor-msgs ros-noetic-std-msgs ros-noetic-tf2 ros-noetic-tf2-geometry-msgs ros-noetic-tf2-ros ros-noetic-trajectory-msgs ros-noetic-ypspur>=1.22.0"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-diagnostic-msgs ros-noetic-diagnostic-msgs-dev ros-noetic-geometry-msgs ros-noetic-geometry-msgs-dev ros-noetic-message-generation ros-noetic-message-generation-dev ros-noetic-nav-msgs ros-noetic-nav-msgs-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-roslint ros-noetic-roslint-dev ros-noetic-rostest ros-noetic-rostest-dev ros-noetic-sensor-msgs ros-noetic-sensor-msgs-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev ros-noetic-tf2 ros-noetic-tf2-dev ros-noetic-tf2-geometry-msgs ros-noetic-tf2-geometry-msgs-dev ros-noetic-tf2-ros ros-noetic-tf2-ros-dev ros-noetic-trajectory-msgs ros-noetic-trajectory-msgs-dev ros-noetic-ypspur-dev>=1.22.0 ros-noetic-ypspur>=1.22.0"
+depends_dev="ros-noetic-diagnostic-msgs ros-noetic-diagnostic-msgs-dev ros-noetic-geometry-msgs ros-noetic-geometry-msgs-dev ros-noetic-message-runtime ros-noetic-message-runtime-dev ros-noetic-nav-msgs ros-noetic-nav-msgs-dev ros-noetic-roscpp ros-noetic-roscpp-dev ros-noetic-sensor-msgs ros-noetic-sensor-msgs-dev ros-noetic-std-msgs ros-noetic-std-msgs-dev ros-noetic-tf2 ros-noetic-tf2-dev ros-noetic-tf2-geometry-msgs ros-noetic-tf2-geometry-msgs-dev ros-noetic-tf2-ros ros-noetic-tf2-ros-dev ros-noetic-trajectory-msgs ros-noetic-trajectory-msgs-dev ros-noetic-ypspur-dev>=1.22.0 ros-noetic-ypspur>=1.22.0"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -259,6 +260,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh

--- a/v3.20/ros/noetic/ros-noetic-ypspur/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-ypspur/APKBUILD
@@ -7,10 +7,11 @@ url="http://wiki.ros.org/$_pkgname"
 arch="all"
 license="MIT"
 
-depends="readline-dev ros-noetic-catkin"
-makedepends="py3-setuptools py3-rosdep py3-rosinstall-generator py3-vcstool chrpath cmake readline-dev"
+depends="ros-noetic-catkin"
+makedepends="chrpath cmake py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool readline-dev"
+depends_dev="readline-dev ros-noetic-catkin-dev"
 
-subpackages="$pkgname-dbg $pkgname-doc"
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
 source=""
 builddir="$startdir/abuild"
@@ -231,6 +232,13 @@ doc() {
 
   default_doc
 }
+
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
 
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh


### PR DESCRIPTION
Updates found in rosdistro
- v3.20/ros/noetic/ros-noetic-actionlib-msgs no upstream update
- v3.20/ros/noetic/ros-noetic-actionlib no upstream update
- v3.20/ros/noetic/ros-noetic-amcl no upstream update
- v3.20/ros/noetic/ros-noetic-angles no upstream update
- v3.20/ros/noetic/ros-noetic-aruco-msgs no upstream update
- v3.20/ros/noetic/ros-noetic-aruco-ros no upstream update
- v3.20/ros/noetic/ros-noetic-aruco no upstream update
- v3.20/ros/noetic/ros-noetic-audio-capture no upstream update
- v3.20/ros/noetic/ros-noetic-audio-common-msgs no upstream update
- v3.20/ros/noetic/ros-noetic-audio-common no upstream update
- v3.20/ros/noetic/ros-noetic-audio-play no upstream update
- v3.20/ros/noetic/ros-noetic-base-local-planner no upstream update
- v3.20/ros/noetic/ros-noetic-behaviortree-cpp-v3 no upstream update
- v3.20/ros/noetic/ros-noetic-behaviortree-cpp no upstream update
- v3.20/ros/noetic/ros-noetic-bond-core no upstream update
- v3.20/ros/noetic/ros-noetic-bond no upstream update
- v3.20/ros/noetic/ros-noetic-bondcpp no upstream update
- v3.20/ros/noetic/ros-noetic-bondpy no upstream update
- v3.20/ros/noetic/ros-noetic-camera-calibration-parsers no upstream update
- v3.20/ros/noetic/ros-noetic-camera-calibration no upstream update
- v3.20/ros/noetic/ros-noetic-camera-info-manager no upstream update
- v3.20/ros/noetic/ros-noetic-carrot-planner no upstream update
- v3.20/ros/noetic/ros-noetic-catkin no upstream update
- v3.20/ros/noetic/ros-noetic-class-loader no upstream update
- v3.20/ros/noetic/ros-noetic-clear-costmap-recovery no upstream update
- v3.20/ros/noetic/ros-noetic-cmake-modules no upstream update
- v3.20/ros/noetic/ros-noetic-combined-robot-hw no upstream update
- v3.20/ros/noetic/ros-noetic-common-msgs no upstream update
- v3.20/ros/noetic/ros-noetic-compressed-depth-image-transport no upstream update
- v3.20/ros/noetic/ros-noetic-compressed-image-transport no upstream update
- v3.20/ros/noetic/ros-noetic-control-msgs no upstream update
- v3.20/ros/noetic/ros-noetic-controller-interface no upstream update
- v3.20/ros/noetic/ros-noetic-controller-manager-msgs no upstream update
- v3.20/ros/noetic/ros-noetic-controller-manager no upstream update
- v3.20/ros/noetic/ros-noetic-costmap-2d no upstream update
- v3.20/ros/noetic/ros-noetic-costmap-cspace-msgs no upstream update
- v3.20/ros/noetic/ros-noetic-costmap-cspace-rviz-plugins no upstream update
- v3.20/ros/noetic/ros-noetic-costmap-cspace no upstream update
- v3.20/ros/noetic/ros-noetic-cpp-common no upstream update
- v3.20/ros/noetic/ros-noetic-cv-bridge no upstream update
- v3.20/ros/noetic/ros-noetic-depth-image-proc no upstream update
- v3.20/ros/noetic/ros-noetic-diagnostic-aggregator no upstream update
- v3.20/ros/noetic/ros-noetic-diagnostic-analysis no upstream update
- v3.20/ros/noetic/ros-noetic-diagnostic-common-diagnostics no upstream update
- v3.20/ros/noetic/ros-noetic-diagnostic-msgs no upstream update
- v3.20/ros/noetic/ros-noetic-diagnostic-updater no upstream update
- v3.20/ros/noetic/ros-noetic-diagnostics no upstream update
- v3.20/ros/noetic/ros-noetic-dwa-local-planner no upstream update
- v3.20/ros/noetic/ros-noetic-dynamic-reconfigure no upstream update
- v3.20/ros/noetic/ros-noetic-eigen-conversions no upstream update
- v3.20/ros/noetic/ros-noetic-executive-smach-visualization no upstream update
- v3.20/ros/noetic/ros-noetic-executive-smach no upstream update
- v3.20/ros/noetic/ros-noetic-fake-localization no upstream update
- v3.20/ros/noetic/ros-noetic-filters no upstream update
- v3.20/ros/noetic/ros-noetic-gencpp no upstream update
- v3.20/ros/noetic/ros-noetic-geneus no upstream update
- v3.20/ros/noetic/ros-noetic-genlisp no upstream update
- v3.20/ros/noetic/ros-noetic-genmsg no upstream update
- v3.20/ros/noetic/ros-noetic-gennodejs no upstream update
- v3.20/ros/noetic/ros-noetic-genpy no upstream update
- v3.20/ros/noetic/ros-noetic-geographic-msgs no upstream update
- v3.20/ros/noetic/ros-noetic-geometry-msgs no upstream update
- v3.20/ros/noetic/ros-noetic-geometry no upstream update
- v3.20/ros/noetic/ros-noetic-gl-dependency no upstream update
- v3.20/ros/noetic/ros-noetic-global-planner no upstream update
- v3.20/ros/noetic/ros-noetic-grid-map-core no upstream update
- v3.20/ros/noetic/ros-noetic-grid-map-cv no upstream update
- v3.20/ros/noetic/ros-noetic-grid-map-msgs no upstream update
- v3.20/ros/noetic/ros-noetic-grid-map-ros no upstream update
- v3.20/ros/noetic/ros-noetic-grid-map-rviz-plugin no upstream update
- v3.20/ros/noetic/ros-noetic-hardware-interface no upstream update
- v3.20/ros/noetic/ros-noetic-ifm3d-core no upstream update
- v3.20/ros/noetic/ros-noetic-ifm3d no upstream update
- v3.20/ros/noetic/ros-noetic-image-common no upstream update
- v3.20/ros/noetic/ros-noetic-image-geometry no upstream update
- v3.20/ros/noetic/ros-noetic-image-pipeline no upstream update
- v3.20/ros/noetic/ros-noetic-image-proc no upstream update
- v3.20/ros/noetic/ros-noetic-image-publisher no upstream update
- v3.20/ros/noetic/ros-noetic-image-rotate no upstream update
- v3.20/ros/noetic/ros-noetic-image-transport-plugins no upstream update
- v3.20/ros/noetic/ros-noetic-image-transport no upstream update
- v3.20/ros/noetic/ros-noetic-image-view no upstream update
- v3.20/ros/noetic/ros-noetic-imu-complementary-filter no upstream update
- v3.20/ros/noetic/ros-noetic-imu-filter-madgwick no upstream update
- v3.20/ros/noetic/ros-noetic-imu-tools no upstream update
- v3.20/ros/noetic/ros-noetic-interactive-markers no upstream update
- v3.20/ros/noetic/ros-noetic-joint-limits-interface no upstream update
- v3.20/ros/noetic/ros-noetic-joint-state-publisher-gui no upstream update
- v3.20/ros/noetic/ros-noetic-joint-state-publisher no upstream update
- v3.20/ros/noetic/ros-noetic-joy no upstream update
- v3.20/ros/noetic/ros-noetic-joystick-interrupt no upstream update
- v3.20/ros/noetic/ros-noetic-kdl-conversions no upstream update
- v3.20/ros/noetic/ros-noetic-kdl-parser no upstream update
- v3.20/ros/noetic/ros-noetic-laser-assembler no upstream update
- v3.20/ros/noetic/ros-noetic-laser-filters no upstream update
- v3.20/ros/noetic/ros-noetic-laser-geometry no upstream update
- v3.20/ros/noetic/ros-noetic-laser-pipeline no upstream update
- v3.20/ros/noetic/ros-noetic-laser-proc no upstream update
- v3.20/ros/noetic/ros-noetic-map-msgs no upstream update
- v3.20/ros/noetic/ros-noetic-map-organizer-msgs no upstream update
- v3.20/ros/noetic/ros-noetic-map-organizer no upstream update
- v3.20/ros/noetic/ros-noetic-map-server no upstream update
- v3.20/ros/noetic/ros-noetic-mcl-3dl-msgs no upstream update
- v3.20/ros/noetic/ros-noetic-mcl-3dl no upstream update
- v3.20/ros/noetic/ros-noetic-media-export no upstream update
- v3.20/ros/noetic/ros-noetic-message-filters no upstream update
- v3.20/ros/noetic/ros-noetic-message-generation no upstream update
- v3.20/ros/noetic/ros-noetic-message-runtime no upstream update
- v3.20/ros/noetic/ros-noetic-mk no upstream update
- v3.20/ros/noetic/ros-noetic-move-base-msgs no upstream update
- v3.20/ros/noetic/ros-noetic-move-base no upstream update
- v3.20/ros/noetic/ros-noetic-move-slow-and-clear no upstream update
- v3.20/ros/noetic/ros-noetic-nav-core no upstream update
- v3.20/ros/noetic/ros-noetic-nav-msgs no upstream update
- v3.20/ros/noetic/ros-noetic-navfn no upstream update
- v3.20/ros/noetic/ros-noetic-navigation no upstream update
- v3.20/ros/noetic/ros-noetic-neonavigation-common no upstream update
- v3.20/ros/noetic/ros-noetic-neonavigation-launch no upstream update
- v3.20/ros/noetic/ros-noetic-neonavigation-metrics-msgs no upstream update
- v3.20/ros/noetic/ros-noetic-neonavigation-msgs no upstream update
- v3.20/ros/noetic/ros-noetic-neonavigation-rviz-plugins no upstream update
- v3.20/ros/noetic/ros-noetic-neonavigation no upstream update
- v3.20/ros/noetic/ros-noetic-nodelet-core no upstream update
- v3.20/ros/noetic/ros-noetic-nodelet-topic-tools no upstream update
- v3.20/ros/noetic/ros-noetic-nodelet no upstream update
- v3.20/ros/noetic/ros-noetic-obj-to-pointcloud no upstream update
- v3.20/ros/noetic/ros-noetic-octomap-msgs no upstream update
- v3.20/ros/noetic/ros-noetic-octomap-ros no upstream update
- v3.20/ros/noetic/ros-noetic-octomap no upstream update
- v3.20/ros/noetic/ros-noetic-pcl-conversions no upstream update
- v3.20/ros/noetic/ros-noetic-pcl-msgs no upstream update
- v3.20/ros/noetic/ros-noetic-pcl-ros no upstream update
- v3.20/ros/noetic/ros-noetic-perception-pcl no upstream update
- v3.20/ros/noetic/ros-noetic-perception no upstream update
- v3.20/ros/noetic/ros-noetic-planner-cspace-msgs no upstream update
- v3.20/ros/noetic/ros-noetic-planner-cspace no upstream update
- v3.20/ros/noetic/ros-noetic-pluginlib no upstream update
- v3.20/ros/noetic/ros-noetic-polled-camera no upstream update
- v3.20/ros/noetic/ros-noetic-python-qt-binding no upstream update
- v3.20/ros/noetic/ros-noetic-qt-dotgraph no upstream update
- v3.20/ros/noetic/ros-noetic-qt-gui-cpp no upstream update
- v3.20/ros/noetic/ros-noetic-qt-gui-py-common no upstream update
- v3.20/ros/noetic/ros-noetic-qt-gui no upstream update
- v3.20/ros/noetic/ros-noetic-qwt-dependency no upstream update
- v3.20/ros/noetic/ros-noetic-realtime-tools no upstream update
- v3.20/ros/noetic/ros-noetic-resource-retriever no upstream update
- v3.20/ros/noetic/ros-noetic-robot-state-publisher no upstream update
- v3.20/ros/noetic/ros-noetic-robot no upstream update
- v3.20/ros/noetic/ros-noetic-ros-base no upstream update
- v3.20/ros/noetic/ros-noetic-ros-comm no upstream update
- v3.20/ros/noetic/ros-noetic-ros-control no upstream update
- v3.20/ros/noetic/ros-noetic-ros-core no upstream update
- v3.20/ros/noetic/ros-noetic-ros-environment no upstream update
- v3.20/ros/noetic/ros-noetic-ros-tutorials no upstream update
- v3.20/ros/noetic/ros-noetic-ros no upstream update
- v3.20/ros/noetic/ros-noetic-rosapi no upstream update
- v3.20/ros/noetic/ros-noetic-rosauth no upstream update
- v3.20/ros/noetic/ros-noetic-rosbag-migration-rule no upstream update
- v3.20/ros/noetic/ros-noetic-rosbag-snapshot-msgs no upstream update
- v3.20/ros/noetic/ros-noetic-rosbag-snapshot no upstream update
- v3.20/ros/noetic/ros-noetic-rosbag-storage no upstream update
- v3.20/ros/noetic/ros-noetic-rosbag no upstream update
- v3.20/ros/noetic/ros-noetic-rosbash no upstream update
- v3.20/ros/noetic/ros-noetic-rosboost-cfg no upstream update
- v3.20/ros/noetic/ros-noetic-rosbridge-library no upstream update
- v3.20/ros/noetic/ros-noetic-rosbridge-msgs no upstream update
- v3.20/ros/noetic/ros-noetic-rosbridge-server no upstream update
- v3.20/ros/noetic/ros-noetic-rosbridge-suite no upstream update
- v3.20/ros/noetic/ros-noetic-rosbuild no upstream update
- v3.20/ros/noetic/ros-noetic-rosclean no upstream update
- v3.20/ros/noetic/ros-noetic-rosconsole-bridge no upstream update
- v3.20/ros/noetic/ros-noetic-rosconsole no upstream update
- v3.20/ros/noetic/ros-noetic-roscpp-core no upstream update
- v3.20/ros/noetic/ros-noetic-roscpp-serialization no upstream update
- v3.20/ros/noetic/ros-noetic-roscpp-traits no upstream update
- v3.20/ros/noetic/ros-noetic-roscpp-tutorials no upstream update
- v3.20/ros/noetic/ros-noetic-roscpp no upstream update
- v3.20/ros/noetic/ros-noetic-roscreate no upstream update
- v3.20/ros/noetic/ros-noetic-rosgraph-msgs no upstream update
- v3.20/ros/noetic/ros-noetic-rosgraph no upstream update
- v3.20/ros/noetic/ros-noetic-roslang no upstream update
- v3.20/ros/noetic/ros-noetic-roslaunch no upstream update
- v3.20/ros/noetic/ros-noetic-roslib no upstream update
- v3.20/ros/noetic/ros-noetic-roslint no upstream update
- v3.20/ros/noetic/ros-noetic-roslisp no upstream update
- v3.20/ros/noetic/ros-noetic-roslz4 no upstream update
- v3.20/ros/noetic/ros-noetic-rosmake no upstream update
- v3.20/ros/noetic/ros-noetic-rosmaster no upstream update
- v3.20/ros/noetic/ros-noetic-rosmsg no upstream update
- v3.20/ros/noetic/ros-noetic-rosnode no upstream update
- v3.20/ros/noetic/ros-noetic-rosout no upstream update
- v3.20/ros/noetic/ros-noetic-rospack no upstream update
- v3.20/ros/noetic/ros-noetic-rosparam no upstream update
- v3.20/ros/noetic/ros-noetic-rospy-tutorials no upstream update
- v3.20/ros/noetic/ros-noetic-rospy no upstream update
- v3.20/ros/noetic/ros-noetic-rosserial-client no upstream update
- v3.20/ros/noetic/ros-noetic-rosserial-msgs no upstream update
- v3.20/ros/noetic/ros-noetic-rosserial-python no upstream update
- v3.20/ros/noetic/ros-noetic-rosserial no upstream update
- v3.20/ros/noetic/ros-noetic-rosservice no upstream update
- v3.20/ros/noetic/ros-noetic-rostest no upstream update
- v3.20/ros/noetic/ros-noetic-rostime no upstream update
- v3.20/ros/noetic/ros-noetic-rostopic no upstream update
- v3.20/ros/noetic/ros-noetic-rosunit no upstream update
- v3.20/ros/noetic/ros-noetic-roswtf no upstream update
- v3.20/ros/noetic/ros-noetic-rotate-recovery no upstream update
- v3.20/ros/noetic/ros-noetic-rqt-action no upstream update
- v3.20/ros/noetic/ros-noetic-rqt-bag-plugins no upstream update
- v3.20/ros/noetic/ros-noetic-rqt-bag no upstream update
- v3.20/ros/noetic/ros-noetic-rqt-common-plugins no upstream update
- v3.20/ros/noetic/ros-noetic-rqt-console no upstream update
- v3.20/ros/noetic/ros-noetic-rqt-dep no upstream update
- v3.20/ros/noetic/ros-noetic-rqt-graph no upstream update
- v3.20/ros/noetic/ros-noetic-rqt-gui-cpp no upstream update
- v3.20/ros/noetic/ros-noetic-rqt-gui-py no upstream update
- v3.20/ros/noetic/ros-noetic-rqt-gui no upstream update
- v3.20/ros/noetic/ros-noetic-rqt-image-view no upstream update
- v3.20/ros/noetic/ros-noetic-rqt-launch no upstream update
- v3.20/ros/noetic/ros-noetic-rqt-logger-level no upstream update
- v3.20/ros/noetic/ros-noetic-rqt-moveit no upstream update
- v3.20/ros/noetic/ros-noetic-rqt-msg no upstream update
- v3.20/ros/noetic/ros-noetic-rqt-nav-view no upstream update
- v3.20/ros/noetic/ros-noetic-rqt-plot no upstream update
- v3.20/ros/noetic/ros-noetic-rqt-pose-view no upstream update
- v3.20/ros/noetic/ros-noetic-rqt-publisher no upstream update
- v3.20/ros/noetic/ros-noetic-rqt-py-common no upstream update
- v3.20/ros/noetic/ros-noetic-rqt-py-console no upstream update
- v3.20/ros/noetic/ros-noetic-rqt-reconfigure no upstream update
- v3.20/ros/noetic/ros-noetic-rqt-robot-dashboard no upstream update
- v3.20/ros/noetic/ros-noetic-rqt-robot-monitor no upstream update
- v3.20/ros/noetic/ros-noetic-rqt-robot-plugins no upstream update
- v3.20/ros/noetic/ros-noetic-rqt-robot-steering no upstream update
- v3.20/ros/noetic/ros-noetic-rqt-runtime-monitor no upstream update
- v3.20/ros/noetic/ros-noetic-rqt-rviz no upstream update
- v3.20/ros/noetic/ros-noetic-rqt-service-caller no upstream update
- v3.20/ros/noetic/ros-noetic-rqt-shell no upstream update
- v3.20/ros/noetic/ros-noetic-rqt-srv no upstream update
- v3.20/ros/noetic/ros-noetic-rqt-tf-tree no upstream update
- v3.20/ros/noetic/ros-noetic-rqt-top no upstream update
- v3.20/ros/noetic/ros-noetic-rqt-topic no upstream update
- v3.20/ros/noetic/ros-noetic-rqt-web no upstream update
- v3.20/ros/noetic/ros-noetic-rviz-imu-plugin no upstream update
- v3.20/ros/noetic/ros-noetic-rviz no upstream update
- v3.20/ros/noetic/ros-noetic-safety-limiter-msgs no upstream update
- v3.20/ros/noetic/ros-noetic-safety-limiter no upstream update
- v3.20/ros/noetic/ros-noetic-self-test no upstream update
- v3.20/ros/noetic/ros-noetic-sensor-msgs no upstream update
- v3.20/ros/noetic/ros-noetic-shape-msgs no upstream update
- v3.20/ros/noetic/ros-noetic-smach-msgs no upstream update
- v3.20/ros/noetic/ros-noetic-smach-ros no upstream update
- v3.20/ros/noetic/ros-noetic-smach-viewer no upstream update
- v3.20/ros/noetic/ros-noetic-smach no upstream update
- v3.20/ros/noetic/ros-noetic-smclib no upstream update
- v3.20/ros/noetic/ros-noetic-sound-play no upstream update
- v3.20/ros/noetic/ros-noetic-std-msgs no upstream update
- v3.20/ros/noetic/ros-noetic-std-srvs no upstream update
- v3.20/ros/noetic/ros-noetic-stereo-image-proc no upstream update
- v3.20/ros/noetic/ros-noetic-stereo-msgs no upstream update
- v3.20/ros/noetic/ros-noetic-tf-conversions no upstream update
- v3.20/ros/noetic/ros-noetic-tf no upstream update
- v3.20/ros/noetic/ros-noetic-tf2-eigen no upstream update
- v3.20/ros/noetic/ros-noetic-tf2-geometry-msgs no upstream update
- v3.20/ros/noetic/ros-noetic-tf2-kdl no upstream update
- v3.20/ros/noetic/ros-noetic-tf2-msgs no upstream update
- v3.20/ros/noetic/ros-noetic-tf2-py no upstream update
- v3.20/ros/noetic/ros-noetic-tf2-ros no upstream update
- v3.20/ros/noetic/ros-noetic-tf2-sensor-msgs no upstream update
- v3.20/ros/noetic/ros-noetic-tf2 no upstream update
- v3.20/ros/noetic/ros-noetic-theora-image-transport no upstream update
- v3.20/ros/noetic/ros-noetic-topic-tools no upstream update
- v3.20/ros/noetic/ros-noetic-track-odometry no upstream update
- v3.20/ros/noetic/ros-noetic-trajectory-msgs no upstream update
- v3.20/ros/noetic/ros-noetic-trajectory-tracker-msgs no upstream update
- v3.20/ros/noetic/ros-noetic-trajectory-tracker-rviz-plugins no upstream update
- v3.20/ros/noetic/ros-noetic-trajectory-tracker no upstream update
- v3.20/ros/noetic/ros-noetic-transmission-interface no upstream update
- v3.20/ros/noetic/ros-noetic-turtlesim no upstream update
- v3.20/ros/noetic/ros-noetic-urdf-parser-plugin no upstream update
- v3.20/ros/noetic/ros-noetic-urdf no upstream update
- v3.20/ros/noetic/ros-noetic-urg-c no upstream update
- v3.20/ros/noetic/ros-noetic-urg-node no upstream update
- v3.20/ros/noetic/ros-noetic-urg-stamped no upstream update
- v3.20/ros/noetic/ros-noetic-usb-cam no upstream update
- v3.20/ros/noetic/ros-noetic-uuid-msgs no upstream update
- v3.20/ros/noetic/ros-noetic-velodyne-driver no upstream update
- v3.20/ros/noetic/ros-noetic-velodyne-laserscan no upstream update
- v3.20/ros/noetic/ros-noetic-velodyne-msgs no upstream update
- v3.20/ros/noetic/ros-noetic-velodyne-pcl no upstream update
- v3.20/ros/noetic/ros-noetic-velodyne-pointcloud no upstream update
- v3.20/ros/noetic/ros-noetic-velodyne no upstream update
- v3.20/ros/noetic/ros-noetic-vision-opencv no upstream update
- v3.20/ros/noetic/ros-noetic-visualization-msgs no upstream update
- v3.20/ros/noetic/ros-noetic-viz no upstream update
- v3.20/ros/noetic/ros-noetic-voxel-grid no upstream update
- v3.20/ros/noetic/ros-noetic-webkit-dependency no upstream update
- v3.20/ros/noetic/ros-noetic-xacro no upstream update
- v3.20/ros/noetic/ros-noetic-xmlrpcpp no upstream update
- v3.20/ros/noetic/ros-noetic-ypspur-ros no upstream update
- v3.20/ros/noetic/ros-noetic-ypspur no upstream update
