### PR TITLE
v3.20/ros/jazzy/ros-jazzy-laser-filters: Fix segmentation fault during compilation

### DIFF
--- a/v3.20/ros/jazzy/ros-jazzy-laser-filters/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-laser-filters/APKBUILD
@@ -1,7 +1,7 @@
 pkgname=ros-jazzy-laser-filters
 _pkgname=laser_filters
 pkgver=2.0.8
-pkgrel=0
+pkgrel=1
 pkgdesc="$_pkgname package for ROS jazzy"
 url="http://ros.org/wiki/laser_filters"
 arch="all"

--- a/v3.20/ros/jazzy/ros-jazzy-laser-filters/apkbuild_hook.sh
+++ b/v3.20/ros/jazzy/ros-jazzy-laser-filters/apkbuild_hook.sh
@@ -1,3 +1,4 @@
 apkbuild_hook() {
   makedepends="${makedepends} ros-jazzy-launch-ros"
+  export MAKEFLAGS="-j1 -l1"
 }


### PR DESCRIPTION
Additional modification for [internal compiler error during building laser_filters package](https://github.com/seqsense/aports-ros-experimental/pull/834#issuecomment-1571211425).
The problem still occurs occasionally.

According to https://forums.developer.nvidia.com/t/ros-hector-mapping-c-internal-compiler-error-segmentation-fault-program-cc1plus/199672, the error might be related to the memory usage. 
In this PR, number of parallel building is reduce to reduce memory usage.