### PR TITLE
Retry on gcc internal compiler error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,8 +31,11 @@ RUN apk add --no-cache \
 
 VOLUME /cache
 
-ENV CC=/usr/lib/ccache/bin/gcc \
-  CXX=/usr/lib/ccache/bin/g++ \
+COPY scripts/gcc-with-retry/gcc /usr/lib/gcc-with-retry/gcc
+RUN ln -s /usr/lib/gcc-with-retry/gcc /usr/lib/gcc-with-retry/g++
+
+ENV CC=/usr/lib/gcc-with-retry/gcc \
+  CXX=/usr/lib/gcc-with-retry/g++ \
   CCACHE_DIR=/cache/ccache \
   CCACHE_DEPEND=true
 

--- a/scripts/gcc-with-retry/gcc
+++ b/scripts/gcc-with-retry/gcc
@@ -2,6 +2,8 @@
 
 set -u
 
+echo "gcc with retry on internal compiler error: $@" >&2
+
 GCC_ICE_RETRY_NUM=${GCC_ICE_RETRY_NUM:-5}
 
 compiler=$(basename $0)
@@ -11,10 +13,14 @@ for i in $(seq ${GCC_ICE_RETRY_NUM}); do
   exit_code=$?
   case ${exit_code} in
     4)
-      echo "gcc internal compiler error is detected: retrying (${i})"
+      echo "gcc internal compiler error is detected: retrying (${i})" >&2
       continue
       ;;
+    0)
+      exit 0
+      ;;
     *)
+      echo "gcc failed with exit code ${exit_code}" >&2
       exit ${exit_code}
       ;;
   esac

--- a/scripts/gcc-with-retry/gcc
+++ b/scripts/gcc-with-retry/gcc
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+set -u
+
+GCC_ICE_RETRY_NUM=${GCC_ICE_RETRY_NUM:-5}
+
+compiler=$(basename $0)
+
+for i in $(seq ${GCC_ICE_RETRY_NUM}); do
+  /usr/lib/ccache/bin/${compiler} $@
+  exit_code=$?
+  case ${exit_code} in
+    4)
+      echo "gcc internal compiler error is detected: retrying (${i})"
+      continue
+      ;;
+    *)
+      exit ${exit_code}
+      ;;
+  esac
+done

--- a/scripts/gcc-with-retry/gcc
+++ b/scripts/gcc-with-retry/gcc
@@ -9,7 +9,7 @@ GCC_ICE_RETRY_NUM=${GCC_ICE_RETRY_NUM:-5}
 compiler=$(basename $0)
 
 for i in $(seq ${GCC_ICE_RETRY_NUM}); do
-  /usr/lib/ccache/bin/${compiler} $@
+  /usr/lib/ccache/bin/${compiler} -pass-exit-codes $@
   exit_code=$?
   case ${exit_code} in
     4)

--- a/scripts/gcc-with-retry/gcc
+++ b/scripts/gcc-with-retry/gcc
@@ -2,8 +2,6 @@
 
 set -u
 
-echo "gcc with retry on internal compiler error: $@" >&2
-
 GCC_ICE_RETRY_NUM=${GCC_ICE_RETRY_NUM:-5}
 
 compiler=$(basename $0)


### PR DESCRIPTION
Retry gcc/g++ command if failed with internal compiler error.

