### PR TITLE
v3.20/backports/pcl: suppress empty cloud conversion warning

### DIFF
--- a/v3.20/backports/pcl/APKBUILD
+++ b/v3.20/backports/pcl/APKBUILD
@@ -12,7 +12,8 @@ makedepends="cmake eigen-dev boost-dev flann-dev qhull-dev qhull-static vtk-dev"
 subpackages="$pkgname-dev $pkgname-doc"
 _gtestver=1.8.0
 source="$pkgname-$pkgver.tar.gz::https://github.com/PointCloudLibrary/$pkgname/archive/$pkgname-$pkgver.tar.gz
-  release-$_gtestver.tar.gz::https://github.com/google/googletest/archive/release-$_gtestver.tar.gz"
+  release-$_gtestver.tar.gz::https://github.com/google/googletest/archive/release-$_gtestver.tar.gz
+  suppress-empty-cloud-conversion-warn.patch"
 builddir="$srcdir/$pkgname-$pkgname-$pkgver"
 
 build() {
@@ -79,4 +80,5 @@ check() {
 sha512sums="
 8e2d2839fe73a955d49b9a72861de2becf2da9a0dc906bd10ab8a3518e270a2f1900d801922d02871d704f2ed380273d35c2d0e04d8da7e24a21eb351c43c00b  pcl-1.14.1.tar.gz
 1dbece324473e53a83a60601b02c92c089f5d314761351974e097b2cf4d24af4296f9eb8653b6b03b1e363d9c5f793897acae1f0c7ac40149216035c4d395d9d  release-1.8.0.tar.gz
+f037e3a492002289e0a4542e96c33aa4c254795fda0198897915731b2f216840476eceba80d6626991e3666c3d6eb1b3b1a436b8804793172c0b1a67344cd228  suppress-empty-cloud-conversion-warn.patch
 "

--- a/v3.20/backports/pcl/APKBUILD
+++ b/v3.20/backports/pcl/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Bradley J Chambers <brad.chambers@gmail.com>
 pkgname=pcl
 pkgver=1.14.1
-pkgrel=0
+pkgrel=1
 pkgdesc="Point Cloud Library (PCL)"
 url="https://github.com/PointCloudLibrary/pcl"
 arch="all !x86 !s390x" # tests fails on x86 and s390x

--- a/v3.20/backports/pcl/suppress-empty-cloud-conversion-warn.patch
+++ b/v3.20/backports/pcl/suppress-empty-cloud-conversion-warn.patch
@@ -1,0 +1,12 @@
+diff --git a/common/include/pcl/conversions.h b/common/include/pcl/conversions.h
+index 20072819d..896d8abb1 100644
+--- a/common/include/pcl/conversions.h
++++ b/common/include/pcl/conversions.h
+@@ -176,7 +176,6 @@ namespace pcl
+     // check if there is data to copy
+     if (msg.width * msg.height == 0)
+     {
+-      PCL_WARN("[pcl::fromPCLPointCloud2] No data to copy.\n");
+       return;
+     }
+ 

--- a/v3.20/ros/noetic/ros-noetic-ifm3d-core/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-ifm3d-core/APKBUILD
@@ -1,7 +1,7 @@
 pkgname=ros-noetic-ifm3d-core
 _pkgname=ifm3d_core
 pkgver=0.18.0
-pkgrel=1
+pkgrel=2
 pkgdesc="$_pkgname package for ROS noetic"
 url="https://github.com/ifm/ifm3d"
 arch="all"

--- a/v3.20/ros/noetic/ros-noetic-ifm3d/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-ifm3d/APKBUILD
@@ -1,7 +1,7 @@
 pkgname=ros-noetic-ifm3d
 _pkgname=ifm3d
 pkgver=0.6.2
-pkgrel=1
+pkgrel=2
 pkgdesc="$_pkgname package for ROS noetic"
 url="https://github.com/lovepark/ifm3d-ros"
 arch="all"

--- a/v3.20/ros/noetic/ros-noetic-map-organizer/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-map-organizer/APKBUILD
@@ -1,7 +1,7 @@
 pkgname=ros-noetic-map-organizer
 _pkgname=map_organizer
 pkgver=0.17.1
-pkgrel=1
+pkgrel=2
 pkgdesc="$_pkgname package for ROS noetic"
 url="http://wiki.ros.org/$_pkgname"
 arch="all"

--- a/v3.20/ros/noetic/ros-noetic-mcl-3dl/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-mcl-3dl/APKBUILD
@@ -1,7 +1,7 @@
 pkgname=ros-noetic-mcl-3dl
 _pkgname=mcl_3dl
 pkgver=0.6.2
-pkgrel=2
+pkgrel=3
 pkgdesc="$_pkgname package for ROS noetic"
 url="http://wiki.ros.org/$_pkgname"
 arch="all"

--- a/v3.20/ros/noetic/ros-noetic-obj-to-pointcloud/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-obj-to-pointcloud/APKBUILD
@@ -1,7 +1,7 @@
 pkgname=ros-noetic-obj-to-pointcloud
 _pkgname=obj_to_pointcloud
 pkgver=0.17.1
-pkgrel=1
+pkgrel=2
 pkgdesc="$_pkgname package for ROS noetic"
 url="http://wiki.ros.org/$_pkgname"
 arch="all"

--- a/v3.20/ros/noetic/ros-noetic-pcl-conversions/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-pcl-conversions/APKBUILD
@@ -1,7 +1,7 @@
 pkgname=ros-noetic-pcl-conversions
 _pkgname=pcl_conversions
 pkgver=1.7.4
-pkgrel=1
+pkgrel=2
 pkgdesc="$_pkgname package for ROS noetic"
 url="http://wiki.ros.org/pcl_conversions"
 arch="all"

--- a/v3.20/ros/noetic/ros-noetic-pcl-msgs/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-pcl-msgs/APKBUILD
@@ -1,7 +1,7 @@
 pkgname=ros-noetic-pcl-msgs
 _pkgname=pcl_msgs
 pkgver=0.3.0
-pkgrel=1
+pkgrel=2
 pkgdesc="$_pkgname package for ROS noetic"
 url="http://wiki.ros.org/pcl_msgs"
 arch="all"

--- a/v3.20/ros/noetic/ros-noetic-pcl-ros/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-pcl-ros/APKBUILD
@@ -1,7 +1,7 @@
 pkgname=ros-noetic-pcl-ros
 _pkgname=pcl_ros
 pkgver=1.7.4
-pkgrel=1
+pkgrel=2
 pkgdesc="$_pkgname package for ROS noetic"
 url="http://ros.org/wiki/perception_pcl"
 arch="all"

--- a/v3.20/ros/noetic/ros-noetic-perception-pcl/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-perception-pcl/APKBUILD
@@ -1,7 +1,7 @@
 pkgname=ros-noetic-perception-pcl
 _pkgname=perception_pcl
 pkgver=1.7.4
-pkgrel=1
+pkgrel=2
 pkgdesc="$_pkgname package for ROS noetic"
 url="http://ros.org/wiki/perception_pcl"
 arch="all"

--- a/v3.20/ros/noetic/ros-noetic-perception/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-perception/APKBUILD
@@ -1,7 +1,7 @@
 pkgname=ros-noetic-perception
 _pkgname=perception
 pkgver=1.5.0
-pkgrel=1
+pkgrel=2
 pkgdesc="$_pkgname package for ROS noetic"
 url="https://github.com/ros/metapackages"
 arch="all"

--- a/v3.20/ros/noetic/ros-noetic-safety-limiter/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-safety-limiter/APKBUILD
@@ -1,7 +1,7 @@
 pkgname=ros-noetic-safety-limiter
 _pkgname=safety_limiter
 pkgver=0.17.1
-pkgrel=1
+pkgrel=2
 pkgdesc="$_pkgname package for ROS noetic"
 url="http://wiki.ros.org/$_pkgname"
 arch="all"

--- a/v3.20/ros/noetic/ros-noetic-velodyne-pcl/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-velodyne-pcl/APKBUILD
@@ -1,7 +1,7 @@
 pkgname=ros-noetic-velodyne-pcl
 _pkgname=velodyne_pcl
 pkgver=1.7.0
-pkgrel=1
+pkgrel=2
 pkgdesc="$_pkgname package for ROS noetic"
 url="http://wiki.ros.org/velodyne_pcl"
 arch="all"


### PR DESCRIPTION
ref: https://github.com/PointCloudLibrary/pcl/commit/788c53eab2123df25e5eb34f45d2ed7dfe6cb48b

I'm going to open an issue on pcl repo to suggest removing this warn message