### PR TITLE
ros-jazzy-launch-testing: update to 3.4.11 and refresh disable-failing-test.patch

### DIFF
--- a/v3.20/ros/jazzy/ros-jazzy-launch-testing/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-launch-testing/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-launch-testing
 _pkgname=launch_testing
-pkgver=3.4.10
+pkgver=3.4.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: launch_testing
     uri: https://github.com/ros2-gbp/launch-release.git
-    version: release/jazzy/launch_testing/3.4.10-1
+    version: release/jazzy/launch_testing/3.4.11-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-launch-testing/disable-failing-test.patch
+++ b/v3.20/ros/jazzy/ros-jazzy-launch-testing/disable-failing-test.patch
@@ -1,6 +1,6 @@
 diff --git a/test/launch_testing/test_io_handler_and_assertions.py b/test/launch_testing/test_io_handler_and_assertions.py
 deleted file mode 100644
-index 68f262f..0000000
+index d6bcea5..0000000
 --- a/test/launch_testing/test_io_handler_and_assertions.py
 +++ /dev/null
 @@ -1,188 +0,0 @@
@@ -112,7 +112,7 @@ index 68f262f..0000000
 -        matches = [t for t in text_lines if 'Called with arguments' in t]
 -        print('Called with arguments: {}'.format(matches))
 -
--        # Two process have args, because thats how process names are passed down
+-        # Two process have args, because that's how process names are passed down
 -        self.assertEqual(2, len(matches))
 -
 -        matches_extra = [t for t in matches if '--extra' in t]

--- a/v3.23/ros/jazzy/ros-jazzy-launch-testing/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-launch-testing/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-launch-testing
 _pkgname=launch_testing
-pkgver=3.4.10
+pkgver=3.4.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: launch_testing
     uri: https://github.com/ros2-gbp/launch-release.git
-    version: release/jazzy/launch_testing/3.4.10-1
+    version: release/jazzy/launch_testing/3.4.11-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-launch-testing/disable-failing-test.patch
+++ b/v3.23/ros/jazzy/ros-jazzy-launch-testing/disable-failing-test.patch
@@ -1,6 +1,6 @@
 diff --git a/test/launch_testing/test_io_handler_and_assertions.py b/test/launch_testing/test_io_handler_and_assertions.py
 deleted file mode 100644
-index 68f262f..0000000
+index d6bcea5..0000000
 --- a/test/launch_testing/test_io_handler_and_assertions.py
 +++ /dev/null
 @@ -1,188 +0,0 @@
@@ -112,7 +112,7 @@ index 68f262f..0000000
 -        matches = [t for t in text_lines if 'Called with arguments' in t]
 -        print('Called with arguments: {}'.format(matches))
 -
--        # Two process have args, because thats how process names are passed down
+-        # Two process have args, because that's how process names are passed down
 -        self.assertEqual(2, len(matches))
 -
 -        matches_extra = [t for t in matches if '--extra' in t]


### PR DESCRIPTION
Unblocks the jazzy auto-update PRs #1280 and #1281, both of which currently fail at `prepare` on this package.

## Why they fail

`launch_testing` 3.4.11 changes exactly one line of `test_io_handler_and_assertions.py` — a typo in a comment:

```diff
-        # Two process have args, because thats how process names are passed down
+        # Two process have args, because that's how process names are passed down
```

`disable-failing-test.patch` deletes that file, so it carries all 188 of its lines as context. One upstream character is enough to stop it applying:

```
Applying .../disable-failing-test.patch
patching file test/launch_testing/test_io_handler_and_assertions.py
Reversed (or previously applied) patch detected!  Assume -R? [n]
Apply anyway? [n]
Skipping patch.
1 out of 1 hunk ignored -- saving rejects to file ...rej
>>> ERROR: ros-jazzy-launch-testing: prepare failed
```

## Why the version bump is in here too

The refreshed patch matches 3.4.11 and only 3.4.11. A patch-only change would break the build at the 3.4.10 currently on master, so the two have to move together — which is also why this could not simply be pushed onto the bot branches.

Both jazzy trees hold byte-identical copies of the package and of the patch, so `v3.20` and `v3.23` move together.

## Verification

Checked out `release/jazzy/launch_testing/3.4.11-1` and ran `patch -p1 --dry-run`:

| patch | result at 3.4.11 |
|---|---|
| current (master) | `Reversed (or previously applied) patch detected` → `Skipping patch` |
| refreshed, `v3.20` | applies cleanly |
| refreshed, `v3.23` | applies cleanly |

## Not covered

- **humble** — its `launch_testing` is on a different version line and is not bumped by the current auto-update PRs. Left alone.
- **#1278 (humble-3.20)** fails for an unrelated reason: `ros-humble-ament-flake8` runs `python -m pytest` from the generated `check()` while `py3-pytest7` is absent from its makedepends, because the generated `makedepends` comes from `package.xml` while `check()` decides how to run tests by grepping `setup.py`.
- **#1281** also reports `ros-jazzy-performance-test-fixture*: libmemory_tools.so: path not found` earlier in its log; not investigated here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)