### PR TITLE
v3.20/ros/noetic/ros-noetic-pluginlib: fix runtime dependencies

### DIFF
--- a/v3.20/ros/noetic/ros-noetic-pluginlib/apkbuild_hook.sh
+++ b/v3.20/ros/noetic/ros-noetic-pluginlib/apkbuild_hook.sh
@@ -1,0 +1,3 @@
+apkbuild_hook() {
+  depends="${depends} boost ros-noetic-class-loader ros-noetic-rosconsole ros-noetic-roslib tinyxml2"
+}


### PR DESCRIPTION
As we separated -dev packages, runtime dependencies must be specified correctly