### PR TITLE
ros-jazzy-demos-nodes-cpp: Disable copyright check

### DIFF
--- a/v3.20/ros/jazzy/ros-jazzy-demo-nodes-cpp-native/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-demo-nodes-cpp-native/APKBUILD
@@ -1,7 +1,7 @@
 pkgname=ros-jazzy-demo-nodes-cpp-native
 _pkgname=demo_nodes_cpp_native
 pkgver=0.33.5
-pkgrel=0
+pkgrel=1
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
 arch="all"

--- a/v3.20/ros/jazzy/ros-jazzy-demo-nodes-cpp-native/diable-copyright-test.patch
+++ b/v3.20/ros/jazzy/ros-jazzy-demo-nodes-cpp-native/diable-copyright-test.patch
@@ -1,0 +1,14 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 2bccfe5..4473107 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -44,6 +44,9 @@ install(TARGETS
+ 
+ if(BUILD_TESTING)
+   find_package(ament_lint_auto REQUIRED)
++  list(APPEND AMENT_LINT_AUTO_EXCLUDE
++    ament_cmake_copyright
++  )
+   ament_lint_auto_find_test_dependencies()
+ 
+   find_package(ament_cmake_pytest REQUIRED)


### PR DESCRIPTION
Fix https://github.com/seqsense/aports-ros-experimental/issues/1133