### PR TITLE
ros-noetic-imu-filter-madgwick: add patch to set tcpNoDelay option to IMU topic

### DIFF
--- a/v3.17/ros/noetic/ros-noetic-imu-filter-madgwick/APKBUILD
+++ b/v3.17/ros/noetic/ros-noetic-imu-filter-madgwick/APKBUILD
@@ -1,7 +1,7 @@
 pkgname=ros-noetic-imu-filter-madgwick
 _pkgname=imu_filter_madgwick
 pkgver=1.2.7
-pkgrel=0
+pkgrel=1
 pkgdesc="$_pkgname package for ROS noetic"
 url="http://ros.org/wiki/imu_filter_madgwick"
 arch="all"

--- a/v3.17/ros/noetic/ros-noetic-imu-filter-madgwick/tcp-no-delay.patch
+++ b/v3.17/ros/noetic/ros-noetic-imu-filter-madgwick/tcp-no-delay.patch
@@ -1,0 +1,21 @@
+diff --git a/src/imu_filter_ros.cpp b/src/imu_filter_ros.cpp
+index ed8bd98..c9766aa 100644
+--- a/src/imu_filter_ros.cpp
++++ b/src/imu_filter_ros.cpp
+@@ -137,12 +137,14 @@ ImuFilterRos::ImuFilterRos(ros::NodeHandle nh, ros::NodeHandle nh_private)
+     int queue_size = 5;
+ 
+     imu_subscriber_.reset(new ImuSubscriber(
+-        nh_, ros::names::resolve("imu") + "/data_raw", queue_size));
++        nh_, ros::names::resolve("imu") + "/data_raw", queue_size,
++        ros::TransportHints().tcpNoDelay(true)));
+ 
+     if (use_mag_)
+     {
+         mag_subscriber_.reset(new MagSubscriber(
+-            nh_, ros::names::resolve("imu") + "/mag", queue_size));
++            nh_, ros::names::resolve("imu") + "/mag", queue_size,
++            ros::TransportHints().tcpNoDelay(true)));
+ 
+         sync_.reset(new Synchronizer(SyncPolicy(queue_size), *imu_subscriber_,
+                                      *mag_subscriber_));

--- a/v3.20/ros/noetic/ros-noetic-imu-filter-madgwick/APKBUILD
+++ b/v3.20/ros/noetic/ros-noetic-imu-filter-madgwick/APKBUILD
@@ -1,7 +1,7 @@
 pkgname=ros-noetic-imu-filter-madgwick
 _pkgname=imu_filter_madgwick
 pkgver=1.2.7
-pkgrel=0
+pkgrel=1
 pkgdesc="$_pkgname package for ROS noetic"
 url="http://ros.org/wiki/imu_filter_madgwick"
 arch="all"

--- a/v3.20/ros/noetic/ros-noetic-imu-filter-madgwick/tcp-no-delay.patch
+++ b/v3.20/ros/noetic/ros-noetic-imu-filter-madgwick/tcp-no-delay.patch
@@ -1,0 +1,21 @@
+diff --git a/src/imu_filter_ros.cpp b/src/imu_filter_ros.cpp
+index ed8bd98..c9766aa 100644
+--- a/src/imu_filter_ros.cpp
++++ b/src/imu_filter_ros.cpp
+@@ -137,12 +137,14 @@ ImuFilterRos::ImuFilterRos(ros::NodeHandle nh, ros::NodeHandle nh_private)
+     int queue_size = 5;
+ 
+     imu_subscriber_.reset(new ImuSubscriber(
+-        nh_, ros::names::resolve("imu") + "/data_raw", queue_size));
++        nh_, ros::names::resolve("imu") + "/data_raw", queue_size,
++        ros::TransportHints().tcpNoDelay(true)));
+ 
+     if (use_mag_)
+     {
+         mag_subscriber_.reset(new MagSubscriber(
+-            nh_, ros::names::resolve("imu") + "/mag", queue_size));
++            nh_, ros::names::resolve("imu") + "/mag", queue_size,
++            ros::TransportHints().tcpNoDelay(true)));
+ 
+         sync_.reset(new Synchronizer(SyncPolicy(queue_size), *imu_subscriber_,
+                                      *mag_subscriber_));


### PR DESCRIPTION
Latency of IMU data should be minimized in almost every use cases