### PR TITLE
Mark ROS package APKBUILD files as generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+v*/ros/*/ros-*/APKBUILD linguist-generated=true


### PR DESCRIPTION
Generated files will be folded by default on PRs.
It should make review easier for focusing on reviewing manually added patches.

(APKBUILD files under backports are manually written and aren't affected by this setting)

https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github