### PR TITLE
v3.20/ros/noetic/ros-noetic-image-transport-plugins: port 1.15.0

### DIFF
--- a/v3.20/ros/noetic/ros-noetic-compressed-depth-image-transport/apkbuild_hook.sh
+++ b/v3.20/ros/noetic/ros-noetic-compressed-depth-image-transport/apkbuild_hook.sh
@@ -1,0 +1,9 @@
+apkbuild_hook() {
+  test ${pkgver} = 1.14.0
+  pkgver=1.15.0
+  rosinstall="- git:
+      local-name: ${_pkgname}
+      uri: https://github.com/ros-gbp/image_transport_plugins-release.git
+      version: release/noetic/${_pkgname}/1.15.0-1
+  "
+}

--- a/v3.20/ros/noetic/ros-noetic-compressed-image-transport/apkbuild_hook.sh
+++ b/v3.20/ros/noetic/ros-noetic-compressed-image-transport/apkbuild_hook.sh
@@ -1,0 +1,13 @@
+apkbuild_hook() {
+  test ${pkgver} = 1.14.0
+  pkgver=1.15.0
+  rosinstall="- git:
+      local-name: ${_pkgname}
+      uri: https://github.com/ros-gbp/image_transport_plugins-release.git
+      version: release/noetic/${_pkgname}/1.15.0-1
+  "
+  depends="ros-noetic-cv-bridge ros-noetic-dynamic-reconfigure ros-noetic-image-transport"
+  makedepends="chrpath libjpeg-turbo-dev py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-noetic-catkin ros-noetic-catkin-dev ros-noetic-cv-bridge ros-noetic-cv-bridge-dev ros-noetic-dynamic-reconfigure ros-noetic-dynamic-reconfigure-dev ros-noetic-image-transport ros-noetic-image-transport-dev ros-noetic-rostest ros-noetic-rostest-dev"
+  depends_dev="libjpeg-turbo-dev ros-noetic-cv-bridge-dev ros-noetic-dynamic-reconfigure-dev ros-noetic-image-transport ros-noetic-image-transport-dev"
+
+}

--- a/v3.20/ros/noetic/ros-noetic-image-transport-plugins/apkbuild_hook.sh
+++ b/v3.20/ros/noetic/ros-noetic-image-transport-plugins/apkbuild_hook.sh
@@ -1,0 +1,9 @@
+apkbuild_hook() {
+  test ${pkgver} = 1.14.0
+  pkgver=1.15.0
+  rosinstall="- git:
+      local-name: ${_pkgname}
+      uri: https://github.com/ros-gbp/image_transport_plugins-release.git
+      version: release/noetic/${_pkgname}/1.15.0-1
+  "
+}

--- a/v3.20/ros/noetic/ros-noetic-theora-image-transport/apkbuild_hook.sh
+++ b/v3.20/ros/noetic/ros-noetic-theora-image-transport/apkbuild_hook.sh
@@ -1,0 +1,9 @@
+apkbuild_hook() {
+  test ${pkgver} = 1.14.0
+  pkgver=1.15.0
+  rosinstall="- git:
+      local-name: ${_pkgname}
+      uri: https://github.com/ros-gbp/image_transport_plugins-release.git
+      version: release/noetic/${_pkgname}/1.15.0-1
+  "
+}


### PR DESCRIPTION
Reverted due to Debian Buster on the official rosdistro: https://github.com/ros/rosdistro/pull/36304