### PR TITLE
v3.20: update py3-colcon-ros

### DIFF
--- a/v3.20/backports/py3-colcon-ros/APKBUILD
+++ b/v3.20/backports/py3-colcon-ros/APKBUILD
@@ -1,7 +1,7 @@
 pkgname=py3-colcon-ros
 _pkgname=colcon-ros
-pkgver=0.4.1
-pkgrel=3
+pkgver=0.5.0
+pkgrel=4
 pkgdesc="Extension for colcon to support ROS packages."
 url="http://colcon.readthedocs.io"
 arch="noarch"
@@ -10,7 +10,8 @@ depends="python3 py3-catkin-pkg py3-colcon-cmake py3-colcon-core py3-colcon-pkg-
 makedepends="py3-gpep517 py3-setuptools py3-wheel"
 checkdepends="py3-pip py3-pytest py3-flake8"
 subpackages="$pkgname-doc"
-source="${_pkgname}-${pkgver}.tar.gz::https://github.com/colcon/$_pkgname/archive/refs/tags/$pkgver.tar.gz"
+source="${_pkgname}-${pkgver}.tar.gz::https://github.com/colcon/$_pkgname/archive/refs/tags/$pkgver.tar.gz
+        fix-flake8-f824.patch"
 builddir="$srcdir/$_pkgname-$pkgver"
 
 build() {
@@ -35,4 +36,5 @@ package() {
         install -Dm644 $builddir/LICENSE "$pkgdir"/usr/share/licenses/$pkgname/LICENSE
 }
 
-sha512sums="3dea3aa961518656b3bc5add702b556cd710e778312440073dd336f03ebc54c0d74c33a0a14558a59fe7142884b028214bb8b6620defc4d95da393d23bf45686  colcon-ros-0.4.1.tar.gz"
+sha512sums="3ff2b4cc07e85fdf0991a8a0e1ac0c998a68967835fbe9df2e46b69da61e5e9f364eb60f02ccecafcd4a474043fc0e0fdd4d0139aa15990b84c397227b0780f3  colcon-ros-0.5.0.tar.gz
+65ce3c7d850076b2d083d99595d31a9943686aa1ce97b0e23916589a9159f0e8a4f699ef2337d5a0d6c3162936709c66d08850f56cd14f0fe7bb56b0a3ea3664  fix-flake8-f824.patch"

--- a/v3.20/backports/py3-colcon-ros/fix-flake8-f824.patch
+++ b/v3.20/backports/py3-colcon-ros/fix-flake8-f824.patch
@@ -1,0 +1,75 @@
+diff --git a/colcon_ros/package_augmentation/ros_ament_python.py b/colcon_ros/package_augmentation/ros_ament_python.py
+index 532d5f8..c9a068c 100644
+--- a/colcon_ros/package_augmentation/ros_ament_python.py
++++ b/colcon_ros/package_augmentation/ros_ament_python.py
+@@ -46,14 +46,12 @@ class RosAmentPythonPackageAugmentation(PackageAugmentationExtensionPoint):
+                         options = config.get('options', {})
+ 
+                         def getter(env):
+-                            nonlocal options
+                             return options
+                         break
+         else:
+             # use information from setup.py file
+ 
+             def getter(env):  # noqa: F811
+-                nonlocal desc
+                 return get_setup_information(
+                     desc.path / 'setup.py', env=env)
+ 
+diff --git a/colcon_ros/package_identification/ros.py b/colcon_ros/package_identification/ros.py
+index 4bfe190..ce68787 100644
+--- a/colcon_ros/package_identification/ros.py
++++ b/colcon_ros/package_identification/ros.py
+@@ -86,7 +86,6 @@ class RosPackageIdentification(
+             descs, additional_argument_names=additional_argument_names)
+ 
+         # get all parsed ROS package manifests
+-        global _cached_packages
+         pkgs = {}
+         for desc in descs:
+             if str(desc.path) not in _cached_packages:
+@@ -161,7 +160,6 @@ def add_group_dependencies(pkgs):
+ 
+ def get_package_with_build_type(path: str):
+     """Get the ROS package and its build type for the given path."""
+-    global _cached_packages
+     if path not in _cached_packages:
+         pkg = _get_package(path)
+         build_type = _get_build_type(pkg, path) if pkg else None
+diff --git a/colcon_ros/prefix_path/ament.py b/colcon_ros/prefix_path/ament.py
+index e060c9c..388ece6 100644
+--- a/colcon_ros/prefix_path/ament.py
++++ b/colcon_ros/prefix_path/ament.py
+@@ -24,7 +24,6 @@ class AmentPrefixPath(PrefixPathExtensionPoint):
+             PrefixPathExtensionPoint.EXTENSION_POINT_VERSION, '^1.0')
+ 
+     def extend_prefix_path(self, paths):  # noqa: D102
+-        global _get_ament_prefix_path_warnings
+         ament_prefix_path = os.environ.get('AMENT_PREFIX_PATH', '')
+         for path in ament_prefix_path.split(os.pathsep):
+             if not path:
+diff --git a/colcon_ros/prefix_path/catkin.py b/colcon_ros/prefix_path/catkin.py
+index 624e404..260f3b1 100644
+--- a/colcon_ros/prefix_path/catkin.py
++++ b/colcon_ros/prefix_path/catkin.py
+@@ -28,7 +28,6 @@ class CmakePrefixPath(PrefixPathExtensionPoint):
+             PrefixPathExtensionPoint.EXTENSION_POINT_VERSION, '^1.0')
+ 
+     def extend_prefix_path(self, paths):  # noqa: D102
+-        global _get_cmake_prefix_path_warnings
+         cmake_prefix_path = os.environ.get('CMAKE_PREFIX_PATH', '')
+         for path in cmake_prefix_path.split(os.pathsep):
+             if not path:
+diff --git a/test/test_spell_check.py b/test/test_spell_check.py
+index 5861814..39484e9 100644
+--- a/test/test_spell_check.py
++++ b/test/test_spell_check.py
+@@ -10,7 +10,6 @@ spell_check_words_path = Path(__file__).parent / 'spell_check.words'
+ 
+ @pytest.fixture(scope='module')
+ def known_words():
+-    global spell_check_words_path
+     return spell_check_words_path.read_text().splitlines()
+ 
+ 


### PR DESCRIPTION
The goal of this PR is to solve the following error observed in `v3.20` (but not in `v3.23`):

```
colcon build --cmake-args -DCMAKE_CXX_FLAGS="-Wall -O0 -coverage" -DCMAKE_C_FLAGS="-Wall -O0 -coverage" -DCMAKE_POLICY_VERSION_MINIMUM=3.5
usage: colcon [-h] [--log-base LOG_BASE] [--log-level LOG_LEVEL] {build,test,test-result} ...
colcon: error: unrecognized arguments: -DCMAKE_POLICY_VERSION_MINIMUM=3.5
```