### PR TITLE
v3.20/ros/noetic/ros-noetic-sensor-msgs: safe empty cloud iterator

### DIFF
--- a/v3.20/ros/noetic/ros-noetic-sensor-msgs/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-sensor-msgs/APKBUILD
@@ -1,7 +1,7 @@
 pkgname=ros-noetic-sensor-msgs
 _pkgname=sensor_msgs
 pkgver=1.13.1
-pkgrel=1
+pkgrel=2
 pkgdesc="$_pkgname package for ROS noetic"
 url="http://ros.org/wiki/sensor_msgs"
 arch="all"

--- a/v3.20/ros/noetic/ros-noetic-sensor-msgs/safe-empty-cloud-iterator.patch
+++ b/v3.20/ros/noetic/ros-noetic-sensor-msgs/safe-empty-cloud-iterator.patch
@@ -1,0 +1,44 @@
+diff --git a/include/sensor_msgs/impl/point_cloud2_iterator.h b/include/sensor_msgs/impl/point_cloud2_iterator.h
+index a580102..8d69213 100644
+--- a/include/sensor_msgs/impl/point_cloud2_iterator.h
++++ b/include/sensor_msgs/impl/point_cloud2_iterator.h
+@@ -249,9 +249,9 @@ PointCloud2IteratorBase<T, TT, U, C, V>::PointCloud2IteratorBase(C &cloud_msg, c
+ {
+   int offset = set_field(cloud_msg, field_name);
+ 
+-  data_char_ = &(cloud_msg.data.front()) + offset;
++  data_char_ = cloud_msg.data.data() + offset;
+   data_ = reinterpret_cast<TT*>(data_char_);
+-  data_end_ = reinterpret_cast<TT*>(&(cloud_msg.data.back()) + 1 + offset);
++  data_end_ = reinterpret_cast<TT*>(data_char_ + cloud_msg.data.size());
+ }
+ 
+ /** Assignment operator
+diff --git a/test/main.cpp b/test/main.cpp
+index 90561e7..eb4c763 100644
+--- a/test/main.cpp
++++ b/test/main.cpp
+@@ -34,8 +34,23 @@
+ 
+ #include <gtest/gtest.h>
+ 
++#define _GLIBCXX_DEBUG  // Enable assertions in STL
++
+ #include <sensor_msgs/point_cloud2_iterator.h>
+ 
++TEST(sensor_msgs, PointCloud2Iterator_Empty)
++{
++  EXPECT_EXIT({
++    sensor_msgs::PointCloud2 cloud_msg;
++    cloud_msg.width = 1;
++    sensor_msgs::PointCloud2Modifier modifier(cloud_msg);
++    modifier.setPointCloud2FieldsByString(1, "xyz");
++
++    sensor_msgs::PointCloud2Iterator<float> iter_x(cloud_msg, "x");
++    exit(0);
++  }, ::testing::ExitedWithCode(0), "");
++}
++
+ TEST(sensor_msgs, PointCloud2Iterator)
+ {
+   // Create a dummy PointCloud2

--- a/v3.20/ros/noetic/ros-noetic-sensor-msgs/safe-empty-cloud-iterator.patch
+++ b/v3.20/ros/noetic/ros-noetic-sensor-msgs/safe-empty-cloud-iterator.patch
@@ -1,4 +1,8 @@
 diff --git a/include/sensor_msgs/impl/point_cloud2_iterator.h b/include/sensor_msgs/impl/point_cloud2_iterator.h
+
+front()/back() of empty STL container causes undefined behavior
+and causes assertion error on recent libstdc++.
+
 index a580102..8d69213 100644
 --- a/include/sensor_msgs/impl/point_cloud2_iterator.h
 +++ b/include/sensor_msgs/impl/point_cloud2_iterator.h

--- a/v3.20/ros/noetic/ros-noetic-sensor-msgs/safe-empty-cloud-iterator.patch
+++ b/v3.20/ros/noetic/ros-noetic-sensor-msgs/safe-empty-cloud-iterator.patch
@@ -19,10 +19,10 @@ index a580102..8d69213 100644
  
  /** Assignment operator
 diff --git a/test/main.cpp b/test/main.cpp
-index 90561e7..eb4c763 100644
+index 90561e7..46e93b9 100644
 --- a/test/main.cpp
 +++ b/test/main.cpp
-@@ -34,8 +34,23 @@
+@@ -34,8 +34,24 @@
  
  #include <gtest/gtest.h>
  
@@ -39,6 +39,7 @@ index 90561e7..eb4c763 100644
 +    modifier.setPointCloud2FieldsByString(1, "xyz");
 +
 +    sensor_msgs::PointCloud2Iterator<float> iter_x(cloud_msg, "x");
++
 +    exit(0);
 +  }, ::testing::ExitedWithCode(0), "");
 +}
@@ -46,3 +47,21 @@ index 90561e7..eb4c763 100644
  TEST(sensor_msgs, PointCloud2Iterator)
  {
    // Create a dummy PointCloud2
+@@ -111,6 +127,17 @@ TEST(sensor_msgs, PointCloud2Iterator)
+     iter_const_2_g += 1;
+     iter_const_2_b = iter_const_2_b + 1;
+   }
++  EXPECT_FALSE(iter_const_1_y != iter_const_1_y.end());
++  EXPECT_FALSE(iter_const_1_z != iter_const_1_z.end());
++  EXPECT_FALSE(iter_const_1_r != iter_const_1_r.end());
++  EXPECT_FALSE(iter_const_1_g != iter_const_1_g.end());
++  EXPECT_FALSE(iter_const_1_b != iter_const_1_b.end());
++  EXPECT_FALSE(iter_const_2_x != iter_const_2_x.end());
++  EXPECT_FALSE(iter_const_2_y != iter_const_2_y.end());
++  EXPECT_FALSE(iter_const_2_z != iter_const_2_z.end());
++  EXPECT_FALSE(iter_const_2_r != iter_const_2_r.end());
++  EXPECT_FALSE(iter_const_2_g != iter_const_2_g.end());
++  EXPECT_FALSE(iter_const_2_b != iter_const_2_b.end());
+   EXPECT_EQ(i, n_points);
+ }
+ 


### PR DESCRIPTION
front()/back() of empty STL container causes undefined behavior and causes assertion error on recent libstdc++.