```
[ 86%] Built target SlamToolboxPlugin
[ 86%] Building CXX object CMakeFiles/toolbox_common.dir/src/laser_utils.cpp.o
during GIMPLE pass: strlen
In file included from /usr/ros/jazzy/include/rclcpp/rclcpp/callback_group.hpp:28,
                 from /usr/ros/jazzy/include/rclcpp/rclcpp/any_executable.hpp:20,
                 from /usr/ros/jazzy/include/rclcpp/rclcpp/memory_strategy.hpp:25,
                 from /usr/ros/jazzy/include/rclcpp/rclcpp/memory_strategies.hpp:18,
                 from /usr/ros/jazzy/include/rclcpp/rclcpp/executor_options.hpp:22,
                 from /usr/ros/jazzy/include/rclcpp/rclcpp/executor.hpp:38,
                 from /usr/ros/jazzy/include/rclcpp/rclcpp/executors/multi_threaded_executor.hpp:25,
                 from /usr/ros/jazzy/include/rclcpp/rclcpp/executors.hpp:21,
                 from /usr/ros/jazzy/include/rclcpp/rclcpp/rclcpp.hpp:172,
                 from /home/builder/aports/jazzy/ros-jazzy-slam-toolbox/abuild/src/slam_toolbox/include/slam_toolbox/slam_toolbox_common.hpp:33,
                 from /home/builder/aports/jazzy/ros-jazzy-slam-toolbox/abuild/src/slam_toolbox/src/slam_toolbox_common.cpp:23:
/usr/ros/jazzy/include/rclcpp/rclcpp/service.hpp: In member function 'void rclcpp::Service<ServiceT>::send_response(rmw_request_id_t&, typename ServiceT::Response&) [with ServiceT = nav_msgs::srv::GetMap]':
/usr/ros/jazzy/include/rclcpp/rclcpp/service.hpp:485:3: internal compiler error: Segmentation fault
  485 |   send_response(rmw_request_id_t & req_id, typename ServiceT::Response & response)
      |   ^~~~~~~~~~~~~
0x1c584c7 internal_error(char const*, ...)
	???:0
Please submit a full bug report, with preprocessed source (by using -freport-bug).
Please include the complete backtrace with any bug report.
See <https://gitlab.alpinelinux.org/alpine/aports/-/issues> for instructions.
gcc internal compiler error is detected: retrying (1)
[ 86%] Building CXX object CMakeFiles/toolbox_common.dir/src/map_saver.cpp.o
[ 87%] Building CXX object CMakeFiles/toolbox_common.dir/src/slam_mapper.cpp.o
during GIMPLE pass: strlen
In file included from /usr/ros/jazzy/include/rclcpp/rclcpp/callback_group.hpp:28,
                 from /usr/ros/jazzy/include/rclcpp/rclcpp/any_executable.hpp:20,
                 from /usr/ros/jazzy/include/rclcpp/rclcpp/memory_strategy.hpp:25,
                 from /usr/ros/jazzy/include/rclcpp/rclcpp/memory_strategies.hpp:18,
                 from /usr/ros/jazzy/include/rclcpp/rclcpp/executor_options.hpp:22,
                 from /usr/ros/jazzy/include/rclcpp/rclcpp/executor.hpp:38,
                 from /usr/ros/jazzy/include/rclcpp/rclcpp/executors/multi_threaded_executor.hpp:25,
                 from /usr/ros/jazzy/include/rclcpp/rclcpp/executors.hpp:21,
                 from /usr/ros/jazzy/include/rclcpp/rclcpp/rclcpp.hpp:172,
                 from /home/builder/aports/jazzy/ros-jazzy-slam-toolbox/abuild/src/slam_toolbox/include/slam_toolbox/map_saver.hpp:25,
                 from /home/builder/aports/jazzy/ros-jazzy-slam-toolbox/abuild/src/slam_toolbox/src/map_saver.cpp:21:
/usr/ros/jazzy/include/rclcpp/rclcpp/service.hpp: In member function 'void rclcpp::Service<ServiceT>::send_response(rmw_request_id_t&, typename ServiceT::Response&) [with ServiceT = slam_toolbox::srv::SaveMap]':
/usr/ros/jazzy/include/rclcpp/rclcpp/service.hpp:485:3: internal compiler error: Segmentation fault
  485 |   send_response(rmw_request_id_t & req_id, typename ServiceT::Response & response)
      |   ^~~~~~~~~~~~~
0x1c584c7 internal_error(char const*, ...)
	???:0
Please submit a full bug report, with preprocessed source (by using -freport-bug).
Please include the complete backtrace with any bug report.
See <https://gitlab.alpinelinux.org/alpine/aports/-/issues> for instructions.
gcc internal compiler error is detected: retrying (1)
[ 88%] Linking CXX shared library libtoolbox_common.so
[ 88%] Built target toolbox_common
```
Second try succeeded on these failures.


---

ref: exit code of gcc ICE: https://gcc.gnu.org/legacy-ml/gcc-patches/2006-03/msg01203.html