### PR TITLE
backports/pcl: Move cmake files into dev subpackage

### DIFF
--- a/v3.17/backports/pcl/APKBUILD
+++ b/v3.17/backports/pcl/APKBUILD
@@ -2,14 +2,14 @@
 # Maintainer: Bradley J Chambers <brad.chambers@gmail.com>
 pkgname=pcl
 pkgver=1.13.0
-pkgrel=2
+pkgrel=3
 pkgdesc="Point Cloud Library (PCL)"
 url="https://github.com/PointCloudLibrary/pcl"
 arch="all !x86 !s390x" # tests fails on x86 and s390x
 license="BSD-3-Clause"
 depends_dev="eigen-dev boost-dev flann-dev qhull-dev qhull-static vtk-dev"
 makedepends="cmake eigen-dev boost-dev flann-dev qhull-dev qhull-static vtk-dev"
-subpackages="$pkgname-dev $pkgname-doc $pkgname-libs"
+subpackages="$pkgname-doc $pkgname-dev $pkgname-libs"
 _gtestver=1.8.0
 source="$pkgname-$pkgver.tar.gz::https://github.com/PointCloudLibrary/$pkgname/archive/$pkgname-$pkgver.tar.gz
   release-$_gtestver.tar.gz::https://github.com/google/googletest/archive/release-$_gtestver.tar.gz"
@@ -69,6 +69,12 @@ package() {
   make DESTDIR="$pkgdir" install
 
   install -Dm 0644 "$builddir"/LICENSE.txt "$pkgdir"/usr/share/licenses/$pkgname/LICENSE.txt
+}
+
+dev() {
+  default_dev
+
+  amove usr/share
 }
 
 check() {

--- a/v3.20/backports/pcl/APKBUILD
+++ b/v3.20/backports/pcl/APKBUILD
@@ -2,14 +2,14 @@
 # Maintainer: Bradley J Chambers <brad.chambers@gmail.com>
 pkgname=pcl
 pkgver=1.14.1
-pkgrel=2
+pkgrel=3
 pkgdesc="Point Cloud Library (PCL)"
 url="https://github.com/PointCloudLibrary/pcl"
 arch="all !x86 !s390x" # tests fails on x86 and s390x
 license="BSD-3-Clause"
 depends_dev="eigen-dev boost-dev flann-dev qhull-dev qhull-static vtk-dev"
 makedepends="cmake eigen-dev boost-dev flann-dev qhull-dev qhull-static vtk-dev"
-subpackages="$pkgname-dev $pkgname-doc $pkgname-libs"
+subpackages="$pkgname-doc $pkgname-dev $pkgname-libs"
 _gtestver=1.8.0
 source="$pkgname-$pkgver.tar.gz::https://github.com/PointCloudLibrary/$pkgname/archive/$pkgname-$pkgver.tar.gz
   release-$_gtestver.tar.gz::https://github.com/google/googletest/archive/release-$_gtestver.tar.gz
@@ -70,6 +70,12 @@ package() {
   make DESTDIR="$pkgdir" install
 
   install -Dm 0644 "$builddir"/LICENSE.txt "$pkgdir"/usr/share/licenses/$pkgname/LICENSE.txt
+}
+
+dev() {
+  default_dev
+
+  amove usr/share
 }
 
 check() {


### PR DESCRIPTION
The cmake files of `pcl` package are under `/usr/share` so `default_dev` doesn't move them into the subpackage directory. This PR uses custom `dev()` method to fix that like https://git.alpinelinux.org/aports/tree/testing/pcl/APKBUILD?id=d0c76b95c9b00375feb9d41d081048215674e151. By this change, it fails to create `-doc` package because the share directory isn't available after `dev()` so the order of subpackages is changed.