### PR TITLE
backports/pcl: add libs subpackage

### DIFF
--- a/v3.17/backports/pcl/APKBUILD
+++ b/v3.17/backports/pcl/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Bradley J Chambers <brad.chambers@gmail.com>
 pkgname=pcl
 pkgver=1.13.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Point Cloud Library (PCL)"
 url="https://github.com/PointCloudLibrary/pcl"
 arch="all !x86 !s390x" # tests fails on x86 and s390x

--- a/v3.17/backports/pcl/APKBUILD
+++ b/v3.17/backports/pcl/APKBUILD
@@ -9,7 +9,7 @@ arch="all !x86 !s390x" # tests fails on x86 and s390x
 license="BSD-3-Clause"
 depends_dev="eigen-dev boost-dev flann-dev qhull-dev qhull-static vtk-dev"
 makedepends="cmake eigen-dev boost-dev flann-dev qhull-dev qhull-static vtk-dev"
-subpackages="$pkgname-dev $pkgname-doc"
+subpackages="$pkgname-dev $pkgname-doc $pkgname-libs"
 _gtestver=1.8.0
 source="$pkgname-$pkgver.tar.gz::https://github.com/PointCloudLibrary/$pkgname/archive/$pkgname-$pkgver.tar.gz
   release-$_gtestver.tar.gz::https://github.com/google/googletest/archive/release-$_gtestver.tar.gz"

--- a/v3.20/backports/pcl/APKBUILD
+++ b/v3.20/backports/pcl/APKBUILD
@@ -2,14 +2,14 @@
 # Maintainer: Bradley J Chambers <brad.chambers@gmail.com>
 pkgname=pcl
 pkgver=1.14.1
-pkgrel=1
+pkgrel=2
 pkgdesc="Point Cloud Library (PCL)"
 url="https://github.com/PointCloudLibrary/pcl"
 arch="all !x86 !s390x" # tests fails on x86 and s390x
 license="BSD-3-Clause"
 depends_dev="eigen-dev boost-dev flann-dev qhull-dev qhull-static vtk-dev"
 makedepends="cmake eigen-dev boost-dev flann-dev qhull-dev qhull-static vtk-dev"
-subpackages="$pkgname-dev $pkgname-doc"
+subpackages="$pkgname-dev $pkgname-doc $pkgname-libs"
 _gtestver=1.8.0
 source="$pkgname-$pkgver.tar.gz::https://github.com/PointCloudLibrary/$pkgname/archive/$pkgname-$pkgver.tar.gz
   release-$_gtestver.tar.gz::https://github.com/google/googletest/archive/release-$_gtestver.tar.gz


### PR DESCRIPTION
`pcl-libs` is required due to recent update of `pcl_conversions` package. https://github.com/seqsense/aports-ros-experimental/pull/1003#issuecomment-2295661147