### PR TITLE
[test] jazzy auto-update (#1280 + #1281) with the launch_testing patch fix (#1282)

### DIFF
--- a/v3.20/ros/jazzy/ros-jazzy-action-msgs/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-action-msgs/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-action-msgs
 _pkgname=action_msgs
-pkgver=2.0.3
+pkgver=2.0.4
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: action_msgs
     uri: https://github.com/ros2-gbp/rcl_interfaces-release.git
-    version: release/jazzy/action_msgs/2.0.3-1
+    version: release/jazzy/action_msgs/2.0.4-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-action-tutorials-cpp/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-action-tutorials-cpp/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-action-tutorials-cpp
 _pkgname=action_tutorials_cpp
-pkgver=0.33.9
+pkgver=0.33.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: action_tutorials_cpp
     uri: https://github.com/ros2-gbp/demos-release.git
-    version: release/jazzy/action_tutorials_cpp/0.33.9-1
+    version: release/jazzy/action_tutorials_cpp/0.33.11-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-action-tutorials-interfaces/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-action-tutorials-interfaces/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-action-tutorials-interfaces
 _pkgname=action_tutorials_interfaces
-pkgver=0.33.9
+pkgver=0.33.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: action_tutorials_interfaces
     uri: https://github.com/ros2-gbp/demos-release.git
-    version: release/jazzy/action_tutorials_interfaces/0.33.9-1
+    version: release/jazzy/action_tutorials_interfaces/0.33.11-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-action-tutorials-py/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-action-tutorials-py/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-action-tutorials-py
 _pkgname=action_tutorials_py
-pkgver=0.33.9
+pkgver=0.33.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: action_tutorials_py
     uri: https://github.com/ros2-gbp/demos-release.git
-    version: release/jazzy/action_tutorials_py/0.33.9-1
+    version: release/jazzy/action_tutorials_py/0.33.11-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-actionlib-msgs/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-actionlib-msgs/APKBUILD
@@ -1,7 +1,7 @@
 pkgname=ros-jazzy-actionlib-msgs
 _pkgname=actionlib_msgs
-pkgver=5.3.6
-pkgrel=1
+pkgver=5.3.8
+pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
 arch="all"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: actionlib_msgs
     uri: https://github.com/ros2-gbp/common_interfaces-release.git
-    version: release/jazzy/actionlib_msgs/5.3.6-1
+    version: release/jazzy/actionlib_msgs/5.3.8-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-ament-clang-format/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-ament-clang-format/APKBUILD
@@ -1,13 +1,13 @@
 pkgname=ros-jazzy-ament-clang-format
 _pkgname=ament_clang_format
-pkgver=0.17.4
+pkgver=0.17.5
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
 arch="all"
 license="Apache License 2.0"
 
-depends="clang py3-yaml ros-jazzy-ros-workspace"
+depends="clang-extra-tools py3-yaml ros-jazzy-ros-workspace"
 makedepends="chrpath py3-pytest7 py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-jazzy-ament-copyright ros-jazzy-ament-copyright-dev ros-jazzy-ament-flake8 ros-jazzy-ament-flake8-dev ros-jazzy-ament-pep257 ros-jazzy-ament-pep257-dev ros-jazzy-ros-workspace-dev"
 depends_dev="ros-jazzy-ros-workspace-dev"
 
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ament_clang_format
     uri: https://github.com/ros2-gbp/ament_lint-release.git
-    version: release/jazzy/ament_clang_format/0.17.4-1
+    version: release/jazzy/ament_clang_format/0.17.5-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-ament-cmake-auto/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-ament-cmake-auto/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-ament-cmake-auto
 _pkgname=ament_cmake_auto
-pkgver=2.5.5
+pkgver=2.5.6
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ament_cmake_auto
     uri: https://github.com/ros2-gbp/ament_cmake-release.git
-    version: release/jazzy/ament_cmake_auto/2.5.5-1
+    version: release/jazzy/ament_cmake_auto/2.5.6-2
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-ament-cmake-clang-format/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-ament-cmake-clang-format/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-ament-cmake-clang-format
 _pkgname=ament_cmake_clang_format
-pkgver=0.17.4
+pkgver=0.17.5
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ament_cmake_clang_format
     uri: https://github.com/ros2-gbp/ament_lint-release.git
-    version: release/jazzy/ament_cmake_clang_format/0.17.4-1
+    version: release/jazzy/ament_cmake_clang_format/0.17.5-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-ament-cmake-copyright/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-ament-cmake-copyright/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-ament-cmake-copyright
 _pkgname=ament_cmake_copyright
-pkgver=0.17.4
+pkgver=0.17.5
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ament_cmake_copyright
     uri: https://github.com/ros2-gbp/ament_lint-release.git
-    version: release/jazzy/ament_cmake_copyright/0.17.4-1
+    version: release/jazzy/ament_cmake_copyright/0.17.5-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-ament-cmake-core/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-ament-cmake-core/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-ament-cmake-core
 _pkgname=ament_cmake_core
-pkgver=2.5.5
+pkgver=2.5.6
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ament_cmake_core
     uri: https://github.com/ros2-gbp/ament_cmake-release.git
-    version: release/jazzy/ament_cmake_core/2.5.5-1
+    version: release/jazzy/ament_cmake_core/2.5.6-2
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-ament-cmake-cppcheck/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-ament-cmake-cppcheck/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-ament-cmake-cppcheck
 _pkgname=ament_cmake_cppcheck
-pkgver=0.17.4
+pkgver=0.17.5
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ament_cmake_cppcheck
     uri: https://github.com/ros2-gbp/ament_lint-release.git
-    version: release/jazzy/ament_cmake_cppcheck/0.17.4-1
+    version: release/jazzy/ament_cmake_cppcheck/0.17.5-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-ament-cmake-cpplint/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-ament-cmake-cpplint/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-ament-cmake-cpplint
 _pkgname=ament_cmake_cpplint
-pkgver=0.17.4
+pkgver=0.17.5
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ament_cmake_cpplint
     uri: https://github.com/ros2-gbp/ament_lint-release.git
-    version: release/jazzy/ament_cmake_cpplint/0.17.4-1
+    version: release/jazzy/ament_cmake_cpplint/0.17.5-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-ament-cmake-export-definitions/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-ament-cmake-export-definitions/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-ament-cmake-export-definitions
 _pkgname=ament_cmake_export_definitions
-pkgver=2.5.5
+pkgver=2.5.6
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ament_cmake_export_definitions
     uri: https://github.com/ros2-gbp/ament_cmake-release.git
-    version: release/jazzy/ament_cmake_export_definitions/2.5.5-1
+    version: release/jazzy/ament_cmake_export_definitions/2.5.6-2
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-ament-cmake-export-dependencies/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-ament-cmake-export-dependencies/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-ament-cmake-export-dependencies
 _pkgname=ament_cmake_export_dependencies
-pkgver=2.5.5
+pkgver=2.5.6
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ament_cmake_export_dependencies
     uri: https://github.com/ros2-gbp/ament_cmake-release.git
-    version: release/jazzy/ament_cmake_export_dependencies/2.5.5-1
+    version: release/jazzy/ament_cmake_export_dependencies/2.5.6-2
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-ament-cmake-export-include-directories/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-ament-cmake-export-include-directories/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-ament-cmake-export-include-directories
 _pkgname=ament_cmake_export_include_directories
-pkgver=2.5.5
+pkgver=2.5.6
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ament_cmake_export_include_directories
     uri: https://github.com/ros2-gbp/ament_cmake-release.git
-    version: release/jazzy/ament_cmake_export_include_directories/2.5.5-1
+    version: release/jazzy/ament_cmake_export_include_directories/2.5.6-2
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-ament-cmake-export-interfaces/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-ament-cmake-export-interfaces/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-ament-cmake-export-interfaces
 _pkgname=ament_cmake_export_interfaces
-pkgver=2.5.5
+pkgver=2.5.6
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ament_cmake_export_interfaces
     uri: https://github.com/ros2-gbp/ament_cmake-release.git
-    version: release/jazzy/ament_cmake_export_interfaces/2.5.5-1
+    version: release/jazzy/ament_cmake_export_interfaces/2.5.6-2
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-ament-cmake-export-libraries/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-ament-cmake-export-libraries/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-ament-cmake-export-libraries
 _pkgname=ament_cmake_export_libraries
-pkgver=2.5.5
+pkgver=2.5.6
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ament_cmake_export_libraries
     uri: https://github.com/ros2-gbp/ament_cmake-release.git
-    version: release/jazzy/ament_cmake_export_libraries/2.5.5-1
+    version: release/jazzy/ament_cmake_export_libraries/2.5.6-2
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-ament-cmake-export-link-flags/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-ament-cmake-export-link-flags/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-ament-cmake-export-link-flags
 _pkgname=ament_cmake_export_link_flags
-pkgver=2.5.5
+pkgver=2.5.6
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ament_cmake_export_link_flags
     uri: https://github.com/ros2-gbp/ament_cmake-release.git
-    version: release/jazzy/ament_cmake_export_link_flags/2.5.5-1
+    version: release/jazzy/ament_cmake_export_link_flags/2.5.6-2
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-ament-cmake-export-targets/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-ament-cmake-export-targets/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-ament-cmake-export-targets
 _pkgname=ament_cmake_export_targets
-pkgver=2.5.5
+pkgver=2.5.6
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ament_cmake_export_targets
     uri: https://github.com/ros2-gbp/ament_cmake-release.git
-    version: release/jazzy/ament_cmake_export_targets/2.5.5-1
+    version: release/jazzy/ament_cmake_export_targets/2.5.6-2
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-ament-cmake-flake8/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-ament-cmake-flake8/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-ament-cmake-flake8
 _pkgname=ament_cmake_flake8
-pkgver=0.17.4
+pkgver=0.17.5
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ament_cmake_flake8
     uri: https://github.com/ros2-gbp/ament_lint-release.git
-    version: release/jazzy/ament_cmake_flake8/0.17.4-1
+    version: release/jazzy/ament_cmake_flake8/0.17.5-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-ament-cmake-gen-version-h/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-ament-cmake-gen-version-h/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-ament-cmake-gen-version-h
 _pkgname=ament_cmake_gen_version_h
-pkgver=2.5.5
+pkgver=2.5.6
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ament_cmake_gen_version_h
     uri: https://github.com/ros2-gbp/ament_cmake-release.git
-    version: release/jazzy/ament_cmake_gen_version_h/2.5.5-1
+    version: release/jazzy/ament_cmake_gen_version_h/2.5.6-2
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-ament-cmake-gmock/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-ament-cmake-gmock/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-ament-cmake-gmock
 _pkgname=ament_cmake_gmock
-pkgver=2.5.5
+pkgver=2.5.6
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ament_cmake_gmock
     uri: https://github.com/ros2-gbp/ament_cmake-release.git
-    version: release/jazzy/ament_cmake_gmock/2.5.5-1
+    version: release/jazzy/ament_cmake_gmock/2.5.6-2
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-ament-cmake-google-benchmark/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-ament-cmake-google-benchmark/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-ament-cmake-google-benchmark
 _pkgname=ament_cmake_google_benchmark
-pkgver=2.5.5
+pkgver=2.5.6
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ament_cmake_google_benchmark
     uri: https://github.com/ros2-gbp/ament_cmake-release.git
-    version: release/jazzy/ament_cmake_google_benchmark/2.5.5-1
+    version: release/jazzy/ament_cmake_google_benchmark/2.5.6-2
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-ament-cmake-gtest/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-ament-cmake-gtest/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-ament-cmake-gtest
 _pkgname=ament_cmake_gtest
-pkgver=2.5.5
+pkgver=2.5.6
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ament_cmake_gtest
     uri: https://github.com/ros2-gbp/ament_cmake-release.git
-    version: release/jazzy/ament_cmake_gtest/2.5.5-1
+    version: release/jazzy/ament_cmake_gtest/2.5.6-2
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-ament-cmake-include-directories/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-ament-cmake-include-directories/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-ament-cmake-include-directories
 _pkgname=ament_cmake_include_directories
-pkgver=2.5.5
+pkgver=2.5.6
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ament_cmake_include_directories
     uri: https://github.com/ros2-gbp/ament_cmake-release.git
-    version: release/jazzy/ament_cmake_include_directories/2.5.5-1
+    version: release/jazzy/ament_cmake_include_directories/2.5.6-2
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-ament-cmake-libraries/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-ament-cmake-libraries/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-ament-cmake-libraries
 _pkgname=ament_cmake_libraries
-pkgver=2.5.5
+pkgver=2.5.6
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ament_cmake_libraries
     uri: https://github.com/ros2-gbp/ament_cmake-release.git
-    version: release/jazzy/ament_cmake_libraries/2.5.5-1
+    version: release/jazzy/ament_cmake_libraries/2.5.6-2
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-ament-cmake-lint-cmake/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-ament-cmake-lint-cmake/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-ament-cmake-lint-cmake
 _pkgname=ament_cmake_lint_cmake
-pkgver=0.17.4
+pkgver=0.17.5
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ament_cmake_lint_cmake
     uri: https://github.com/ros2-gbp/ament_lint-release.git
-    version: release/jazzy/ament_cmake_lint_cmake/0.17.4-1
+    version: release/jazzy/ament_cmake_lint_cmake/0.17.5-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-ament-cmake-pep257/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-ament-cmake-pep257/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-ament-cmake-pep257
 _pkgname=ament_cmake_pep257
-pkgver=0.17.4
+pkgver=0.17.5
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ament_cmake_pep257
     uri: https://github.com/ros2-gbp/ament_lint-release.git
-    version: release/jazzy/ament_cmake_pep257/0.17.4-1
+    version: release/jazzy/ament_cmake_pep257/0.17.5-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-ament-cmake-pytest/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-ament-cmake-pytest/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-ament-cmake-pytest
 _pkgname=ament_cmake_pytest
-pkgver=2.5.5
+pkgver=2.5.6
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ament_cmake_pytest
     uri: https://github.com/ros2-gbp/ament_cmake-release.git
-    version: release/jazzy/ament_cmake_pytest/2.5.5-1
+    version: release/jazzy/ament_cmake_pytest/2.5.6-2
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-ament-cmake-python/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-ament-cmake-python/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-ament-cmake-python
 _pkgname=ament_cmake_python
-pkgver=2.5.5
+pkgver=2.5.6
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ament_cmake_python
     uri: https://github.com/ros2-gbp/ament_cmake-release.git
-    version: release/jazzy/ament_cmake_python/2.5.5-1
+    version: release/jazzy/ament_cmake_python/2.5.6-2
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-ament-cmake-ros/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-ament-cmake-ros/APKBUILD
@@ -1,7 +1,7 @@
 pkgname=ros-jazzy-ament-cmake-ros
 _pkgname=ament_cmake_ros
-pkgver=0.12.0
-pkgrel=1
+pkgver=0.12.1
+pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
 arch="all"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ament_cmake_ros
     uri: https://github.com/ros2-gbp/ament_cmake_ros-release.git
-    version: release/jazzy/ament_cmake_ros/0.12.0-3
+    version: release/jazzy/ament_cmake_ros/0.12.1-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-ament-cmake-target-dependencies/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-ament-cmake-target-dependencies/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-ament-cmake-target-dependencies
 _pkgname=ament_cmake_target_dependencies
-pkgver=2.5.5
+pkgver=2.5.6
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ament_cmake_target_dependencies
     uri: https://github.com/ros2-gbp/ament_cmake-release.git
-    version: release/jazzy/ament_cmake_target_dependencies/2.5.5-1
+    version: release/jazzy/ament_cmake_target_dependencies/2.5.6-2
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-ament-cmake-test/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-ament-cmake-test/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-ament-cmake-test
 _pkgname=ament_cmake_test
-pkgver=2.5.5
+pkgver=2.5.6
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ament_cmake_test
     uri: https://github.com/ros2-gbp/ament_cmake-release.git
-    version: release/jazzy/ament_cmake_test/2.5.5-1
+    version: release/jazzy/ament_cmake_test/2.5.6-2
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-ament-cmake-uncrustify/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-ament-cmake-uncrustify/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-ament-cmake-uncrustify
 _pkgname=ament_cmake_uncrustify
-pkgver=0.17.4
+pkgver=0.17.5
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ament_cmake_uncrustify
     uri: https://github.com/ros2-gbp/ament_lint-release.git
-    version: release/jazzy/ament_cmake_uncrustify/0.17.4-1
+    version: release/jazzy/ament_cmake_uncrustify/0.17.5-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-ament-cmake-vendor-package/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-ament-cmake-vendor-package/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-ament-cmake-vendor-package
 _pkgname=ament_cmake_vendor_package
-pkgver=2.5.5
+pkgver=2.5.6
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ament_cmake_vendor_package
     uri: https://github.com/ros2-gbp/ament_cmake-release.git
-    version: release/jazzy/ament_cmake_vendor_package/2.5.5-1
+    version: release/jazzy/ament_cmake_vendor_package/2.5.6-2
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-ament-cmake-version/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-ament-cmake-version/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-ament-cmake-version
 _pkgname=ament_cmake_version
-pkgver=2.5.5
+pkgver=2.5.6
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ament_cmake_version
     uri: https://github.com/ros2-gbp/ament_cmake-release.git
-    version: release/jazzy/ament_cmake_version/2.5.5-1
+    version: release/jazzy/ament_cmake_version/2.5.6-2
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-ament-cmake-xmllint/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-ament-cmake-xmllint/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-ament-cmake-xmllint
 _pkgname=ament_cmake_xmllint
-pkgver=0.17.4
+pkgver=0.17.5
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ament_cmake_xmllint
     uri: https://github.com/ros2-gbp/ament_lint-release.git
-    version: release/jazzy/ament_cmake_xmllint/0.17.4-1
+    version: release/jazzy/ament_cmake_xmllint/0.17.5-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-ament-cmake/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-ament-cmake/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-ament-cmake
 _pkgname=ament_cmake
-pkgver=2.5.5
+pkgver=2.5.6
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ament_cmake
     uri: https://github.com/ros2-gbp/ament_cmake-release.git
-    version: release/jazzy/ament_cmake/2.5.5-1
+    version: release/jazzy/ament_cmake/2.5.6-2
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-ament-copyright/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-ament-copyright/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-ament-copyright
 _pkgname=ament_copyright
-pkgver=0.17.4
+pkgver=0.17.5
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ament_copyright
     uri: https://github.com/ros2-gbp/ament_lint-release.git
-    version: release/jazzy/ament_copyright/0.17.4-1
+    version: release/jazzy/ament_copyright/0.17.5-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-ament-cppcheck/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-ament-cppcheck/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-ament-cppcheck
 _pkgname=ament_cppcheck
-pkgver=0.17.4
+pkgver=0.17.5
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ament_cppcheck
     uri: https://github.com/ros2-gbp/ament_lint-release.git
-    version: release/jazzy/ament_cppcheck/0.17.4-1
+    version: release/jazzy/ament_cppcheck/0.17.5-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-ament-cpplint/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-ament-cpplint/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-ament-cpplint
 _pkgname=ament_cpplint
-pkgver=0.17.4
+pkgver=0.17.5
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ament_cpplint
     uri: https://github.com/ros2-gbp/ament_lint-release.git
-    version: release/jazzy/ament_cpplint/0.17.4-1
+    version: release/jazzy/ament_cpplint/0.17.5-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-ament-flake8/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-ament-flake8/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-ament-flake8
 _pkgname=ament_flake8
-pkgver=0.17.4
+pkgver=0.17.5
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ament_flake8
     uri: https://github.com/ros2-gbp/ament_lint-release.git
-    version: release/jazzy/ament_flake8/0.17.4-1
+    version: release/jazzy/ament_flake8/0.17.5-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-ament-index-cpp/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-ament-index-cpp/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-ament-index-cpp
 _pkgname=ament_index_cpp
-pkgver=1.8.2
+pkgver=1.8.4
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ament_index_cpp
     uri: https://github.com/ros2-gbp/ament_index-release.git
-    version: release/jazzy/ament_index_cpp/1.8.2-1
+    version: release/jazzy/ament_index_cpp/1.8.4-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-ament-index-python/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-ament-index-python/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-ament-index-python
 _pkgname=ament_index_python
-pkgver=1.8.2
+pkgver=1.8.4
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ament_index_python
     uri: https://github.com/ros2-gbp/ament_index-release.git
-    version: release/jazzy/ament_index_python/1.8.2-1
+    version: release/jazzy/ament_index_python/1.8.4-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-ament-lint-auto/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-ament-lint-auto/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-ament-lint-auto
 _pkgname=ament_lint_auto
-pkgver=0.17.4
+pkgver=0.17.5
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ament_lint_auto
     uri: https://github.com/ros2-gbp/ament_lint-release.git
-    version: release/jazzy/ament_lint_auto/0.17.4-1
+    version: release/jazzy/ament_lint_auto/0.17.5-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-ament-lint-cmake/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-ament-lint-cmake/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-ament-lint-cmake
 _pkgname=ament_lint_cmake
-pkgver=0.17.4
+pkgver=0.17.5
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ament_lint_cmake
     uri: https://github.com/ros2-gbp/ament_lint-release.git
-    version: release/jazzy/ament_lint_cmake/0.17.4-1
+    version: release/jazzy/ament_lint_cmake/0.17.5-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-ament-lint-common/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-ament-lint-common/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-ament-lint-common
 _pkgname=ament_lint_common
-pkgver=0.17.4
+pkgver=0.17.5
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ament_lint_common
     uri: https://github.com/ros2-gbp/ament_lint-release.git
-    version: release/jazzy/ament_lint_common/0.17.4-1
+    version: release/jazzy/ament_lint_common/0.17.5-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-ament-lint/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-ament-lint/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-ament-lint
 _pkgname=ament_lint
-pkgver=0.17.4
+pkgver=0.17.5
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ament_lint
     uri: https://github.com/ros2-gbp/ament_lint-release.git
-    version: release/jazzy/ament_lint/0.17.4-1
+    version: release/jazzy/ament_lint/0.17.5-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-ament-mypy/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-ament-mypy/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-ament-mypy
 _pkgname=ament_mypy
-pkgver=0.17.4
+pkgver=0.17.5
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ament_mypy
     uri: https://github.com/ros2-gbp/ament_lint-release.git
-    version: release/jazzy/ament_mypy/0.17.4-1
+    version: release/jazzy/ament_mypy/0.17.5-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-ament-pep257/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-ament-pep257/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-ament-pep257
 _pkgname=ament_pep257
-pkgver=0.17.4
+pkgver=0.17.5
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ament_pep257
     uri: https://github.com/ros2-gbp/ament_lint-release.git
-    version: release/jazzy/ament_pep257/0.17.4-1
+    version: release/jazzy/ament_pep257/0.17.5-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-ament-pycodestyle/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-ament-pycodestyle/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-ament-pycodestyle
 _pkgname=ament_pycodestyle
-pkgver=0.17.4
+pkgver=0.17.5
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ament_pycodestyle
     uri: https://github.com/ros2-gbp/ament_lint-release.git
-    version: release/jazzy/ament_pycodestyle/0.17.4-1
+    version: release/jazzy/ament_pycodestyle/0.17.5-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-ament-uncrustify/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-ament-uncrustify/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-ament-uncrustify
 _pkgname=ament_uncrustify
-pkgver=0.17.4
+pkgver=0.17.5
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ament_uncrustify
     uri: https://github.com/ros2-gbp/ament_lint-release.git
-    version: release/jazzy/ament_uncrustify/0.17.4-1
+    version: release/jazzy/ament_uncrustify/0.17.5-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-ament-xmllint/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-ament-xmllint/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-ament-xmllint
 _pkgname=ament_xmllint
-pkgver=0.17.4
+pkgver=0.17.5
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ament_xmllint
     uri: https://github.com/ros2-gbp/ament_lint-release.git
-    version: release/jazzy/ament_xmllint/0.17.4-1
+    version: release/jazzy/ament_xmllint/0.17.5-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-behaviortree-cpp/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-behaviortree-cpp/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-behaviortree-cpp
 _pkgname=behaviortree_cpp
-pkgver=4.8.3
+pkgver=4.9.1
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: behaviortree_cpp
     uri: https://github.com/ros2-gbp/behaviortree_cpp_v4-release.git
-    version: release/jazzy/behaviortree_cpp/4.8.3-1
+    version: release/jazzy/behaviortree_cpp/4.9.1-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-bond/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-bond/APKBUILD
@@ -1,7 +1,7 @@
 pkgname=ros-jazzy-bond
 _pkgname=bond
-pkgver=4.1.2
-pkgrel=1
+pkgver=4.2.0
+pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="http://www.ros.org/wiki/bond"
 arch="all"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: bond
     uri: https://github.com/ros2-gbp/bond_core-release.git
-    version: release/jazzy/bond/4.1.2-1
+    version: release/jazzy/bond/4.2.0-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-bondcpp/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-bondcpp/APKBUILD
@@ -1,7 +1,7 @@
 pkgname=ros-jazzy-bondcpp
 _pkgname=bondcpp
-pkgver=4.1.2
-pkgrel=1
+pkgver=4.2.0
+pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="http://www.ros.org/wiki/bondcpp"
 arch="all"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: bondcpp
     uri: https://github.com/ros2-gbp/bond_core-release.git
-    version: release/jazzy/bondcpp/4.1.2-1
+    version: release/jazzy/bondcpp/4.2.0-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-builtin-interfaces/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-builtin-interfaces/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-builtin-interfaces
 _pkgname=builtin_interfaces
-pkgver=2.0.3
+pkgver=2.0.4
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: builtin_interfaces
     uri: https://github.com/ros2-gbp/rcl_interfaces-release.git
-    version: release/jazzy/builtin_interfaces/2.0.3-1
+    version: release/jazzy/builtin_interfaces/2.0.4-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-camera-calibration-parsers/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-camera-calibration-parsers/APKBUILD
@@ -1,14 +1,14 @@
 pkgname=ros-jazzy-camera-calibration-parsers
 _pkgname=camera_calibration_parsers
-pkgver=5.1.7
-pkgrel=1
+pkgver=5.1.8
+pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="http://ros.org/wiki/camera_calibration_parsers"
 arch="all"
 license="BSD"
 
 depends="ros-jazzy-rclcpp ros-jazzy-ros-workspace ros-jazzy-sensor-msgs ros-jazzy-yaml-cpp-vendor"
-makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-jazzy-ament-cmake-gtest ros-jazzy-ament-cmake-gtest-dev ros-jazzy-ament-cmake-ros ros-jazzy-ament-cmake-ros-dev ros-jazzy-ament-lint-auto ros-jazzy-ament-lint-auto-dev ros-jazzy-ament-lint-common ros-jazzy-ament-lint-common-dev ros-jazzy-rclcpp ros-jazzy-rclcpp-dev ros-jazzy-ros-workspace-dev ros-jazzy-sensor-msgs ros-jazzy-sensor-msgs-dev ros-jazzy-yaml-cpp-vendor ros-jazzy-yaml-cpp-vendor-dev"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-jazzy-ament-cmake-gen-version-h ros-jazzy-ament-cmake-gen-version-h-dev ros-jazzy-ament-cmake-gtest ros-jazzy-ament-cmake-gtest-dev ros-jazzy-ament-cmake-ros ros-jazzy-ament-cmake-ros-dev ros-jazzy-ament-lint-auto ros-jazzy-ament-lint-auto-dev ros-jazzy-ament-lint-common ros-jazzy-ament-lint-common-dev ros-jazzy-rclcpp ros-jazzy-rclcpp-dev ros-jazzy-ros-workspace-dev ros-jazzy-sensor-msgs ros-jazzy-sensor-msgs-dev ros-jazzy-yaml-cpp-vendor ros-jazzy-yaml-cpp-vendor-dev"
 depends_dev="ros-jazzy-rclcpp ros-jazzy-rclcpp-dev ros-jazzy-ros-workspace-dev ros-jazzy-sensor-msgs ros-jazzy-sensor-msgs-dev ros-jazzy-yaml-cpp-vendor ros-jazzy-yaml-cpp-vendor-dev"
 
 subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: camera_calibration_parsers
     uri: https://github.com/ros2-gbp/image_common-release.git
-    version: release/jazzy/camera_calibration_parsers/5.1.7-1
+    version: release/jazzy/camera_calibration_parsers/5.1.8-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-camera-calibration/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-camera-calibration/APKBUILD
@@ -1,9 +1,9 @@
 pkgname=ros-jazzy-camera-calibration
 _pkgname=camera_calibration
-pkgver=5.0.11
-pkgrel=1
+pkgver=5.0.13
+pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
-url="https://index.ros.org/p/camera_calibration/github-ros-perception-image_pipeline/"
+url="https://index.ros.org/p/camera_calibration/"
 arch="all"
 license="BSD"
 
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: camera_calibration
     uri: https://github.com/ros2-gbp/image_pipeline-release.git
-    version: release/jazzy/camera_calibration/5.0.11-1
+    version: release/jazzy/camera_calibration/5.0.13-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-camera-info-manager/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-camera-info-manager/APKBUILD
@@ -1,14 +1,14 @@
 pkgname=ros-jazzy-camera-info-manager
 _pkgname=camera_info_manager
-pkgver=5.1.7
-pkgrel=1
+pkgver=5.1.8
+pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="http://ros.org/wiki/camera_info_manager"
 arch="all"
 license="BSD"
 
 depends="ros-jazzy-ament-index-cpp ros-jazzy-camera-calibration-parsers ros-jazzy-rclcpp ros-jazzy-rclcpp-lifecycle ros-jazzy-rcpputils ros-jazzy-ros-workspace ros-jazzy-sensor-msgs"
-makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-jazzy-ament-cmake-gtest ros-jazzy-ament-cmake-gtest-dev ros-jazzy-ament-cmake-ros ros-jazzy-ament-cmake-ros-dev ros-jazzy-ament-index-cpp ros-jazzy-ament-index-cpp-dev ros-jazzy-ament-lint-auto ros-jazzy-ament-lint-auto-dev ros-jazzy-ament-lint-common ros-jazzy-ament-lint-common-dev ros-jazzy-camera-calibration-parsers ros-jazzy-camera-calibration-parsers-dev ros-jazzy-rclcpp ros-jazzy-rclcpp-dev ros-jazzy-rclcpp-lifecycle ros-jazzy-rclcpp-lifecycle-dev ros-jazzy-rcpputils ros-jazzy-rcpputils-dev ros-jazzy-ros-workspace-dev ros-jazzy-sensor-msgs ros-jazzy-sensor-msgs-dev"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-jazzy-ament-cmake-gen-version-h ros-jazzy-ament-cmake-gen-version-h-dev ros-jazzy-ament-cmake-gtest ros-jazzy-ament-cmake-gtest-dev ros-jazzy-ament-cmake-ros ros-jazzy-ament-cmake-ros-dev ros-jazzy-ament-index-cpp ros-jazzy-ament-index-cpp-dev ros-jazzy-ament-lint-auto ros-jazzy-ament-lint-auto-dev ros-jazzy-ament-lint-common ros-jazzy-ament-lint-common-dev ros-jazzy-camera-calibration-parsers ros-jazzy-camera-calibration-parsers-dev ros-jazzy-rclcpp ros-jazzy-rclcpp-dev ros-jazzy-rclcpp-lifecycle ros-jazzy-rclcpp-lifecycle-dev ros-jazzy-rcpputils ros-jazzy-rcpputils-dev ros-jazzy-ros-workspace-dev ros-jazzy-sensor-msgs ros-jazzy-sensor-msgs-dev"
 depends_dev="ros-jazzy-ament-index-cpp ros-jazzy-ament-index-cpp-dev ros-jazzy-camera-calibration-parsers ros-jazzy-camera-calibration-parsers-dev ros-jazzy-rclcpp ros-jazzy-rclcpp-dev ros-jazzy-rclcpp-lifecycle ros-jazzy-rclcpp-lifecycle-dev ros-jazzy-rcpputils ros-jazzy-rcpputils-dev ros-jazzy-ros-workspace-dev ros-jazzy-sensor-msgs ros-jazzy-sensor-msgs-dev"
 
 subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: camera_info_manager
     uri: https://github.com/ros2-gbp/image_common-release.git
-    version: release/jazzy/camera_info_manager/5.1.7-1
+    version: release/jazzy/camera_info_manager/5.1.8-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-class-loader/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-class-loader/APKBUILD
@@ -1,7 +1,7 @@
 pkgname=ros-jazzy-class-loader
 _pkgname=class_loader
-pkgver=2.7.0
-pkgrel=1
+pkgver=2.7.1
+pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="http://ros.org/wiki/class_loader"
 arch="all"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: class_loader
     uri: https://github.com/ros2-gbp/class_loader-release.git
-    version: release/jazzy/class_loader/2.7.0-3
+    version: release/jazzy/class_loader/2.7.1-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-common-interfaces/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-common-interfaces/APKBUILD
@@ -1,7 +1,7 @@
 pkgname=ros-jazzy-common-interfaces
 _pkgname=common_interfaces
-pkgver=5.3.6
-pkgrel=1
+pkgver=5.3.8
+pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
 arch="all"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: common_interfaces
     uri: https://github.com/ros2-gbp/common_interfaces-release.git
-    version: release/jazzy/common_interfaces/5.3.6-1
+    version: release/jazzy/common_interfaces/5.3.8-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-composition-interfaces/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-composition-interfaces/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-composition-interfaces
 _pkgname=composition_interfaces
-pkgver=2.0.3
+pkgver=2.0.4
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: composition_interfaces
     uri: https://github.com/ros2-gbp/rcl_interfaces-release.git
-    version: release/jazzy/composition_interfaces/2.0.3-1
+    version: release/jazzy/composition_interfaces/2.0.4-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-composition/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-composition/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-composition
 _pkgname=composition
-pkgver=0.33.9
+pkgver=0.33.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: composition
     uri: https://github.com/ros2-gbp/demos-release.git
-    version: release/jazzy/composition/0.33.9-1
+    version: release/jazzy/composition/0.33.11-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-compressed-depth-image-transport/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-compressed-depth-image-transport/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-compressed-depth-image-transport
 _pkgname=compressed_depth_image_transport
-pkgver=4.0.6
+pkgver=4.0.7
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="http://www.ros.org/wiki/image_transport_plugins"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: compressed_depth_image_transport
     uri: https://github.com/ros2-gbp/image_transport_plugins-release.git
-    version: release/jazzy/compressed_depth_image_transport/4.0.6-1
+    version: release/jazzy/compressed_depth_image_transport/4.0.7-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-compressed-image-transport/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-compressed-image-transport/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-compressed-image-transport
 _pkgname=compressed_image_transport
-pkgver=4.0.6
+pkgver=4.0.7
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="http://www.ros.org/wiki/image_transport_plugins"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: compressed_image_transport
     uri: https://github.com/ros2-gbp/image_transport_plugins-release.git
-    version: release/jazzy/compressed_image_transport/4.0.6-1
+    version: release/jazzy/compressed_image_transport/4.0.7-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-console-bridge-vendor/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-console-bridge-vendor/APKBUILD
@@ -1,7 +1,7 @@
 pkgname=ros-jazzy-console-bridge-vendor
 _pkgname=console_bridge_vendor
-pkgver=1.7.1
-pkgrel=1
+pkgver=1.7.2
+pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://github.com/ros/console_bridge"
 arch="all"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: console_bridge_vendor
     uri: https://github.com/ros2-gbp/console_bridge_vendor-release.git
-    version: release/jazzy/console_bridge_vendor/1.7.1-3
+    version: release/jazzy/console_bridge_vendor/1.7.2-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-costmap-queue/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-costmap-queue/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-costmap-queue
 _pkgname=costmap_queue
-pkgver=1.3.11
+pkgver=1.3.12
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: costmap_queue
     uri: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/costmap_queue/1.3.11-1
+    version: release/jazzy/costmap_queue/1.3.12-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-demo-nodes-cpp-native/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-demo-nodes-cpp-native/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-demo-nodes-cpp-native
 _pkgname=demo_nodes_cpp_native
-pkgver=0.33.9
+pkgver=0.33.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: demo_nodes_cpp_native
     uri: https://github.com/ros2-gbp/demos-release.git
-    version: release/jazzy/demo_nodes_cpp_native/0.33.9-1
+    version: release/jazzy/demo_nodes_cpp_native/0.33.11-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-demo-nodes-cpp/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-demo-nodes-cpp/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-demo-nodes-cpp
 _pkgname=demo_nodes_cpp
-pkgver=0.33.9
+pkgver=0.33.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: demo_nodes_cpp
     uri: https://github.com/ros2-gbp/demos-release.git
-    version: release/jazzy/demo_nodes_cpp/0.33.9-1
+    version: release/jazzy/demo_nodes_cpp/0.33.11-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-demo-nodes-py/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-demo-nodes-py/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-demo-nodes-py
 _pkgname=demo_nodes_py
-pkgver=0.33.9
+pkgver=0.33.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: demo_nodes_py
     uri: https://github.com/ros2-gbp/demos-release.git
-    version: release/jazzy/demo_nodes_py/0.33.9-1
+    version: release/jazzy/demo_nodes_py/0.33.11-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-depth-image-proc/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-depth-image-proc/APKBUILD
@@ -1,14 +1,14 @@
 pkgname=ros-jazzy-depth-image-proc
 _pkgname=depth_image_proc
-pkgver=5.0.11
-pkgrel=1
+pkgver=5.0.13
+pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
-url="https://index.ros.org/p/depth_image_proc/github-ros-perception-image_pipeline/"
+url="https://index.ros.org/p/depth_image_proc/"
 arch="all"
 license="BSD"
 
 depends="ros-jazzy-cv-bridge ros-jazzy-image-geometry ros-jazzy-image-proc ros-jazzy-image-transport ros-jazzy-message-filters ros-jazzy-rclcpp ros-jazzy-rclcpp-components ros-jazzy-ros-workspace ros-jazzy-sensor-msgs ros-jazzy-stereo-msgs ros-jazzy-tf2 ros-jazzy-tf2-eigen ros-jazzy-tf2-ros"
-makedepends="chrpath opencv-dev py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-jazzy-ament-cmake-auto ros-jazzy-ament-cmake-auto-dev ros-jazzy-ament-lint-auto ros-jazzy-ament-lint-auto-dev ros-jazzy-ament-lint-common ros-jazzy-ament-lint-common-dev ros-jazzy-class-loader ros-jazzy-class-loader-dev ros-jazzy-cv-bridge ros-jazzy-cv-bridge-dev ros-jazzy-image-geometry ros-jazzy-image-geometry-dev ros-jazzy-image-proc ros-jazzy-image-proc-dev ros-jazzy-image-transport ros-jazzy-image-transport-dev ros-jazzy-message-filters ros-jazzy-message-filters-dev ros-jazzy-rclcpp ros-jazzy-rclcpp-components ros-jazzy-rclcpp-components-dev ros-jazzy-rclcpp-dev ros-jazzy-ros-workspace-dev ros-jazzy-sensor-msgs ros-jazzy-sensor-msgs-dev ros-jazzy-stereo-msgs ros-jazzy-stereo-msgs-dev ros-jazzy-tf2 ros-jazzy-tf2-dev ros-jazzy-tf2-eigen ros-jazzy-tf2-eigen-dev ros-jazzy-tf2-ros ros-jazzy-tf2-ros-dev"
+makedepends="chrpath opencv-dev py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-jazzy-ament-cmake-auto ros-jazzy-ament-cmake-auto-dev ros-jazzy-ament-cmake-gtest ros-jazzy-ament-cmake-gtest-dev ros-jazzy-ament-lint-auto ros-jazzy-ament-lint-auto-dev ros-jazzy-ament-lint-common ros-jazzy-ament-lint-common-dev ros-jazzy-class-loader ros-jazzy-class-loader-dev ros-jazzy-cv-bridge ros-jazzy-cv-bridge-dev ros-jazzy-image-geometry ros-jazzy-image-geometry-dev ros-jazzy-image-proc ros-jazzy-image-proc-dev ros-jazzy-image-transport ros-jazzy-image-transport-dev ros-jazzy-message-filters ros-jazzy-message-filters-dev ros-jazzy-rclcpp ros-jazzy-rclcpp-components ros-jazzy-rclcpp-components-dev ros-jazzy-rclcpp-dev ros-jazzy-ros-workspace-dev ros-jazzy-sensor-msgs ros-jazzy-sensor-msgs-dev ros-jazzy-stereo-msgs ros-jazzy-stereo-msgs-dev ros-jazzy-tf2 ros-jazzy-tf2-dev ros-jazzy-tf2-eigen ros-jazzy-tf2-eigen-dev ros-jazzy-tf2-ros ros-jazzy-tf2-ros-dev"
 depends_dev="opencv-dev ros-jazzy-cv-bridge ros-jazzy-cv-bridge-dev ros-jazzy-image-geometry ros-jazzy-image-geometry-dev ros-jazzy-image-proc ros-jazzy-image-proc-dev ros-jazzy-image-transport ros-jazzy-image-transport-dev ros-jazzy-message-filters ros-jazzy-message-filters-dev ros-jazzy-rclcpp ros-jazzy-rclcpp-components ros-jazzy-rclcpp-components-dev ros-jazzy-rclcpp-dev ros-jazzy-ros-workspace-dev ros-jazzy-sensor-msgs ros-jazzy-sensor-msgs-dev ros-jazzy-stereo-msgs ros-jazzy-stereo-msgs-dev ros-jazzy-tf2 ros-jazzy-tf2-dev ros-jazzy-tf2-eigen ros-jazzy-tf2-eigen-dev ros-jazzy-tf2-ros ros-jazzy-tf2-ros-dev"
 
 subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: depth_image_proc
     uri: https://github.com/ros2-gbp/image_pipeline-release.git
-    version: release/jazzy/depth_image_proc/5.0.11-1
+    version: release/jazzy/depth_image_proc/5.0.13-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-diagnostic-msgs/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-diagnostic-msgs/APKBUILD
@@ -1,7 +1,7 @@
 pkgname=ros-jazzy-diagnostic-msgs
 _pkgname=diagnostic_msgs
-pkgver=5.3.6
-pkgrel=1
+pkgver=5.3.8
+pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
 arch="all"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: diagnostic_msgs
     uri: https://github.com/ros2-gbp/common_interfaces-release.git
-    version: release/jazzy/diagnostic_msgs/5.3.6-1
+    version: release/jazzy/diagnostic_msgs/5.3.8-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-diagnostic-updater/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-diagnostic-updater/APKBUILD
@@ -1,9 +1,9 @@
 pkgname=ros-jazzy-diagnostic-updater
 _pkgname=diagnostic_updater
-pkgver=4.2.6
-pkgrel=1
+pkgver=4.2.7
+pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
-url="http://www.ros.org/wiki/diagnostic_updater"
+url="https://index.ros.org/p/diagnostic_updater/"
 arch="all"
 license="BSD-3-Clause"
 
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: diagnostic_updater
     uri: https://github.com/ros2-gbp/diagnostics-release.git
-    version: release/jazzy/diagnostic_updater/4.2.6-1
+    version: release/jazzy/diagnostic_updater/4.2.7-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-domain-coordinator/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-domain-coordinator/APKBUILD
@@ -1,7 +1,7 @@
 pkgname=ros-jazzy-domain-coordinator
 _pkgname=domain_coordinator
-pkgver=0.12.0
-pkgrel=1
+pkgver=0.12.1
+pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
 arch="all"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: domain_coordinator
     uri: https://github.com/ros2-gbp/ament_cmake_ros-release.git
-    version: release/jazzy/domain_coordinator/0.12.0-3
+    version: release/jazzy/domain_coordinator/0.12.1-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-dummy-map-server/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-dummy-map-server/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-dummy-map-server
 _pkgname=dummy_map_server
-pkgver=0.33.9
+pkgver=0.33.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: dummy_map_server
     uri: https://github.com/ros2-gbp/demos-release.git
-    version: release/jazzy/dummy_map_server/0.33.9-1
+    version: release/jazzy/dummy_map_server/0.33.11-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-dummy-robot-bringup/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-dummy-robot-bringup/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-dummy-robot-bringup
 _pkgname=dummy_robot_bringup
-pkgver=0.33.9
+pkgver=0.33.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: dummy_robot_bringup
     uri: https://github.com/ros2-gbp/demos-release.git
-    version: release/jazzy/dummy_robot_bringup/0.33.9-1
+    version: release/jazzy/dummy_robot_bringup/0.33.11-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-dummy-sensors/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-dummy-sensors/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-dummy-sensors
 _pkgname=dummy_sensors
-pkgver=0.33.9
+pkgver=0.33.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: dummy_sensors
     uri: https://github.com/ros2-gbp/demos-release.git
-    version: release/jazzy/dummy_sensors/0.33.9-1
+    version: release/jazzy/dummy_sensors/0.33.11-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-dwb-core/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-dwb-core/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-dwb-core
 _pkgname=dwb_core
-pkgver=1.3.11
+pkgver=1.3.12
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: dwb_core
     uri: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/dwb_core/1.3.11-1
+    version: release/jazzy/dwb_core/1.3.12-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-dwb-critics/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-dwb-critics/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-dwb-critics
 _pkgname=dwb_critics
-pkgver=1.3.11
+pkgver=1.3.12
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: dwb_critics
     uri: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/dwb_critics/1.3.11-1
+    version: release/jazzy/dwb_critics/1.3.12-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-dwb-msgs/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-dwb-msgs/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-dwb-msgs
 _pkgname=dwb_msgs
-pkgver=1.3.11
+pkgver=1.3.12
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: dwb_msgs
     uri: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/dwb_msgs/1.3.11-1
+    version: release/jazzy/dwb_msgs/1.3.12-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-dwb-plugins/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-dwb-plugins/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-dwb-plugins
 _pkgname=dwb_plugins
-pkgver=1.3.11
+pkgver=1.3.12
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: dwb_plugins
     uri: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/dwb_plugins/1.3.11-1
+    version: release/jazzy/dwb_plugins/1.3.12-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-eigen3-cmake-module/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-eigen3-cmake-module/APKBUILD
@@ -1,7 +1,7 @@
 pkgname=ros-jazzy-eigen3-cmake-module
 _pkgname=eigen3_cmake_module
-pkgver=0.3.0
-pkgrel=1
+pkgver=0.3.1
+pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
 arch="all"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: eigen3_cmake_module
     uri: https://github.com/ros2-gbp/eigen3_cmake_module-release.git
-    version: release/jazzy/eigen3_cmake_module/0.3.0-3
+    version: release/jazzy/eigen3_cmake_module/0.3.1-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-example-interfaces/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-example-interfaces/APKBUILD
@@ -1,7 +1,7 @@
 pkgname=ros-jazzy-example-interfaces
 _pkgname=example_interfaces
-pkgver=0.12.0
-pkgrel=1
+pkgver=0.12.1
+pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
 arch="all"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: example_interfaces
     uri: https://github.com/ros2-gbp/example_interfaces-release.git
-    version: release/jazzy/example_interfaces/0.12.0-3
+    version: release/jazzy/example_interfaces/0.12.1-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-fastrtps-cmake-module/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-fastrtps-cmake-module/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-fastrtps-cmake-module
 _pkgname=fastrtps_cmake_module
-pkgver=3.6.3
+pkgver=3.6.4
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: fastrtps_cmake_module
     uri: https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release.git
-    version: release/jazzy/fastrtps_cmake_module/3.6.3-1
+    version: release/jazzy/fastrtps_cmake_module/3.6.4-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-fastrtps/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-fastrtps/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-fastrtps
 _pkgname=fastrtps
-pkgver=2.14.5
+pkgver=2.14.6
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://www.eprosima.com/"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: fastrtps
     uri: https://github.com/ros2-gbp/fastdds-release.git
-    version: release/jazzy/fastrtps/2.14.5-2
+    version: release/jazzy/fastrtps/2.14.6-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-geometry-msgs/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-geometry-msgs/APKBUILD
@@ -1,7 +1,7 @@
 pkgname=ros-jazzy-geometry-msgs
 _pkgname=geometry_msgs
-pkgver=5.3.6
-pkgrel=1
+pkgver=5.3.8
+pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
 arch="all"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: geometry_msgs
     uri: https://github.com/ros2-gbp/common_interfaces-release.git
-    version: release/jazzy/geometry_msgs/5.3.6-1
+    version: release/jazzy/geometry_msgs/5.3.8-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-geometry2/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-geometry2/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-geometry2
 _pkgname=geometry2
-pkgver=0.36.19
+pkgver=0.36.22
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="http://www.ros.org/wiki/geometry2"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: geometry2
     uri: https://github.com/ros2-gbp/geometry2-release.git
-    version: release/jazzy/geometry2/0.36.19-1
+    version: release/jazzy/geometry2/0.36.22-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-gz-cmake-vendor/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-gz-cmake-vendor/APKBUILD
@@ -1,7 +1,7 @@
 pkgname=ros-jazzy-gz-cmake-vendor
 _pkgname=gz_cmake_vendor
-pkgver=0.0.10
-pkgrel=1
+pkgver=0.0.12
+pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://github.com/gazebosim/gz-cmake"
 arch="all"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: gz_cmake_vendor
     uri: https://github.com/ros2-gbp/gz_cmake_vendor-release.git
-    version: release/jazzy/gz_cmake_vendor/0.0.10-1
+    version: release/jazzy/gz_cmake_vendor/0.0.12-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-gz-math-vendor/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-gz-math-vendor/APKBUILD
@@ -1,7 +1,7 @@
 pkgname=ros-jazzy-gz-math-vendor
 _pkgname=gz_math_vendor
-pkgver=0.0.8
-pkgrel=1
+pkgver=0.0.9
+pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://github.com/gazebosim/gz-math"
 arch="all"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: gz_math_vendor
     uri: https://github.com/ros2-gbp/gz_math_vendor-release.git
-    version: release/jazzy/gz_math_vendor/0.0.8-1
+    version: release/jazzy/gz_math_vendor/0.0.9-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-image-common/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-image-common/APKBUILD
@@ -1,7 +1,7 @@
 pkgname=ros-jazzy-image-common
 _pkgname=image_common
-pkgver=5.1.7
-pkgrel=1
+pkgver=5.1.8
+pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="http://www.ros.org/wiki/image_common"
 arch="all"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: image_common
     uri: https://github.com/ros2-gbp/image_common-release.git
-    version: release/jazzy/image_common/5.1.7-1
+    version: release/jazzy/image_common/5.1.8-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-image-pipeline/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-image-pipeline/APKBUILD
@@ -1,9 +1,9 @@
 pkgname=ros-jazzy-image-pipeline
 _pkgname=image_pipeline
-pkgver=5.0.11
-pkgrel=1
+pkgver=5.0.13
+pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
-url="https://index.ros.org/p/image_pipeline/github-ros-perception-image_pipeline/"
+url="https://index.ros.org/p/image_pipeline/"
 arch="all"
 license="BSD"
 
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: image_pipeline
     uri: https://github.com/ros2-gbp/image_pipeline-release.git
-    version: release/jazzy/image_pipeline/5.0.11-1
+    version: release/jazzy/image_pipeline/5.0.13-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-image-proc/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-image-proc/APKBUILD
@@ -1,9 +1,9 @@
 pkgname=ros-jazzy-image-proc
 _pkgname=image_proc
-pkgver=5.0.11
-pkgrel=1
+pkgver=5.0.13
+pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
-url="https://index.ros.org/p/image_proc/github-ros-perception-image_pipeline/"
+url="https://index.ros.org/p/image_proc/"
 arch="all"
 license="BSD"
 
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: image_proc
     uri: https://github.com/ros2-gbp/image_pipeline-release.git
-    version: release/jazzy/image_proc/5.0.11-1
+    version: release/jazzy/image_proc/5.0.13-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-image-publisher/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-image-publisher/APKBUILD
@@ -1,9 +1,9 @@
 pkgname=ros-jazzy-image-publisher
 _pkgname=image_publisher
-pkgver=5.0.11
-pkgrel=1
+pkgver=5.0.13
+pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
-url="https://index.ros.org/p/image_publisher/github-ros-perception-image_pipeline/"
+url="https://index.ros.org/p/image_publisher/"
 arch="all"
 license="BSD"
 
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: image_publisher
     uri: https://github.com/ros2-gbp/image_pipeline-release.git
-    version: release/jazzy/image_publisher/5.0.11-1
+    version: release/jazzy/image_publisher/5.0.13-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-image-rotate/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-image-rotate/APKBUILD
@@ -1,9 +1,9 @@
 pkgname=ros-jazzy-image-rotate
 _pkgname=image_rotate
-pkgver=5.0.11
-pkgrel=1
+pkgver=5.0.13
+pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
-url="https://index.ros.org/p/image_rotate/github-ros-perception-image_pipeline/"
+url="https://index.ros.org/p/image_rotate/"
 arch="all"
 license="BSD"
 
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: image_rotate
     uri: https://github.com/ros2-gbp/image_pipeline-release.git
-    version: release/jazzy/image_rotate/5.0.11-1
+    version: release/jazzy/image_rotate/5.0.13-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-image-tools/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-image-tools/APKBUILD
@@ -1,15 +1,15 @@
 pkgname=ros-jazzy-image-tools
 _pkgname=image_tools
-pkgver=0.33.9
+pkgver=0.33.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
 arch="all"
 license="Apache License 2.0"
 
-depends="ros-jazzy-rclcpp ros-jazzy-rclcpp-components ros-jazzy-ros-workspace ros-jazzy-sensor-msgs ros-jazzy-std-msgs"
+depends="libopencv_core libopencv_highgui libopencv_imgcodecs libopencv_imgproc libopencv_videoio ros-jazzy-rclcpp ros-jazzy-rclcpp-components ros-jazzy-ros-workspace ros-jazzy-sensor-msgs ros-jazzy-std-msgs"
 makedepends="chrpath opencv-dev py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-jazzy-ament-cmake ros-jazzy-ament-cmake-dev ros-jazzy-ament-cmake-pytest ros-jazzy-ament-cmake-pytest-dev ros-jazzy-ament-lint-auto ros-jazzy-ament-lint-auto-dev ros-jazzy-ament-lint-common ros-jazzy-ament-lint-common-dev ros-jazzy-launch ros-jazzy-launch-dev ros-jazzy-launch-ros ros-jazzy-launch-ros-dev ros-jazzy-launch-testing ros-jazzy-launch-testing-ament-cmake ros-jazzy-launch-testing-ament-cmake-dev ros-jazzy-launch-testing-dev ros-jazzy-launch-testing-ros ros-jazzy-launch-testing-ros-dev ros-jazzy-rclcpp ros-jazzy-rclcpp-components ros-jazzy-rclcpp-components-dev ros-jazzy-rclcpp-dev ros-jazzy-rmw-implementation-cmake ros-jazzy-rmw-implementation-cmake-dev ros-jazzy-ros-workspace-dev ros-jazzy-sensor-msgs ros-jazzy-sensor-msgs-dev ros-jazzy-std-msgs ros-jazzy-std-msgs-dev"
-depends_dev="opencv-dev ros-jazzy-rclcpp-components-dev ros-jazzy-rclcpp-dev ros-jazzy-ros-workspace-dev ros-jazzy-sensor-msgs-dev ros-jazzy-std-msgs-dev"
+depends_dev="ros-jazzy-rclcpp-components-dev ros-jazzy-rclcpp-dev ros-jazzy-ros-workspace-dev ros-jazzy-sensor-msgs-dev ros-jazzy-std-msgs-dev"
 
 subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: image_tools
     uri: https://github.com/ros2-gbp/demos-release.git
-    version: release/jazzy/image_tools/0.33.9-1
+    version: release/jazzy/image_tools/0.33.11-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-image-transport-plugins/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-image-transport-plugins/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-image-transport-plugins
 _pkgname=image_transport_plugins
-pkgver=4.0.6
+pkgver=4.0.7
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="http://www.ros.org/wiki/image_transport_plugins"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: image_transport_plugins
     uri: https://github.com/ros2-gbp/image_transport_plugins-release.git
-    version: release/jazzy/image_transport_plugins/4.0.6-1
+    version: release/jazzy/image_transport_plugins/4.0.7-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-image-transport/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-image-transport/APKBUILD
@@ -1,14 +1,14 @@
 pkgname=ros-jazzy-image-transport
 _pkgname=image_transport
-pkgver=5.1.7
-pkgrel=1
+pkgver=5.1.8
+pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="http://ros.org/wiki/image_transport"
 arch="all"
 license="BSD"
 
 depends="ros-jazzy-message-filters ros-jazzy-pluginlib ros-jazzy-rclcpp ros-jazzy-rclcpp-components ros-jazzy-ros-workspace ros-jazzy-sensor-msgs"
-makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-jazzy-ament-cmake-gtest ros-jazzy-ament-cmake-gtest-dev ros-jazzy-ament-cmake-ros ros-jazzy-ament-cmake-ros-dev ros-jazzy-ament-lint-auto ros-jazzy-ament-lint-auto-dev ros-jazzy-ament-lint-common ros-jazzy-ament-lint-common-dev ros-jazzy-message-filters ros-jazzy-message-filters-dev ros-jazzy-pluginlib ros-jazzy-pluginlib-dev ros-jazzy-rclcpp ros-jazzy-rclcpp-components ros-jazzy-rclcpp-components-dev ros-jazzy-rclcpp-dev ros-jazzy-ros-workspace-dev ros-jazzy-sensor-msgs ros-jazzy-sensor-msgs-dev"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-jazzy-ament-cmake-gen-version-h ros-jazzy-ament-cmake-gen-version-h-dev ros-jazzy-ament-cmake-gtest ros-jazzy-ament-cmake-gtest-dev ros-jazzy-ament-cmake-ros ros-jazzy-ament-cmake-ros-dev ros-jazzy-ament-lint-auto ros-jazzy-ament-lint-auto-dev ros-jazzy-ament-lint-common ros-jazzy-ament-lint-common-dev ros-jazzy-message-filters ros-jazzy-message-filters-dev ros-jazzy-pluginlib ros-jazzy-pluginlib-dev ros-jazzy-rclcpp ros-jazzy-rclcpp-components ros-jazzy-rclcpp-components-dev ros-jazzy-rclcpp-dev ros-jazzy-ros-workspace-dev ros-jazzy-sensor-msgs ros-jazzy-sensor-msgs-dev"
 depends_dev="ros-jazzy-message-filters ros-jazzy-message-filters-dev ros-jazzy-pluginlib ros-jazzy-pluginlib-dev ros-jazzy-rclcpp ros-jazzy-rclcpp-components ros-jazzy-rclcpp-components-dev ros-jazzy-rclcpp-dev ros-jazzy-ros-workspace-dev ros-jazzy-sensor-msgs ros-jazzy-sensor-msgs-dev"
 
 subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: image_transport
     uri: https://github.com/ros2-gbp/image_common-release.git
-    version: release/jazzy/image_transport/5.1.7-1
+    version: release/jazzy/image_transport/5.1.8-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-image-view/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-image-view/APKBUILD
@@ -1,9 +1,9 @@
 pkgname=ros-jazzy-image-view
 _pkgname=image_view
-pkgver=5.0.11
-pkgrel=1
+pkgver=5.0.13
+pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
-url="https://index.ros.org/p/image_view/github-ros-perception-image_pipeline/"
+url="https://index.ros.org/p/image_view/"
 arch="all"
 license="BSD"
 
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: image_view
     uri: https://github.com/ros2-gbp/image_pipeline-release.git
-    version: release/jazzy/image_view/5.0.11-1
+    version: release/jazzy/image_view/5.0.13-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-intra-process-demo/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-intra-process-demo/APKBUILD
@@ -1,15 +1,15 @@
 pkgname=ros-jazzy-intra-process-demo
 _pkgname=intra_process_demo
-pkgver=0.33.9
+pkgver=0.33.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
 arch="all"
 license="Apache License 2.0"
 
-depends="ros-jazzy-rclcpp ros-jazzy-ros-workspace ros-jazzy-sensor-msgs"
+depends="libopencv_core libopencv_highgui libopencv_imgproc libopencv_videoio ros-jazzy-rclcpp ros-jazzy-ros-workspace ros-jazzy-sensor-msgs"
 makedepends="chrpath opencv-dev py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-jazzy-ament-cmake ros-jazzy-ament-cmake-dev ros-jazzy-ament-cmake-pytest ros-jazzy-ament-cmake-pytest-dev ros-jazzy-ament-lint-auto ros-jazzy-ament-lint-auto-dev ros-jazzy-ament-lint-common ros-jazzy-ament-lint-common-dev ros-jazzy-launch ros-jazzy-launch-dev ros-jazzy-launch-testing ros-jazzy-launch-testing-ament-cmake ros-jazzy-launch-testing-ament-cmake-dev ros-jazzy-launch-testing-dev ros-jazzy-rclcpp ros-jazzy-rclcpp-dev ros-jazzy-rmw-implementation-cmake ros-jazzy-rmw-implementation-cmake-dev ros-jazzy-ros-workspace-dev ros-jazzy-sensor-msgs ros-jazzy-sensor-msgs-dev ros-jazzy-std-msgs ros-jazzy-std-msgs-dev"
-depends_dev="opencv-dev ros-jazzy-rclcpp-dev ros-jazzy-ros-workspace-dev ros-jazzy-sensor-msgs-dev"
+depends_dev="ros-jazzy-rclcpp-dev ros-jazzy-ros-workspace-dev ros-jazzy-sensor-msgs-dev"
 
 subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: intra_process_demo
     uri: https://github.com/ros2-gbp/demos-release.git
-    version: release/jazzy/intra_process_demo/0.33.9-1
+    version: release/jazzy/intra_process_demo/0.33.11-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-launch-ros/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-launch-ros/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-launch-ros
 _pkgname=launch_ros
-pkgver=0.26.11
+pkgver=0.26.12
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: launch_ros
     uri: https://github.com/ros2-gbp/launch_ros-release.git
-    version: release/jazzy/launch_ros/0.26.11-1
+    version: release/jazzy/launch_ros/0.26.12-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-launch-testing-ament-cmake/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-launch-testing-ament-cmake/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-launch-testing-ament-cmake
 _pkgname=launch_testing_ament_cmake
-pkgver=3.4.10
+pkgver=3.4.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: launch_testing_ament_cmake
     uri: https://github.com/ros2-gbp/launch-release.git
-    version: release/jazzy/launch_testing_ament_cmake/3.4.10-1
+    version: release/jazzy/launch_testing_ament_cmake/3.4.11-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-launch-testing-ros/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-launch-testing-ros/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-launch-testing-ros
 _pkgname=launch_testing_ros
-pkgver=0.26.11
+pkgver=0.26.12
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: launch_testing_ros
     uri: https://github.com/ros2-gbp/launch_ros-release.git
-    version: release/jazzy/launch_testing_ros/0.26.11-1
+    version: release/jazzy/launch_testing_ros/0.26.12-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-launch-testing/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-launch-testing/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-launch-testing
 _pkgname=launch_testing
-pkgver=3.4.10
+pkgver=3.4.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: launch_testing
     uri: https://github.com/ros2-gbp/launch-release.git
-    version: release/jazzy/launch_testing/3.4.10-1
+    version: release/jazzy/launch_testing/3.4.11-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-launch-testing/disable-failing-test.patch
+++ b/v3.20/ros/jazzy/ros-jazzy-launch-testing/disable-failing-test.patch
@@ -1,6 +1,6 @@
 diff --git a/test/launch_testing/test_io_handler_and_assertions.py b/test/launch_testing/test_io_handler_and_assertions.py
 deleted file mode 100644
-index 68f262f..0000000
+index d6bcea5..0000000
 --- a/test/launch_testing/test_io_handler_and_assertions.py
 +++ /dev/null
 @@ -1,188 +0,0 @@
@@ -112,7 +112,7 @@ index 68f262f..0000000
 -        matches = [t for t in text_lines if 'Called with arguments' in t]
 -        print('Called with arguments: {}'.format(matches))
 -
--        # Two process have args, because thats how process names are passed down
+-        # Two process have args, because that's how process names are passed down
 -        self.assertEqual(2, len(matches))
 -
 -        matches_extra = [t for t in matches if '--extra' in t]

--- a/v3.20/ros/jazzy/ros-jazzy-launch-xml/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-launch-xml/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-launch-xml
 _pkgname=launch_xml
-pkgver=3.4.10
+pkgver=3.4.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: launch_xml
     uri: https://github.com/ros2-gbp/launch-release.git
-    version: release/jazzy/launch_xml/3.4.10-1
+    version: release/jazzy/launch_xml/3.4.11-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-launch-yaml/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-launch-yaml/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-launch-yaml
 _pkgname=launch_yaml
-pkgver=3.4.10
+pkgver=3.4.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: launch_yaml
     uri: https://github.com/ros2-gbp/launch-release.git
-    version: release/jazzy/launch_yaml/3.4.10-1
+    version: release/jazzy/launch_yaml/3.4.11-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-launch/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-launch/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-launch
 _pkgname=launch
-pkgver=3.4.10
+pkgver=3.4.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: launch
     uri: https://github.com/ros2-gbp/launch-release.git
-    version: release/jazzy/launch/3.4.10-1
+    version: release/jazzy/launch/3.4.11-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-liblz4-vendor/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-liblz4-vendor/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-liblz4-vendor
 _pkgname=liblz4_vendor
-pkgver=0.26.9
+pkgver=0.26.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://github.com/lz4/lz4/"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: liblz4_vendor
     uri: https://github.com/ros2-gbp/rosbag2-release.git
-    version: release/jazzy/liblz4_vendor/0.26.9-1
+    version: release/jazzy/liblz4_vendor/0.26.11-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-libyaml-vendor/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-libyaml-vendor/APKBUILD
@@ -1,7 +1,7 @@
 pkgname=ros-jazzy-libyaml-vendor
 _pkgname=libyaml_vendor
-pkgver=1.6.3
-pkgrel=1
+pkgver=1.6.4
+pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://github.com/yaml/libyaml"
 arch="all"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: libyaml_vendor
     uri: https://github.com/ros2-gbp/libyaml_vendor-release.git
-    version: release/jazzy/libyaml_vendor/1.6.3-2
+    version: release/jazzy/libyaml_vendor/1.6.4-2
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-lifecycle-msgs/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-lifecycle-msgs/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-lifecycle-msgs
 _pkgname=lifecycle_msgs
-pkgver=2.0.3
+pkgver=2.0.4
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: lifecycle_msgs
     uri: https://github.com/ros2-gbp/rcl_interfaces-release.git
-    version: release/jazzy/lifecycle_msgs/2.0.3-1
+    version: release/jazzy/lifecycle_msgs/2.0.4-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-lifecycle/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-lifecycle/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-lifecycle
 _pkgname=lifecycle
-pkgver=0.33.9
+pkgver=0.33.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: lifecycle
     uri: https://github.com/ros2-gbp/demos-release.git
-    version: release/jazzy/lifecycle/0.33.9-1
+    version: release/jazzy/lifecycle/0.33.11-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-logging-demo/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-logging-demo/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-logging-demo
 _pkgname=logging_demo
-pkgver=0.33.9
+pkgver=0.33.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: logging_demo
     uri: https://github.com/ros2-gbp/demos-release.git
-    version: release/jazzy/logging_demo/0.33.9-1
+    version: release/jazzy/logging_demo/0.33.11-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-mcap-vendor/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-mcap-vendor/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-mcap-vendor
 _pkgname=mcap_vendor
-pkgver=0.26.9
+pkgver=0.26.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: mcap_vendor
     uri: https://github.com/ros2-gbp/rosbag2-release.git
-    version: release/jazzy/mcap_vendor/0.26.9-1
+    version: release/jazzy/mcap_vendor/0.26.11-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-message-filters/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-message-filters/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-message-filters
 _pkgname=message_filters
-pkgver=4.11.10
+pkgver=4.11.17
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://github.com/ros2/message_filters"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: message_filters
     uri: https://github.com/ros2-gbp/ros2_message_filters-release.git
-    version: release/jazzy/message_filters/4.11.10-1
+    version: release/jazzy/message_filters/4.11.17-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-mimick-vendor/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-mimick-vendor/APKBUILD
@@ -1,7 +1,7 @@
 pkgname=ros-jazzy-mimick-vendor
 _pkgname=mimick_vendor
-pkgver=0.6.2
-pkgrel=1
+pkgver=0.6.3
+pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://github.com/Snaipe/Mimick"
 arch="all"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: mimick_vendor
     uri: https://github.com/ros2-gbp/mimick_vendor-release.git
-    version: release/jazzy/mimick_vendor/0.6.2-1
+    version: release/jazzy/mimick_vendor/0.6.3-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-nav-2d-msgs/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-nav-2d-msgs/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-nav-2d-msgs
 _pkgname=nav_2d_msgs
-pkgver=1.3.11
+pkgver=1.3.12
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: nav_2d_msgs
     uri: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/nav_2d_msgs/1.3.11-1
+    version: release/jazzy/nav_2d_msgs/1.3.12-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-nav-2d-utils/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-nav-2d-utils/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-nav-2d-utils
 _pkgname=nav_2d_utils
-pkgver=1.3.11
+pkgver=1.3.12
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: nav_2d_utils
     uri: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/nav_2d_utils/1.3.11-1
+    version: release/jazzy/nav_2d_utils/1.3.12-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-nav-msgs/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-nav-msgs/APKBUILD
@@ -1,7 +1,7 @@
 pkgname=ros-jazzy-nav-msgs
 _pkgname=nav_msgs
-pkgver=5.3.6
-pkgrel=1
+pkgver=5.3.8
+pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
 arch="all"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: nav_msgs
     uri: https://github.com/ros2-gbp/common_interfaces-release.git
-    version: release/jazzy/nav_msgs/5.3.6-1
+    version: release/jazzy/nav_msgs/5.3.8-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-nav2-amcl/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-nav2-amcl/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-nav2-amcl
 _pkgname=nav2_amcl
-pkgver=1.3.11
+pkgver=1.3.12
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: nav2_amcl
     uri: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/nav2_amcl/1.3.11-1
+    version: release/jazzy/nav2_amcl/1.3.12-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-nav2-behavior-tree/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-nav2-behavior-tree/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-nav2-behavior-tree
 _pkgname=nav2_behavior_tree
-pkgver=1.3.11
+pkgver=1.3.12
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: nav2_behavior_tree
     uri: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/nav2_behavior_tree/1.3.11-1
+    version: release/jazzy/nav2_behavior_tree/1.3.12-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-nav2-behaviors/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-nav2-behaviors/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-nav2-behaviors
 _pkgname=nav2_behaviors
-pkgver=1.3.11
+pkgver=1.3.12
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: nav2_behaviors
     uri: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/nav2_behaviors/1.3.11-1
+    version: release/jazzy/nav2_behaviors/1.3.12-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-nav2-bt-navigator/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-nav2-bt-navigator/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-nav2-bt-navigator
 _pkgname=nav2_bt_navigator
-pkgver=1.3.11
+pkgver=1.3.12
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: nav2_bt_navigator
     uri: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/nav2_bt_navigator/1.3.11-1
+    version: release/jazzy/nav2_bt_navigator/1.3.12-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-nav2-collision-monitor/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-nav2-collision-monitor/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-nav2-collision-monitor
 _pkgname=nav2_collision_monitor
-pkgver=1.3.11
+pkgver=1.3.12
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: nav2_collision_monitor
     uri: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/nav2_collision_monitor/1.3.11-1
+    version: release/jazzy/nav2_collision_monitor/1.3.12-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-nav2-common/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-nav2-common/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-nav2-common
 _pkgname=nav2_common
-pkgver=1.3.11
+pkgver=1.3.12
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: nav2_common
     uri: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/nav2_common/1.3.11-1
+    version: release/jazzy/nav2_common/1.3.12-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-nav2-constrained-smoother/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-nav2-constrained-smoother/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-nav2-constrained-smoother
 _pkgname=nav2_constrained_smoother
-pkgver=1.3.11
+pkgver=1.3.12
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: nav2_constrained_smoother
     uri: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/nav2_constrained_smoother/1.3.11-1
+    version: release/jazzy/nav2_constrained_smoother/1.3.12-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-nav2-controller/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-nav2-controller/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-nav2-controller
 _pkgname=nav2_controller
-pkgver=1.3.11
+pkgver=1.3.12
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: nav2_controller
     uri: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/nav2_controller/1.3.11-1
+    version: release/jazzy/nav2_controller/1.3.12-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-nav2-core/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-nav2-core/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-nav2-core
 _pkgname=nav2_core
-pkgver=1.3.11
+pkgver=1.3.12
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: nav2_core
     uri: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/nav2_core/1.3.11-1
+    version: release/jazzy/nav2_core/1.3.12-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-nav2-costmap-2d/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-nav2-costmap-2d/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-nav2-costmap-2d
 _pkgname=nav2_costmap_2d
-pkgver=1.3.11
+pkgver=1.3.12
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: nav2_costmap_2d
     uri: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/nav2_costmap_2d/1.3.11-1
+    version: release/jazzy/nav2_costmap_2d/1.3.12-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-nav2-dwb-controller/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-nav2-dwb-controller/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-nav2-dwb-controller
 _pkgname=nav2_dwb_controller
-pkgver=1.3.11
+pkgver=1.3.12
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: nav2_dwb_controller
     uri: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/nav2_dwb_controller/1.3.11-1
+    version: release/jazzy/nav2_dwb_controller/1.3.12-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-nav2-graceful-controller/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-nav2-graceful-controller/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-nav2-graceful-controller
 _pkgname=nav2_graceful_controller
-pkgver=1.3.11
+pkgver=1.3.12
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: nav2_graceful_controller
     uri: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/nav2_graceful_controller/1.3.11-1
+    version: release/jazzy/nav2_graceful_controller/1.3.12-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-nav2-lifecycle-manager/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-nav2-lifecycle-manager/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-nav2-lifecycle-manager
 _pkgname=nav2_lifecycle_manager
-pkgver=1.3.11
+pkgver=1.3.12
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: nav2_lifecycle_manager
     uri: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/nav2_lifecycle_manager/1.3.11-1
+    version: release/jazzy/nav2_lifecycle_manager/1.3.12-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-nav2-map-server/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-nav2-map-server/APKBUILD
@@ -1,15 +1,15 @@
 pkgname=ros-jazzy-nav2-map-server
 _pkgname=nav2_map_server
-pkgver=1.3.11
+pkgver=1.3.12
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
 arch="all"
 license="Apache-2.0"
 
-depends="graphicsmagick ros-jazzy-launch-ros ros-jazzy-launch-testing ros-jazzy-nav-msgs ros-jazzy-nav2-msgs ros-jazzy-nav2-util ros-jazzy-rclcpp ros-jazzy-rclcpp-lifecycle ros-jazzy-ros-workspace ros-jazzy-std-msgs ros-jazzy-tf2 ros-jazzy-yaml-cpp-vendor"
-makedepends="chrpath graphicsmagick graphicsmagick-dev py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-jazzy-ament-cmake ros-jazzy-ament-cmake-dev ros-jazzy-ament-cmake-gtest ros-jazzy-ament-cmake-gtest-dev ros-jazzy-ament-cmake-pytest ros-jazzy-ament-cmake-pytest-dev ros-jazzy-ament-lint-auto ros-jazzy-ament-lint-auto-dev ros-jazzy-ament-lint-common ros-jazzy-ament-lint-common-dev ros-jazzy-launch ros-jazzy-launch-dev ros-jazzy-launch-ros ros-jazzy-launch-ros-dev ros-jazzy-launch-testing ros-jazzy-launch-testing-dev ros-jazzy-nav-msgs ros-jazzy-nav-msgs-dev ros-jazzy-nav2-common ros-jazzy-nav2-common-dev ros-jazzy-nav2-msgs ros-jazzy-nav2-msgs-dev ros-jazzy-nav2-util ros-jazzy-nav2-util-dev ros-jazzy-rclcpp ros-jazzy-rclcpp-dev ros-jazzy-rclcpp-lifecycle ros-jazzy-rclcpp-lifecycle-dev ros-jazzy-ros-workspace-dev ros-jazzy-std-msgs ros-jazzy-std-msgs-dev ros-jazzy-tf2 ros-jazzy-tf2-dev ros-jazzy-yaml-cpp-vendor ros-jazzy-yaml-cpp-vendor-dev"
-depends_dev="graphicsmagick graphicsmagick-dev ros-jazzy-launch-ros ros-jazzy-launch-ros-dev ros-jazzy-launch-testing ros-jazzy-launch-testing-dev ros-jazzy-nav-msgs ros-jazzy-nav-msgs-dev ros-jazzy-nav2-msgs ros-jazzy-nav2-msgs-dev ros-jazzy-nav2-util ros-jazzy-nav2-util-dev ros-jazzy-rclcpp ros-jazzy-rclcpp-dev ros-jazzy-rclcpp-lifecycle ros-jazzy-rclcpp-lifecycle-dev ros-jazzy-ros-workspace-dev ros-jazzy-std-msgs ros-jazzy-std-msgs-dev ros-jazzy-tf2 ros-jazzy-tf2-dev ros-jazzy-yaml-cpp-vendor ros-jazzy-yaml-cpp-vendor-dev"
+depends="graphicsmagick graphicsmagick-c++ ros-jazzy-launch-ros ros-jazzy-launch-testing ros-jazzy-nav-msgs ros-jazzy-nav2-msgs ros-jazzy-nav2-util ros-jazzy-rclcpp ros-jazzy-rclcpp-lifecycle ros-jazzy-ros-workspace ros-jazzy-std-msgs ros-jazzy-tf2 ros-jazzy-yaml-cpp-vendor"
+makedepends="chrpath graphicsmagick graphicsmagick-c++ graphicsmagick-dev py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-jazzy-ament-cmake ros-jazzy-ament-cmake-dev ros-jazzy-ament-cmake-gtest ros-jazzy-ament-cmake-gtest-dev ros-jazzy-ament-cmake-pytest ros-jazzy-ament-cmake-pytest-dev ros-jazzy-ament-lint-auto ros-jazzy-ament-lint-auto-dev ros-jazzy-ament-lint-common ros-jazzy-ament-lint-common-dev ros-jazzy-launch ros-jazzy-launch-dev ros-jazzy-launch-ros ros-jazzy-launch-ros-dev ros-jazzy-launch-testing ros-jazzy-launch-testing-dev ros-jazzy-nav-msgs ros-jazzy-nav-msgs-dev ros-jazzy-nav2-common ros-jazzy-nav2-common-dev ros-jazzy-nav2-msgs ros-jazzy-nav2-msgs-dev ros-jazzy-nav2-util ros-jazzy-nav2-util-dev ros-jazzy-rclcpp ros-jazzy-rclcpp-dev ros-jazzy-rclcpp-lifecycle ros-jazzy-rclcpp-lifecycle-dev ros-jazzy-ros-workspace-dev ros-jazzy-std-msgs ros-jazzy-std-msgs-dev ros-jazzy-tf2 ros-jazzy-tf2-dev ros-jazzy-yaml-cpp-vendor ros-jazzy-yaml-cpp-vendor-dev"
+depends_dev="graphicsmagick graphicsmagick-c++ graphicsmagick-dev ros-jazzy-launch-ros ros-jazzy-launch-ros-dev ros-jazzy-launch-testing ros-jazzy-launch-testing-dev ros-jazzy-nav-msgs ros-jazzy-nav-msgs-dev ros-jazzy-nav2-msgs ros-jazzy-nav2-msgs-dev ros-jazzy-nav2-util ros-jazzy-nav2-util-dev ros-jazzy-rclcpp ros-jazzy-rclcpp-dev ros-jazzy-rclcpp-lifecycle ros-jazzy-rclcpp-lifecycle-dev ros-jazzy-ros-workspace-dev ros-jazzy-std-msgs ros-jazzy-std-msgs-dev ros-jazzy-tf2 ros-jazzy-tf2-dev ros-jazzy-yaml-cpp-vendor ros-jazzy-yaml-cpp-vendor-dev"
 
 subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: nav2_map_server
     uri: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/nav2_map_server/1.3.11-1
+    version: release/jazzy/nav2_map_server/1.3.12-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-nav2-mppi-controller/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-nav2-mppi-controller/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-nav2-mppi-controller
 _pkgname=nav2_mppi_controller
-pkgver=1.3.11
+pkgver=1.3.12
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: nav2_mppi_controller
     uri: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/nav2_mppi_controller/1.3.11-1
+    version: release/jazzy/nav2_mppi_controller/1.3.12-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-nav2-msgs/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-nav2-msgs/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-nav2-msgs
 _pkgname=nav2_msgs
-pkgver=1.3.11
+pkgver=1.3.12
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: nav2_msgs
     uri: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/nav2_msgs/1.3.11-1
+    version: release/jazzy/nav2_msgs/1.3.12-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-nav2-navfn-planner/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-nav2-navfn-planner/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-nav2-navfn-planner
 _pkgname=nav2_navfn_planner
-pkgver=1.3.11
+pkgver=1.3.12
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: nav2_navfn_planner
     uri: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/nav2_navfn_planner/1.3.11-1
+    version: release/jazzy/nav2_navfn_planner/1.3.12-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-nav2-planner/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-nav2-planner/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-nav2-planner
 _pkgname=nav2_planner
-pkgver=1.3.11
+pkgver=1.3.12
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: nav2_planner
     uri: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/nav2_planner/1.3.11-1
+    version: release/jazzy/nav2_planner/1.3.12-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-nav2-regulated-pure-pursuit-controller/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-nav2-regulated-pure-pursuit-controller/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-nav2-regulated-pure-pursuit-controller
 _pkgname=nav2_regulated_pure_pursuit_controller
-pkgver=1.3.11
+pkgver=1.3.12
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: nav2_regulated_pure_pursuit_controller
     uri: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/nav2_regulated_pure_pursuit_controller/1.3.11-1
+    version: release/jazzy/nav2_regulated_pure_pursuit_controller/1.3.12-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-nav2-rotation-shim-controller/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-nav2-rotation-shim-controller/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-nav2-rotation-shim-controller
 _pkgname=nav2_rotation_shim_controller
-pkgver=1.3.11
+pkgver=1.3.12
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: nav2_rotation_shim_controller
     uri: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/nav2_rotation_shim_controller/1.3.11-1
+    version: release/jazzy/nav2_rotation_shim_controller/1.3.12-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-nav2-route/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-nav2-route/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-nav2-route
 _pkgname=nav2_route
-pkgver=1.3.11
+pkgver=1.3.12
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: nav2_route
     uri: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/nav2_route/1.3.11-1
+    version: release/jazzy/nav2_route/1.3.12-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-nav2-rviz-plugins/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-nav2-rviz-plugins/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-nav2-rviz-plugins
 _pkgname=nav2_rviz_plugins
-pkgver=1.3.11
+pkgver=1.3.12
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: nav2_rviz_plugins
     uri: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/nav2_rviz_plugins/1.3.11-1
+    version: release/jazzy/nav2_rviz_plugins/1.3.12-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-nav2-simple-commander/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-nav2-simple-commander/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-nav2-simple-commander
 _pkgname=nav2_simple_commander
-pkgver=1.3.11
+pkgver=1.3.12
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: nav2_simple_commander
     uri: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/nav2_simple_commander/1.3.11-1
+    version: release/jazzy/nav2_simple_commander/1.3.12-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-nav2-smac-planner/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-nav2-smac-planner/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-nav2-smac-planner
 _pkgname=nav2_smac_planner
-pkgver=1.3.11
+pkgver=1.3.12
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: nav2_smac_planner
     uri: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/nav2_smac_planner/1.3.11-1
+    version: release/jazzy/nav2_smac_planner/1.3.12-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-nav2-smoother/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-nav2-smoother/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-nav2-smoother
 _pkgname=nav2_smoother
-pkgver=1.3.11
+pkgver=1.3.12
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: nav2_smoother
     uri: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/nav2_smoother/1.3.11-1
+    version: release/jazzy/nav2_smoother/1.3.12-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-nav2-theta-star-planner/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-nav2-theta-star-planner/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-nav2-theta-star-planner
 _pkgname=nav2_theta_star_planner
-pkgver=1.3.11
+pkgver=1.3.12
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: nav2_theta_star_planner
     uri: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/nav2_theta_star_planner/1.3.11-1
+    version: release/jazzy/nav2_theta_star_planner/1.3.12-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-nav2-util/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-nav2-util/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-nav2-util
 _pkgname=nav2_util
-pkgver=1.3.11
+pkgver=1.3.12
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: nav2_util
     uri: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/nav2_util/1.3.11-1
+    version: release/jazzy/nav2_util/1.3.12-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-nav2-velocity-smoother/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-nav2-velocity-smoother/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-nav2-velocity-smoother
 _pkgname=nav2_velocity_smoother
-pkgver=1.3.11
+pkgver=1.3.12
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: nav2_velocity_smoother
     uri: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/nav2_velocity_smoother/1.3.11-1
+    version: release/jazzy/nav2_velocity_smoother/1.3.12-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-nav2-voxel-grid/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-nav2-voxel-grid/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-nav2-voxel-grid
 _pkgname=nav2_voxel_grid
-pkgver=1.3.11
+pkgver=1.3.12
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: nav2_voxel_grid
     uri: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/nav2_voxel_grid/1.3.11-1
+    version: release/jazzy/nav2_voxel_grid/1.3.12-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-navigation2/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-navigation2/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-navigation2
 _pkgname=navigation2
-pkgver=1.3.11
+pkgver=1.3.12
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: navigation2
     uri: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/navigation2/1.3.11-1
+    version: release/jazzy/navigation2/1.3.12-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-opennav-docking-bt/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-opennav-docking-bt/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-opennav-docking-bt
 _pkgname=opennav_docking_bt
-pkgver=1.3.11
+pkgver=1.3.12
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: opennav_docking_bt
     uri: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/opennav_docking_bt/1.3.11-1
+    version: release/jazzy/opennav_docking_bt/1.3.12-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-opennav-docking-core/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-opennav-docking-core/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-opennav-docking-core
 _pkgname=opennav_docking_core
-pkgver=1.3.11
+pkgver=1.3.12
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: opennav_docking_core
     uri: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/opennav_docking_core/1.3.11-1
+    version: release/jazzy/opennav_docking_core/1.3.12-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-opennav-docking/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-opennav-docking/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-opennav-docking
 _pkgname=opennav_docking
-pkgver=1.3.11
+pkgver=1.3.12
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: opennav_docking
     uri: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/opennav_docking/1.3.11-1
+    version: release/jazzy/opennav_docking/1.3.12-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-orocos-kdl-vendor/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-orocos-kdl-vendor/APKBUILD
@@ -1,7 +1,7 @@
 pkgname=ros-jazzy-orocos-kdl-vendor
 _pkgname=orocos_kdl_vendor
-pkgver=0.5.1
-pkgrel=1
+pkgver=0.5.2
+pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://github.com/orocos/orocos_kinematics_dynamics"
 arch="all"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: orocos_kdl_vendor
     uri: https://github.com/ros2-gbp/orocos_kdl_vendor-release.git
-    version: release/jazzy/orocos_kdl_vendor/0.5.1-2
+    version: release/jazzy/orocos_kdl_vendor/0.5.2-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-pcl-conversions/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-pcl-conversions/APKBUILD
@@ -1,11 +1,11 @@
 pkgname=ros-jazzy-pcl-conversions
 _pkgname=pcl_conversions
-pkgver=2.6.2
-pkgrel=1
+pkgver=2.6.5
+pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="http://wiki.ros.org/pcl_conversions"
 arch="all"
-license="BSD"
+license="BSD-3-Clause"
 
 depends="pcl-libs ros-jazzy-message-filters ros-jazzy-pcl-msgs ros-jazzy-rclcpp ros-jazzy-ros-workspace ros-jazzy-sensor-msgs ros-jazzy-std-msgs"
 makedepends="chrpath eigen-dev pcl-dev py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-jazzy-ament-cmake ros-jazzy-ament-cmake-dev ros-jazzy-ament-cmake-gtest ros-jazzy-ament-cmake-gtest-dev ros-jazzy-message-filters ros-jazzy-message-filters-dev ros-jazzy-pcl-msgs ros-jazzy-pcl-msgs-dev ros-jazzy-rclcpp ros-jazzy-rclcpp-dev ros-jazzy-ros-workspace-dev ros-jazzy-sensor-msgs ros-jazzy-sensor-msgs-dev ros-jazzy-std-msgs ros-jazzy-std-msgs-dev"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: pcl_conversions
     uri: https://github.com/ros2-gbp/perception_pcl-release.git
-    version: release/jazzy/pcl_conversions/2.6.2-1
+    version: release/jazzy/pcl_conversions/2.6.5-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-pcl-ros/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-pcl-ros/APKBUILD
@@ -1,14 +1,14 @@
 pkgname=ros-jazzy-pcl-ros
 _pkgname=pcl_ros
-pkgver=2.6.2
-pkgrel=1
+pkgver=2.6.5
+pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="http://ros.org/wiki/perception_pcl"
 arch="all"
-license="BSD"
+license="BSD-3-Clause"
 
 depends="pcl-libs ros-jazzy-geometry-msgs ros-jazzy-pcl-conversions ros-jazzy-rclcpp ros-jazzy-rclcpp-components ros-jazzy-ros-workspace ros-jazzy-sensor-msgs ros-jazzy-tf2 ros-jazzy-tf2-eigen ros-jazzy-tf2-geometry-msgs ros-jazzy-tf2-ros"
-makedepends="chrpath eigen-dev pcl-dev py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-jazzy-ament-cmake ros-jazzy-ament-cmake-dev ros-jazzy-ament-cmake-gtest ros-jazzy-ament-cmake-gtest-dev ros-jazzy-ament-cmake-pytest ros-jazzy-ament-cmake-pytest-dev ros-jazzy-ament-lint-auto ros-jazzy-ament-lint-auto-dev ros-jazzy-ament-lint-common ros-jazzy-ament-lint-common-dev ros-jazzy-geometry-msgs ros-jazzy-geometry-msgs-dev ros-jazzy-launch ros-jazzy-launch-dev ros-jazzy-launch-ros ros-jazzy-launch-ros-dev ros-jazzy-launch-testing ros-jazzy-launch-testing-dev ros-jazzy-launch-testing-ros ros-jazzy-launch-testing-ros-dev ros-jazzy-pcl-conversions ros-jazzy-pcl-conversions-dev ros-jazzy-rclcpp ros-jazzy-rclcpp-components ros-jazzy-rclcpp-components-dev ros-jazzy-rclcpp-dev ros-jazzy-ros-workspace-dev ros-jazzy-sensor-msgs ros-jazzy-sensor-msgs-dev ros-jazzy-tf2 ros-jazzy-tf2-dev ros-jazzy-tf2-eigen ros-jazzy-tf2-eigen-dev ros-jazzy-tf2-geometry-msgs ros-jazzy-tf2-geometry-msgs-dev ros-jazzy-tf2-ros ros-jazzy-tf2-ros-dev"
+makedepends="chrpath eigen-dev pcl-dev py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-jazzy-ament-cmake ros-jazzy-ament-cmake-dev ros-jazzy-ament-cmake-gtest ros-jazzy-ament-cmake-gtest-dev ros-jazzy-ament-cmake-pytest ros-jazzy-ament-cmake-pytest-dev ros-jazzy-ament-cmake-ros ros-jazzy-ament-cmake-ros-dev ros-jazzy-ament-lint-auto ros-jazzy-ament-lint-auto-dev ros-jazzy-ament-lint-common ros-jazzy-ament-lint-common-dev ros-jazzy-geometry-msgs ros-jazzy-geometry-msgs-dev ros-jazzy-launch ros-jazzy-launch-dev ros-jazzy-launch-ros ros-jazzy-launch-ros-dev ros-jazzy-launch-testing ros-jazzy-launch-testing-dev ros-jazzy-launch-testing-ros ros-jazzy-launch-testing-ros-dev ros-jazzy-pcl-conversions ros-jazzy-pcl-conversions-dev ros-jazzy-rclcpp ros-jazzy-rclcpp-components ros-jazzy-rclcpp-components-dev ros-jazzy-rclcpp-dev ros-jazzy-ros-workspace-dev ros-jazzy-sensor-msgs ros-jazzy-sensor-msgs-dev ros-jazzy-tf2 ros-jazzy-tf2-dev ros-jazzy-tf2-eigen ros-jazzy-tf2-eigen-dev ros-jazzy-tf2-geometry-msgs ros-jazzy-tf2-geometry-msgs-dev ros-jazzy-tf2-ros ros-jazzy-tf2-ros-dev"
 depends_dev="eigen-dev pcl-dev ros-jazzy-geometry-msgs ros-jazzy-geometry-msgs-dev ros-jazzy-pcl-conversions ros-jazzy-pcl-conversions-dev ros-jazzy-rclcpp ros-jazzy-rclcpp-components ros-jazzy-rclcpp-components-dev ros-jazzy-rclcpp-dev ros-jazzy-ros-workspace-dev ros-jazzy-sensor-msgs ros-jazzy-sensor-msgs-dev ros-jazzy-tf2 ros-jazzy-tf2-dev ros-jazzy-tf2-eigen ros-jazzy-tf2-eigen-dev ros-jazzy-tf2-geometry-msgs ros-jazzy-tf2-geometry-msgs-dev ros-jazzy-tf2-ros ros-jazzy-tf2-ros-dev"
 
 subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: pcl_ros
     uri: https://github.com/ros2-gbp/perception_pcl-release.git
-    version: release/jazzy/pcl_ros/2.6.2-1
+    version: release/jazzy/pcl_ros/2.6.5-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-pendulum-control/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-pendulum-control/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-pendulum-control
 _pkgname=pendulum_control
-pkgver=0.33.9
+pkgver=0.33.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: pendulum_control
     uri: https://github.com/ros2-gbp/demos-release.git
-    version: release/jazzy/pendulum_control/0.33.9-1
+    version: release/jazzy/pendulum_control/0.33.11-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-pendulum-msgs/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-pendulum-msgs/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-pendulum-msgs
 _pkgname=pendulum_msgs
-pkgver=0.33.9
+pkgver=0.33.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: pendulum_msgs
     uri: https://github.com/ros2-gbp/demos-release.git
-    version: release/jazzy/pendulum_msgs/0.33.9-1
+    version: release/jazzy/pendulum_msgs/0.33.11-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-perception-pcl/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-perception-pcl/APKBUILD
@@ -1,11 +1,11 @@
 pkgname=ros-jazzy-perception-pcl
 _pkgname=perception_pcl
-pkgver=2.6.2
-pkgrel=1
+pkgver=2.6.5
+pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="http://ros.org/wiki/perception_pcl"
 arch="all"
-license="BSD"
+license="BSD-3-Clause"
 
 depends="ros-jazzy-pcl-conversions ros-jazzy-pcl-msgs ros-jazzy-pcl-ros ros-jazzy-ros-workspace"
 makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-jazzy-ament-cmake ros-jazzy-ament-cmake-dev ros-jazzy-pcl-conversions-dev ros-jazzy-pcl-msgs-dev ros-jazzy-pcl-ros-dev ros-jazzy-ros-workspace-dev"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: perception_pcl
     uri: https://github.com/ros2-gbp/perception_pcl-release.git
-    version: release/jazzy/perception_pcl/2.6.2-1
+    version: release/jazzy/perception_pcl/2.6.5-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-performance-test-fixture/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-performance-test-fixture/APKBUILD
@@ -1,7 +1,7 @@
 pkgname=ros-jazzy-performance-test-fixture
 _pkgname=performance_test_fixture
-pkgver=0.2.1
-pkgrel=1
+pkgver=0.2.2
+pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
 arch="all"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: performance_test_fixture
     uri: https://github.com/ros2-gbp/performance_test_fixture-release.git
-    version: release/jazzy/performance_test_fixture/0.2.1-2
+    version: release/jazzy/performance_test_fixture/0.2.2-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-pluginlib/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-pluginlib/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-pluginlib
 _pkgname=pluginlib
-pkgver=5.4.4
+pkgver=5.4.5
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="http://www.ros.org/wiki/pluginlib"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: pluginlib
     uri: https://github.com/ros2-gbp/pluginlib-release.git
-    version: release/jazzy/pluginlib/5.4.4-1
+    version: release/jazzy/pluginlib/5.4.5-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-point-cloud-transport/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-point-cloud-transport/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-point-cloud-transport
 _pkgname=point_cloud_transport
-pkgver=4.0.7
+pkgver=4.0.9
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://github.com/ros-perception/point_cloud_transport"
@@ -8,7 +8,7 @@ arch="all"
 license="BSD"
 
 depends="ros-jazzy-message-filters ros-jazzy-pluginlib ros-jazzy-rclcpp ros-jazzy-rclcpp-components ros-jazzy-rcpputils ros-jazzy-rmw ros-jazzy-ros-workspace ros-jazzy-sensor-msgs"
-makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-jazzy-ament-cmake-ros ros-jazzy-ament-cmake-ros-dev ros-jazzy-ament-lint-auto ros-jazzy-ament-lint-auto-dev ros-jazzy-ament-lint-common ros-jazzy-ament-lint-common-dev ros-jazzy-message-filters ros-jazzy-message-filters-dev ros-jazzy-pluginlib ros-jazzy-pluginlib-dev ros-jazzy-rclcpp ros-jazzy-rclcpp-components ros-jazzy-rclcpp-components-dev ros-jazzy-rclcpp-dev ros-jazzy-rcpputils ros-jazzy-rcpputils-dev ros-jazzy-rmw ros-jazzy-rmw-dev ros-jazzy-ros-workspace-dev ros-jazzy-sensor-msgs ros-jazzy-sensor-msgs-dev"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-jazzy-ament-cmake-gen-version-h ros-jazzy-ament-cmake-gen-version-h-dev ros-jazzy-ament-cmake-ros ros-jazzy-ament-cmake-ros-dev ros-jazzy-ament-lint-auto ros-jazzy-ament-lint-auto-dev ros-jazzy-ament-lint-common ros-jazzy-ament-lint-common-dev ros-jazzy-message-filters ros-jazzy-message-filters-dev ros-jazzy-pluginlib ros-jazzy-pluginlib-dev ros-jazzy-rclcpp ros-jazzy-rclcpp-components ros-jazzy-rclcpp-components-dev ros-jazzy-rclcpp-dev ros-jazzy-rcpputils ros-jazzy-rcpputils-dev ros-jazzy-rmw ros-jazzy-rmw-dev ros-jazzy-ros-workspace-dev ros-jazzy-sensor-msgs ros-jazzy-sensor-msgs-dev"
 depends_dev="ros-jazzy-message-filters ros-jazzy-message-filters-dev ros-jazzy-pluginlib ros-jazzy-pluginlib-dev ros-jazzy-rclcpp ros-jazzy-rclcpp-components ros-jazzy-rclcpp-components-dev ros-jazzy-rclcpp-dev ros-jazzy-rcpputils ros-jazzy-rcpputils-dev ros-jazzy-rmw ros-jazzy-rmw-dev ros-jazzy-ros-workspace-dev ros-jazzy-sensor-msgs ros-jazzy-sensor-msgs-dev"
 
 subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: point_cloud_transport
     uri: https://github.com/ros2-gbp/point_cloud_transport-release.git
-    version: release/jazzy/point_cloud_transport/4.0.7-1
+    version: release/jazzy/point_cloud_transport/4.0.9-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-python-orocos-kdl-vendor/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-python-orocos-kdl-vendor/APKBUILD
@@ -1,7 +1,7 @@
 pkgname=ros-jazzy-python-orocos-kdl-vendor
 _pkgname=python_orocos_kdl_vendor
-pkgver=0.5.1
-pkgrel=1
+pkgver=0.5.2
+pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://github.com/orocos/orocos_kinematics_dynamics"
 arch="all"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: python_orocos_kdl_vendor
     uri: https://github.com/ros2-gbp/orocos_kdl_vendor-release.git
-    version: release/jazzy/python_orocos_kdl_vendor/0.5.1-2
+    version: release/jazzy/python_orocos_kdl_vendor/0.5.2-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-qt-dotgraph/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-qt-dotgraph/APKBUILD
@@ -1,7 +1,7 @@
 pkgname=ros-jazzy-qt-dotgraph
 _pkgname=qt_dotgraph
-pkgver=2.7.5
-pkgrel=1
+pkgver=2.7.6
+pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="http://ros.org/wiki/qt_dotgraph"
 arch="all"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: qt_dotgraph
     uri: https://github.com/ros2-gbp/qt_gui_core-release.git
-    version: release/jazzy/qt_dotgraph/2.7.5-1
+    version: release/jazzy/qt_dotgraph/2.7.6-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-qt-gui-cpp/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-qt-gui-cpp/APKBUILD
@@ -1,7 +1,7 @@
 pkgname=ros-jazzy-qt-gui-cpp
 _pkgname=qt_gui_cpp
-pkgver=2.7.5
-pkgrel=1
+pkgver=2.7.6
+pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="http://ros.org/wiki/qt_gui_cpp"
 arch="all"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: qt_gui_cpp
     uri: https://github.com/ros2-gbp/qt_gui_core-release.git
-    version: release/jazzy/qt_gui_cpp/2.7.5-1
+    version: release/jazzy/qt_gui_cpp/2.7.6-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-qt-gui-py-common/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-qt-gui-py-common/APKBUILD
@@ -1,7 +1,7 @@
 pkgname=ros-jazzy-qt-gui-py-common
 _pkgname=qt_gui_py_common
-pkgver=2.7.5
-pkgrel=1
+pkgver=2.7.6
+pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="http://ros.org/wiki/qt_gui_py_common"
 arch="all"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: qt_gui_py_common
     uri: https://github.com/ros2-gbp/qt_gui_core-release.git
-    version: release/jazzy/qt_gui_py_common/2.7.5-1
+    version: release/jazzy/qt_gui_py_common/2.7.6-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-qt-gui/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-qt-gui/APKBUILD
@@ -1,7 +1,7 @@
 pkgname=ros-jazzy-qt-gui
 _pkgname=qt_gui
-pkgver=2.7.5
-pkgrel=1
+pkgver=2.7.6
+pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="http://ros.org/wiki/qt_gui"
 arch="all"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: qt_gui
     uri: https://github.com/ros2-gbp/qt_gui_core-release.git
-    version: release/jazzy/qt_gui/2.7.5-1
+    version: release/jazzy/qt_gui/2.7.6-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-quality-of-service-demo-cpp/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-quality-of-service-demo-cpp/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-quality-of-service-demo-cpp
 _pkgname=quality_of_service_demo_cpp
-pkgver=0.33.9
+pkgver=0.33.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: quality_of_service_demo_cpp
     uri: https://github.com/ros2-gbp/demos-release.git
-    version: release/jazzy/quality_of_service_demo_cpp/0.33.9-1
+    version: release/jazzy/quality_of_service_demo_cpp/0.33.11-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-quality-of-service-demo-py/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-quality-of-service-demo-py/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-quality-of-service-demo-py
 _pkgname=quality_of_service_demo_py
-pkgver=0.33.9
+pkgver=0.33.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: quality_of_service_demo_py
     uri: https://github.com/ros2-gbp/demos-release.git
-    version: release/jazzy/quality_of_service_demo_py/0.33.9-1
+    version: release/jazzy/quality_of_service_demo_py/0.33.11-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-rcl-action/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-rcl-action/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rcl-action
 _pkgname=rcl_action
-pkgver=9.2.9
+pkgver=9.2.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rcl_action
     uri: https://github.com/ros2-gbp/rcl-release.git
-    version: release/jazzy/rcl_action/9.2.9-1
+    version: release/jazzy/rcl_action/9.2.11-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-rcl-interfaces/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-rcl-interfaces/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rcl-interfaces
 _pkgname=rcl_interfaces
-pkgver=2.0.3
+pkgver=2.0.4
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rcl_interfaces
     uri: https://github.com/ros2-gbp/rcl_interfaces-release.git
-    version: release/jazzy/rcl_interfaces/2.0.3-1
+    version: release/jazzy/rcl_interfaces/2.0.4-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-rcl-lifecycle/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-rcl-lifecycle/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rcl-lifecycle
 _pkgname=rcl_lifecycle
-pkgver=9.2.9
+pkgver=9.2.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rcl_lifecycle
     uri: https://github.com/ros2-gbp/rcl-release.git
-    version: release/jazzy/rcl_lifecycle/9.2.9-1
+    version: release/jazzy/rcl_lifecycle/9.2.11-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-rcl-yaml-param-parser/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-rcl-yaml-param-parser/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rcl-yaml-param-parser
 _pkgname=rcl_yaml_param_parser
-pkgver=9.2.9
+pkgver=9.2.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rcl_yaml_param_parser
     uri: https://github.com/ros2-gbp/rcl-release.git
-    version: release/jazzy/rcl_yaml_param_parser/9.2.9-1
+    version: release/jazzy/rcl_yaml_param_parser/9.2.11-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-rcl/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-rcl/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rcl
 _pkgname=rcl
-pkgver=9.2.9
+pkgver=9.2.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rcl
     uri: https://github.com/ros2-gbp/rcl-release.git
-    version: release/jazzy/rcl/9.2.9-1
+    version: release/jazzy/rcl/9.2.11-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-rclcpp-action/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-rclcpp-action/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rclcpp-action
 _pkgname=rclcpp_action
-pkgver=28.1.16
+pkgver=28.1.21
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rclcpp_action
     uri: https://github.com/ros2-gbp/rclcpp-release.git
-    version: release/jazzy/rclcpp_action/28.1.16-1
+    version: release/jazzy/rclcpp_action/28.1.21-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-rclcpp-components/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-rclcpp-components/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rclcpp-components
 _pkgname=rclcpp_components
-pkgver=28.1.16
+pkgver=28.1.21
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rclcpp_components
     uri: https://github.com/ros2-gbp/rclcpp-release.git
-    version: release/jazzy/rclcpp_components/28.1.16-1
+    version: release/jazzy/rclcpp_components/28.1.21-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-rclcpp-lifecycle/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-rclcpp-lifecycle/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rclcpp-lifecycle
 _pkgname=rclcpp_lifecycle
-pkgver=28.1.16
+pkgver=28.1.21
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rclcpp_lifecycle
     uri: https://github.com/ros2-gbp/rclcpp-release.git
-    version: release/jazzy/rclcpp_lifecycle/28.1.16-1
+    version: release/jazzy/rclcpp_lifecycle/28.1.21-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-rclcpp/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-rclcpp/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rclcpp
 _pkgname=rclcpp
-pkgver=28.1.16
+pkgver=28.1.21
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rclcpp
     uri: https://github.com/ros2-gbp/rclcpp-release.git
-    version: release/jazzy/rclcpp/28.1.16-1
+    version: release/jazzy/rclcpp/28.1.21-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-rclpy/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-rclpy/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rclpy
 _pkgname=rclpy
-pkgver=7.1.9
+pkgver=7.1.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rclpy
     uri: https://github.com/ros2-gbp/rclpy-release.git
-    version: release/jazzy/rclpy/7.1.9-1
+    version: release/jazzy/rclpy/7.1.11-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-rclpy/disable-flaky-test.patch
+++ b/v3.20/ros/jazzy/ros-jazzy-rclpy/disable-flaky-test.patch
@@ -1,5 +1,5 @@
 diff --git a/test/test_timer.py b/test/test_timer.py
-index 394f750..dbe095c 100644
+index 9ca7363..3ff1326 100644
 --- a/test/test_timer.py
 +++ b/test/test_timer.py
 @@ -101,54 +101,54 @@ def test_number_callbacks(period):
@@ -39,7 +39,7 @@ index 394f750..dbe095c 100644
 -                        executor.spin_once(timeout_sec=period / 10)
 -                    assert [] == callbacks
 -
--                    # Reenable timer and make sure callbacks are received again
+-                    # Re-enable timer and make sure callbacks are received again
 -                    timer.reset()
 -                    assert not timer.is_canceled()
 -                    begin_time = time.time()
@@ -87,7 +87,7 @@ index 394f750..dbe095c 100644
 +#                         executor.spin_once(timeout_sec=period / 10)
 +#                     assert [] == callbacks
 +#
-+#                     # Reenable timer and make sure callbacks are received again
++#                     # Re-enable timer and make sure callbacks are received again
 +#                     timer.reset()
 +#                     assert not timer.is_canceled()
 +#                     begin_time = time.time()

--- a/v3.20/ros/jazzy/ros-jazzy-rcpputils/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-rcpputils/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rcpputils
 _pkgname=rcpputils
-pkgver=2.11.3
+pkgver=2.11.4
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rcpputils
     uri: https://github.com/ros2-gbp/rcpputils-release.git
-    version: release/jazzy/rcpputils/2.11.3-1
+    version: release/jazzy/rcpputils/2.11.4-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-rcutils/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-rcutils/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rcutils
 _pkgname=rcutils
-pkgver=6.7.5
+pkgver=6.7.6
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rcutils
     uri: https://github.com/ros2-gbp/rcutils-release.git
-    version: release/jazzy/rcutils/6.7.5-1
+    version: release/jazzy/rcutils/6.7.6-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-rmw-fastrtps-cpp/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-rmw-fastrtps-cpp/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rmw-fastrtps-cpp
 _pkgname=rmw_fastrtps_cpp
-pkgver=8.4.3
+pkgver=8.4.4
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -8,8 +8,8 @@ arch="all"
 license="Apache License 2.0"
 
 depends="ros-jazzy-rcpputils ros-jazzy-rcutils ros-jazzy-rmw ros-jazzy-rmw-fastrtps-shared-cpp ros-jazzy-ros-workspace ros-jazzy-rosidl-dynamic-typesupport ros-jazzy-rosidl-dynamic-typesupport-fastrtps ros-jazzy-tracetools"
-makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-jazzy-ament-cmake ros-jazzy-ament-cmake-dev ros-jazzy-ament-cmake-gtest ros-jazzy-ament-cmake-gtest-dev ros-jazzy-ament-cmake-ros ros-jazzy-ament-cmake-ros-dev ros-jazzy-ament-lint-auto ros-jazzy-ament-lint-auto-dev ros-jazzy-ament-lint-common ros-jazzy-ament-lint-common-dev ros-jazzy-fastcdr ros-jazzy-fastcdr-dev ros-jazzy-fastrtps ros-jazzy-fastrtps-cmake-module ros-jazzy-fastrtps-cmake-module-dev ros-jazzy-fastrtps-dev ros-jazzy-osrf-testing-tools-cpp ros-jazzy-osrf-testing-tools-cpp-dev ros-jazzy-rcpputils ros-jazzy-rcpputils-dev ros-jazzy-rcutils ros-jazzy-rcutils-dev ros-jazzy-rmw ros-jazzy-rmw-dds-common ros-jazzy-rmw-dds-common-dev ros-jazzy-rmw-dev ros-jazzy-rmw-fastrtps-shared-cpp ros-jazzy-rmw-fastrtps-shared-cpp-dev ros-jazzy-ros-workspace-dev ros-jazzy-rosidl-dynamic-typesupport ros-jazzy-rosidl-dynamic-typesupport-dev ros-jazzy-rosidl-dynamic-typesupport-fastrtps ros-jazzy-rosidl-dynamic-typesupport-fastrtps-dev ros-jazzy-rosidl-runtime-c ros-jazzy-rosidl-runtime-c-dev ros-jazzy-rosidl-runtime-cpp ros-jazzy-rosidl-runtime-cpp-dev ros-jazzy-rosidl-typesupport-fastrtps-c ros-jazzy-rosidl-typesupport-fastrtps-c-dev ros-jazzy-rosidl-typesupport-fastrtps-cpp ros-jazzy-rosidl-typesupport-fastrtps-cpp-dev ros-jazzy-test-msgs ros-jazzy-test-msgs-dev ros-jazzy-tracetools ros-jazzy-tracetools-dev"
-depends_dev="ros-jazzy-ament-cmake ros-jazzy-ament-cmake-dev ros-jazzy-fastcdr ros-jazzy-fastcdr-dev ros-jazzy-fastrtps ros-jazzy-fastrtps-cmake-module ros-jazzy-fastrtps-cmake-module-dev ros-jazzy-fastrtps-dev ros-jazzy-rcpputils-dev ros-jazzy-rcutils ros-jazzy-rcutils-dev ros-jazzy-rmw ros-jazzy-rmw-dds-common ros-jazzy-rmw-dds-common-dev ros-jazzy-rmw-dev ros-jazzy-rmw-fastrtps-shared-cpp ros-jazzy-rmw-fastrtps-shared-cpp-dev ros-jazzy-ros-workspace-dev ros-jazzy-rosidl-dynamic-typesupport ros-jazzy-rosidl-dynamic-typesupport-dev ros-jazzy-rosidl-dynamic-typesupport-fastrtps-dev ros-jazzy-rosidl-runtime-c ros-jazzy-rosidl-runtime-c-dev ros-jazzy-rosidl-runtime-cpp ros-jazzy-rosidl-runtime-cpp-dev ros-jazzy-rosidl-typesupport-fastrtps-c ros-jazzy-rosidl-typesupport-fastrtps-c-dev ros-jazzy-rosidl-typesupport-fastrtps-cpp ros-jazzy-rosidl-typesupport-fastrtps-cpp-dev ros-jazzy-tracetools ros-jazzy-tracetools-dev"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-jazzy-ament-cmake-gtest ros-jazzy-ament-cmake-gtest-dev ros-jazzy-ament-cmake-ros ros-jazzy-ament-cmake-ros-dev ros-jazzy-ament-lint-auto ros-jazzy-ament-lint-auto-dev ros-jazzy-ament-lint-common ros-jazzy-ament-lint-common-dev ros-jazzy-fastcdr ros-jazzy-fastcdr-dev ros-jazzy-fastrtps ros-jazzy-fastrtps-cmake-module ros-jazzy-fastrtps-cmake-module-dev ros-jazzy-fastrtps-dev ros-jazzy-osrf-testing-tools-cpp ros-jazzy-osrf-testing-tools-cpp-dev ros-jazzy-rcpputils ros-jazzy-rcpputils-dev ros-jazzy-rcutils ros-jazzy-rcutils-dev ros-jazzy-rmw ros-jazzy-rmw-dds-common ros-jazzy-rmw-dds-common-dev ros-jazzy-rmw-dev ros-jazzy-rmw-fastrtps-shared-cpp ros-jazzy-rmw-fastrtps-shared-cpp-dev ros-jazzy-ros-workspace-dev ros-jazzy-rosidl-dynamic-typesupport ros-jazzy-rosidl-dynamic-typesupport-dev ros-jazzy-rosidl-dynamic-typesupport-fastrtps ros-jazzy-rosidl-dynamic-typesupport-fastrtps-dev ros-jazzy-rosidl-runtime-c ros-jazzy-rosidl-runtime-c-dev ros-jazzy-rosidl-runtime-cpp ros-jazzy-rosidl-runtime-cpp-dev ros-jazzy-rosidl-typesupport-fastrtps-c ros-jazzy-rosidl-typesupport-fastrtps-c-dev ros-jazzy-rosidl-typesupport-fastrtps-cpp ros-jazzy-rosidl-typesupport-fastrtps-cpp-dev ros-jazzy-test-msgs ros-jazzy-test-msgs-dev ros-jazzy-tracetools ros-jazzy-tracetools-dev"
+depends_dev="ros-jazzy-fastcdr ros-jazzy-fastcdr-dev ros-jazzy-fastrtps ros-jazzy-fastrtps-cmake-module ros-jazzy-fastrtps-cmake-module-dev ros-jazzy-fastrtps-dev ros-jazzy-rcpputils-dev ros-jazzy-rcutils ros-jazzy-rcutils-dev ros-jazzy-rmw ros-jazzy-rmw-dds-common ros-jazzy-rmw-dds-common-dev ros-jazzy-rmw-dev ros-jazzy-rmw-fastrtps-shared-cpp ros-jazzy-rmw-fastrtps-shared-cpp-dev ros-jazzy-ros-workspace-dev ros-jazzy-rosidl-dynamic-typesupport ros-jazzy-rosidl-dynamic-typesupport-dev ros-jazzy-rosidl-dynamic-typesupport-fastrtps-dev ros-jazzy-rosidl-runtime-c ros-jazzy-rosidl-runtime-c-dev ros-jazzy-rosidl-runtime-cpp ros-jazzy-rosidl-runtime-cpp-dev ros-jazzy-rosidl-typesupport-fastrtps-c ros-jazzy-rosidl-typesupport-fastrtps-c-dev ros-jazzy-rosidl-typesupport-fastrtps-cpp ros-jazzy-rosidl-typesupport-fastrtps-cpp-dev ros-jazzy-tracetools ros-jazzy-tracetools-dev"
 
 subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rmw_fastrtps_cpp
     uri: https://github.com/ros2-gbp/rmw_fastrtps-release.git
-    version: release/jazzy/rmw_fastrtps_cpp/8.4.3-1
+    version: release/jazzy/rmw_fastrtps_cpp/8.4.4-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-rmw-fastrtps-dynamic-cpp/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-rmw-fastrtps-dynamic-cpp/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rmw-fastrtps-dynamic-cpp
 _pkgname=rmw_fastrtps_dynamic_cpp
-pkgver=8.4.3
+pkgver=8.4.4
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -8,8 +8,8 @@ arch="all"
 license="Apache License 2.0"
 
 depends="ros-jazzy-ros-workspace"
-makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-jazzy-ament-cmake ros-jazzy-ament-cmake-dev ros-jazzy-ament-cmake-gtest ros-jazzy-ament-cmake-gtest-dev ros-jazzy-ament-cmake-ros ros-jazzy-ament-cmake-ros-dev ros-jazzy-ament-lint-auto ros-jazzy-ament-lint-auto-dev ros-jazzy-ament-lint-common ros-jazzy-ament-lint-common-dev ros-jazzy-fastcdr ros-jazzy-fastcdr-dev ros-jazzy-fastrtps ros-jazzy-fastrtps-cmake-module ros-jazzy-fastrtps-cmake-module-dev ros-jazzy-fastrtps-dev ros-jazzy-osrf-testing-tools-cpp ros-jazzy-osrf-testing-tools-cpp-dev ros-jazzy-rcpputils ros-jazzy-rcpputils-dev ros-jazzy-rcutils ros-jazzy-rcutils-dev ros-jazzy-rmw ros-jazzy-rmw-dds-common ros-jazzy-rmw-dds-common-dev ros-jazzy-rmw-dev ros-jazzy-rmw-fastrtps-shared-cpp ros-jazzy-rmw-fastrtps-shared-cpp-dev ros-jazzy-ros-workspace-dev ros-jazzy-rosidl-runtime-c ros-jazzy-rosidl-runtime-c-dev ros-jazzy-rosidl-typesupport-introspection-c ros-jazzy-rosidl-typesupport-introspection-c-dev ros-jazzy-rosidl-typesupport-introspection-cpp ros-jazzy-rosidl-typesupport-introspection-cpp-dev ros-jazzy-test-msgs ros-jazzy-test-msgs-dev"
-depends_dev="ros-jazzy-ament-cmake ros-jazzy-ament-cmake-dev ros-jazzy-fastcdr ros-jazzy-fastcdr-dev ros-jazzy-fastrtps ros-jazzy-fastrtps-cmake-module ros-jazzy-fastrtps-cmake-module-dev ros-jazzy-fastrtps-dev ros-jazzy-rcpputils ros-jazzy-rcpputils-dev ros-jazzy-rcutils ros-jazzy-rcutils-dev ros-jazzy-rmw ros-jazzy-rmw-dds-common ros-jazzy-rmw-dds-common-dev ros-jazzy-rmw-dev ros-jazzy-rmw-fastrtps-shared-cpp ros-jazzy-rmw-fastrtps-shared-cpp-dev ros-jazzy-ros-workspace-dev ros-jazzy-rosidl-runtime-c ros-jazzy-rosidl-runtime-c-dev ros-jazzy-rosidl-typesupport-introspection-c ros-jazzy-rosidl-typesupport-introspection-c-dev ros-jazzy-rosidl-typesupport-introspection-cpp ros-jazzy-rosidl-typesupport-introspection-cpp-dev"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-jazzy-ament-cmake-gtest ros-jazzy-ament-cmake-gtest-dev ros-jazzy-ament-cmake-ros ros-jazzy-ament-cmake-ros-dev ros-jazzy-ament-lint-auto ros-jazzy-ament-lint-auto-dev ros-jazzy-ament-lint-common ros-jazzy-ament-lint-common-dev ros-jazzy-fastcdr ros-jazzy-fastcdr-dev ros-jazzy-fastrtps ros-jazzy-fastrtps-cmake-module ros-jazzy-fastrtps-cmake-module-dev ros-jazzy-fastrtps-dev ros-jazzy-osrf-testing-tools-cpp ros-jazzy-osrf-testing-tools-cpp-dev ros-jazzy-rcpputils ros-jazzy-rcpputils-dev ros-jazzy-rcutils ros-jazzy-rcutils-dev ros-jazzy-rmw ros-jazzy-rmw-dds-common ros-jazzy-rmw-dds-common-dev ros-jazzy-rmw-dev ros-jazzy-rmw-fastrtps-shared-cpp ros-jazzy-rmw-fastrtps-shared-cpp-dev ros-jazzy-ros-workspace-dev ros-jazzy-rosidl-runtime-c ros-jazzy-rosidl-runtime-c-dev ros-jazzy-rosidl-typesupport-introspection-c ros-jazzy-rosidl-typesupport-introspection-c-dev ros-jazzy-rosidl-typesupport-introspection-cpp ros-jazzy-rosidl-typesupport-introspection-cpp-dev ros-jazzy-test-msgs ros-jazzy-test-msgs-dev"
+depends_dev="ros-jazzy-fastcdr ros-jazzy-fastcdr-dev ros-jazzy-fastrtps ros-jazzy-fastrtps-cmake-module ros-jazzy-fastrtps-cmake-module-dev ros-jazzy-fastrtps-dev ros-jazzy-rcpputils ros-jazzy-rcpputils-dev ros-jazzy-rcutils ros-jazzy-rcutils-dev ros-jazzy-rmw ros-jazzy-rmw-dds-common ros-jazzy-rmw-dds-common-dev ros-jazzy-rmw-dev ros-jazzy-rmw-fastrtps-shared-cpp ros-jazzy-rmw-fastrtps-shared-cpp-dev ros-jazzy-ros-workspace-dev ros-jazzy-rosidl-runtime-c ros-jazzy-rosidl-runtime-c-dev ros-jazzy-rosidl-typesupport-introspection-c ros-jazzy-rosidl-typesupport-introspection-c-dev ros-jazzy-rosidl-typesupport-introspection-cpp ros-jazzy-rosidl-typesupport-introspection-cpp-dev"
 
 subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rmw_fastrtps_dynamic_cpp
     uri: https://github.com/ros2-gbp/rmw_fastrtps-release.git
-    version: release/jazzy/rmw_fastrtps_dynamic_cpp/8.4.3-1
+    version: release/jazzy/rmw_fastrtps_dynamic_cpp/8.4.4-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-rmw-fastrtps-shared-cpp/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-rmw-fastrtps-shared-cpp/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rmw-fastrtps-shared-cpp
 _pkgname=rmw_fastrtps_shared_cpp
-pkgver=8.4.3
+pkgver=8.4.4
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -8,8 +8,8 @@ arch="all"
 license="Apache License 2.0"
 
 depends="ros-jazzy-ros-workspace"
-makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-jazzy-ament-cmake ros-jazzy-ament-cmake-dev ros-jazzy-ament-cmake-ros ros-jazzy-ament-cmake-ros-dev ros-jazzy-ament-lint-auto ros-jazzy-ament-lint-auto-dev ros-jazzy-ament-lint-common ros-jazzy-ament-lint-common-dev ros-jazzy-fastcdr ros-jazzy-fastcdr-dev ros-jazzy-fastrtps ros-jazzy-fastrtps-cmake-module ros-jazzy-fastrtps-cmake-module-dev ros-jazzy-fastrtps-dev ros-jazzy-osrf-testing-tools-cpp ros-jazzy-osrf-testing-tools-cpp-dev ros-jazzy-rcpputils ros-jazzy-rcpputils-dev ros-jazzy-rcutils ros-jazzy-rcutils-dev ros-jazzy-rmw ros-jazzy-rmw-dds-common ros-jazzy-rmw-dds-common-dev ros-jazzy-rmw-dev ros-jazzy-ros-workspace-dev ros-jazzy-rosidl-dynamic-typesupport ros-jazzy-rosidl-dynamic-typesupport-dev ros-jazzy-rosidl-runtime-c ros-jazzy-rosidl-runtime-c-dev ros-jazzy-rosidl-typesupport-introspection-c ros-jazzy-rosidl-typesupport-introspection-c-dev ros-jazzy-rosidl-typesupport-introspection-cpp ros-jazzy-rosidl-typesupport-introspection-cpp-dev ros-jazzy-tracetools ros-jazzy-tracetools-dev"
-depends_dev="ros-jazzy-ament-cmake ros-jazzy-ament-cmake-dev ros-jazzy-fastcdr ros-jazzy-fastcdr-dev ros-jazzy-fastrtps ros-jazzy-fastrtps-cmake-module ros-jazzy-fastrtps-cmake-module-dev ros-jazzy-fastrtps-dev ros-jazzy-rcpputils ros-jazzy-rcpputils-dev ros-jazzy-rcutils ros-jazzy-rcutils-dev ros-jazzy-rmw ros-jazzy-rmw-dds-common ros-jazzy-rmw-dds-common-dev ros-jazzy-rmw-dev ros-jazzy-ros-workspace-dev ros-jazzy-rosidl-dynamic-typesupport ros-jazzy-rosidl-dynamic-typesupport-dev ros-jazzy-rosidl-typesupport-introspection-c ros-jazzy-rosidl-typesupport-introspection-c-dev ros-jazzy-rosidl-typesupport-introspection-cpp ros-jazzy-rosidl-typesupport-introspection-cpp-dev ros-jazzy-tracetools ros-jazzy-tracetools-dev"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-jazzy-ament-cmake-ros ros-jazzy-ament-cmake-ros-dev ros-jazzy-ament-lint-auto ros-jazzy-ament-lint-auto-dev ros-jazzy-ament-lint-common ros-jazzy-ament-lint-common-dev ros-jazzy-fastcdr ros-jazzy-fastcdr-dev ros-jazzy-fastrtps ros-jazzy-fastrtps-cmake-module ros-jazzy-fastrtps-cmake-module-dev ros-jazzy-fastrtps-dev ros-jazzy-osrf-testing-tools-cpp ros-jazzy-osrf-testing-tools-cpp-dev ros-jazzy-rcpputils ros-jazzy-rcpputils-dev ros-jazzy-rcutils ros-jazzy-rcutils-dev ros-jazzy-rmw ros-jazzy-rmw-dds-common ros-jazzy-rmw-dds-common-dev ros-jazzy-rmw-dev ros-jazzy-ros-workspace-dev ros-jazzy-rosidl-dynamic-typesupport ros-jazzy-rosidl-dynamic-typesupport-dev ros-jazzy-rosidl-runtime-c ros-jazzy-rosidl-runtime-c-dev ros-jazzy-rosidl-typesupport-introspection-c ros-jazzy-rosidl-typesupport-introspection-c-dev ros-jazzy-rosidl-typesupport-introspection-cpp ros-jazzy-rosidl-typesupport-introspection-cpp-dev ros-jazzy-tracetools ros-jazzy-tracetools-dev"
+depends_dev="ros-jazzy-fastcdr ros-jazzy-fastcdr-dev ros-jazzy-fastrtps ros-jazzy-fastrtps-cmake-module ros-jazzy-fastrtps-cmake-module-dev ros-jazzy-fastrtps-dev ros-jazzy-rcpputils ros-jazzy-rcpputils-dev ros-jazzy-rcutils ros-jazzy-rcutils-dev ros-jazzy-rmw ros-jazzy-rmw-dds-common ros-jazzy-rmw-dds-common-dev ros-jazzy-rmw-dev ros-jazzy-ros-workspace-dev ros-jazzy-rosidl-dynamic-typesupport ros-jazzy-rosidl-dynamic-typesupport-dev ros-jazzy-rosidl-typesupport-introspection-c ros-jazzy-rosidl-typesupport-introspection-c-dev ros-jazzy-rosidl-typesupport-introspection-cpp ros-jazzy-rosidl-typesupport-introspection-cpp-dev ros-jazzy-tracetools ros-jazzy-tracetools-dev"
 
 subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rmw_fastrtps_shared_cpp
     uri: https://github.com/ros2-gbp/rmw_fastrtps-release.git
-    version: release/jazzy/rmw_fastrtps_shared_cpp/8.4.3-1
+    version: release/jazzy/rmw_fastrtps_shared_cpp/8.4.4-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-robot-state-publisher/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-robot-state-publisher/APKBUILD
@@ -1,7 +1,7 @@
 pkgname=ros-jazzy-robot-state-publisher
 _pkgname=robot_state_publisher
-pkgver=3.3.3
-pkgrel=1
+pkgver=3.3.4
+pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
 arch="all"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: robot_state_publisher
     uri: https://github.com/ros2-gbp/robot_state_publisher-release.git
-    version: release/jazzy/robot_state_publisher/3.3.3-3
+    version: release/jazzy/robot_state_publisher/3.3.4-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-ros-testing/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-ros-testing/APKBUILD
@@ -1,7 +1,7 @@
 pkgname=ros-jazzy-ros-testing
 _pkgname=ros_testing
-pkgver=0.6.0
-pkgrel=1
+pkgver=0.6.1
+pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
 arch="all"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ros_testing
     uri: https://github.com/ros2-gbp/ros_testing-release.git
-    version: release/jazzy/ros_testing/0.6.0-3
+    version: release/jazzy/ros_testing/0.6.1-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-ros2action/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-ros2action/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-ros2action
 _pkgname=ros2action
-pkgver=0.32.8
+pkgver=0.32.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ros2action
     uri: https://github.com/ros2-gbp/ros2cli-release.git
-    version: release/jazzy/ros2action/0.32.8-1
+    version: release/jazzy/ros2action/0.32.11-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-ros2bag/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-ros2bag/APKBUILD
@@ -1,15 +1,15 @@
 pkgname=ros-jazzy-ros2bag
 _pkgname=ros2bag
-pkgver=0.26.9
+pkgver=0.26.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
 arch="all"
 license="Apache License 2.0"
 
-depends="py3-yaml ros-jazzy-ament-index-python ros-jazzy-rclpy ros-jazzy-ros-workspace ros-jazzy-ros2cli ros-jazzy-rosbag2-py"
+depends="py3-yaml ros-jazzy-ament-index-python ros-jazzy-rclpy ros-jazzy-ros-workspace ros-jazzy-ros2cli ros-jazzy-rosbag2-py ros-jazzy-rosbag2-storage-default-plugins"
 makedepends="chrpath py3-pytest7 py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-jazzy-ament-copyright ros-jazzy-ament-copyright-dev ros-jazzy-ament-flake8 ros-jazzy-ament-flake8-dev ros-jazzy-ament-index-python-dev ros-jazzy-ament-pep257 ros-jazzy-ament-pep257-dev ros-jazzy-launch-testing ros-jazzy-launch-testing-dev ros-jazzy-launch-testing-ros ros-jazzy-launch-testing-ros-dev ros-jazzy-rclpy-dev ros-jazzy-ros-workspace-dev ros-jazzy-ros2cli-dev ros-jazzy-rosbag2-py-dev ros-jazzy-rosbag2-storage-default-plugins ros-jazzy-rosbag2-storage-default-plugins-dev ros-jazzy-rosbag2-test-common ros-jazzy-rosbag2-test-common-dev"
-depends_dev="ros-jazzy-ament-index-python-dev ros-jazzy-rclpy-dev ros-jazzy-ros-workspace-dev ros-jazzy-ros2cli-dev ros-jazzy-rosbag2-py-dev"
+depends_dev="ros-jazzy-ament-index-python-dev ros-jazzy-rclpy-dev ros-jazzy-ros-workspace-dev ros-jazzy-ros2cli-dev ros-jazzy-rosbag2-py-dev ros-jazzy-rosbag2-storage-default-plugins-dev"
 
 subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ros2bag
     uri: https://github.com/ros2-gbp/rosbag2-release.git
-    version: release/jazzy/ros2bag/0.26.9-1
+    version: release/jazzy/ros2bag/0.26.11-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-ros2cli-test-interfaces/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-ros2cli-test-interfaces/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-ros2cli-test-interfaces
 _pkgname=ros2cli_test_interfaces
-pkgver=0.32.8
+pkgver=0.32.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ros2cli_test_interfaces
     uri: https://github.com/ros2-gbp/ros2cli-release.git
-    version: release/jazzy/ros2cli_test_interfaces/0.32.8-1
+    version: release/jazzy/ros2cli_test_interfaces/0.32.11-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-ros2cli/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-ros2cli/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-ros2cli
 _pkgname=ros2cli
-pkgver=0.32.8
+pkgver=0.32.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ros2cli
     uri: https://github.com/ros2-gbp/ros2cli-release.git
-    version: release/jazzy/ros2cli/0.32.8-1
+    version: release/jazzy/ros2cli/0.32.11-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-ros2component/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-ros2component/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-ros2component
 _pkgname=ros2component
-pkgver=0.32.8
+pkgver=0.32.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ros2component
     uri: https://github.com/ros2-gbp/ros2cli-release.git
-    version: release/jazzy/ros2component/0.32.8-1
+    version: release/jazzy/ros2component/0.32.11-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-ros2doctor/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-ros2doctor/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-ros2doctor
 _pkgname=ros2doctor
-pkgver=0.32.8
+pkgver=0.32.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ros2doctor
     uri: https://github.com/ros2-gbp/ros2cli-release.git
-    version: release/jazzy/ros2doctor/0.32.8-1
+    version: release/jazzy/ros2doctor/0.32.11-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-ros2interface/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-ros2interface/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-ros2interface
 _pkgname=ros2interface
-pkgver=0.32.8
+pkgver=0.32.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ros2interface
     uri: https://github.com/ros2-gbp/ros2cli-release.git
-    version: release/jazzy/ros2interface/0.32.8-1
+    version: release/jazzy/ros2interface/0.32.11-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-ros2launch/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-ros2launch/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-ros2launch
 _pkgname=ros2launch
-pkgver=0.26.11
+pkgver=0.26.12
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ros2launch
     uri: https://github.com/ros2-gbp/launch_ros-release.git
-    version: release/jazzy/ros2launch/0.26.11-1
+    version: release/jazzy/ros2launch/0.26.12-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-ros2lifecycle-test-fixtures/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-ros2lifecycle-test-fixtures/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-ros2lifecycle-test-fixtures
 _pkgname=ros2lifecycle_test_fixtures
-pkgver=0.32.8
+pkgver=0.32.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ros2lifecycle_test_fixtures
     uri: https://github.com/ros2-gbp/ros2cli-release.git
-    version: release/jazzy/ros2lifecycle_test_fixtures/0.32.8-1
+    version: release/jazzy/ros2lifecycle_test_fixtures/0.32.11-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-ros2lifecycle/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-ros2lifecycle/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-ros2lifecycle
 _pkgname=ros2lifecycle
-pkgver=0.32.8
+pkgver=0.32.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ros2lifecycle
     uri: https://github.com/ros2-gbp/ros2cli-release.git
-    version: release/jazzy/ros2lifecycle/0.32.8-1
+    version: release/jazzy/ros2lifecycle/0.32.11-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-ros2multicast/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-ros2multicast/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-ros2multicast
 _pkgname=ros2multicast
-pkgver=0.32.8
+pkgver=0.32.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ros2multicast
     uri: https://github.com/ros2-gbp/ros2cli-release.git
-    version: release/jazzy/ros2multicast/0.32.8-1
+    version: release/jazzy/ros2multicast/0.32.11-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-ros2node/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-ros2node/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-ros2node
 _pkgname=ros2node
-pkgver=0.32.8
+pkgver=0.32.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ros2node
     uri: https://github.com/ros2-gbp/ros2cli-release.git
-    version: release/jazzy/ros2node/0.32.8-1
+    version: release/jazzy/ros2node/0.32.11-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-ros2param/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-ros2param/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-ros2param
 _pkgname=ros2param
-pkgver=0.32.8
+pkgver=0.32.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ros2param
     uri: https://github.com/ros2-gbp/ros2cli-release.git
-    version: release/jazzy/ros2param/0.32.8-1
+    version: release/jazzy/ros2param/0.32.11-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-ros2pkg/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-ros2pkg/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-ros2pkg
 _pkgname=ros2pkg
-pkgver=0.32.8
+pkgver=0.32.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ros2pkg
     uri: https://github.com/ros2-gbp/ros2cli-release.git
-    version: release/jazzy/ros2pkg/0.32.8-1
+    version: release/jazzy/ros2pkg/0.32.11-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-ros2plugin/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-ros2plugin/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-ros2plugin
 _pkgname=ros2plugin
-pkgver=5.4.4
+pkgver=5.4.5
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ros2plugin
     uri: https://github.com/ros2-gbp/pluginlib-release.git
-    version: release/jazzy/ros2plugin/5.4.4-1
+    version: release/jazzy/ros2plugin/5.4.5-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-ros2run/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-ros2run/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-ros2run
 _pkgname=ros2run
-pkgver=0.32.8
+pkgver=0.32.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ros2run
     uri: https://github.com/ros2-gbp/ros2cli-release.git
-    version: release/jazzy/ros2run/0.32.8-1
+    version: release/jazzy/ros2run/0.32.11-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-ros2service/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-ros2service/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-ros2service
 _pkgname=ros2service
-pkgver=0.32.8
+pkgver=0.32.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ros2service
     uri: https://github.com/ros2-gbp/ros2cli-release.git
-    version: release/jazzy/ros2service/0.32.8-1
+    version: release/jazzy/ros2service/0.32.11-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-ros2test/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-ros2test/APKBUILD
@@ -1,7 +1,7 @@
 pkgname=ros-jazzy-ros2test
 _pkgname=ros2test
-pkgver=0.6.0
-pkgrel=1
+pkgver=0.6.1
+pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
 arch="all"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ros2test
     uri: https://github.com/ros2-gbp/ros_testing-release.git
-    version: release/jazzy/ros2test/0.6.0-3
+    version: release/jazzy/ros2test/0.6.1-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-ros2topic/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-ros2topic/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-ros2topic
 _pkgname=ros2topic
-pkgver=0.32.8
+pkgver=0.32.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ros2topic
     uri: https://github.com/ros2-gbp/ros2cli-release.git
-    version: release/jazzy/ros2topic/0.32.8-1
+    version: release/jazzy/ros2topic/0.32.11-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-rosbag2-compression-zstd/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-rosbag2-compression-zstd/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rosbag2-compression-zstd
 _pkgname=rosbag2_compression_zstd
-pkgver=0.26.9
+pkgver=0.26.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rosbag2_compression_zstd
     uri: https://github.com/ros2-gbp/rosbag2-release.git
-    version: release/jazzy/rosbag2_compression_zstd/0.26.9-1
+    version: release/jazzy/rosbag2_compression_zstd/0.26.11-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-rosbag2-compression/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-rosbag2-compression/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rosbag2-compression
 _pkgname=rosbag2_compression
-pkgver=0.26.9
+pkgver=0.26.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rosbag2_compression
     uri: https://github.com/ros2-gbp/rosbag2-release.git
-    version: release/jazzy/rosbag2_compression/0.26.9-1
+    version: release/jazzy/rosbag2_compression/0.26.11-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-rosbag2-cpp/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-rosbag2-cpp/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rosbag2-cpp
 _pkgname=rosbag2_cpp
-pkgver=0.26.9
+pkgver=0.26.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rosbag2_cpp
     uri: https://github.com/ros2-gbp/rosbag2-release.git
-    version: release/jazzy/rosbag2_cpp/0.26.9-1
+    version: release/jazzy/rosbag2_cpp/0.26.11-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-rosbag2-interfaces/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-rosbag2-interfaces/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rosbag2-interfaces
 _pkgname=rosbag2_interfaces
-pkgver=0.26.9
+pkgver=0.26.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rosbag2_interfaces
     uri: https://github.com/ros2-gbp/rosbag2-release.git
-    version: release/jazzy/rosbag2_interfaces/0.26.9-1
+    version: release/jazzy/rosbag2_interfaces/0.26.11-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-rosbag2-py/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-rosbag2-py/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rosbag2-py
 _pkgname=rosbag2_py
-pkgver=0.26.9
+pkgver=0.26.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rosbag2_py
     uri: https://github.com/ros2-gbp/rosbag2-release.git
-    version: release/jazzy/rosbag2_py/0.26.9-1
+    version: release/jazzy/rosbag2_py/0.26.11-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-rosbag2-storage-default-plugins/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-rosbag2-storage-default-plugins/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rosbag2-storage-default-plugins
 _pkgname=rosbag2_storage_default_plugins
-pkgver=0.26.9
+pkgver=0.26.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rosbag2_storage_default_plugins
     uri: https://github.com/ros2-gbp/rosbag2-release.git
-    version: release/jazzy/rosbag2_storage_default_plugins/0.26.9-1
+    version: release/jazzy/rosbag2_storage_default_plugins/0.26.11-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-rosbag2-storage-mcap/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-rosbag2-storage-mcap/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rosbag2-storage-mcap
 _pkgname=rosbag2_storage_mcap
-pkgver=0.26.9
+pkgver=0.26.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rosbag2_storage_mcap
     uri: https://github.com/ros2-gbp/rosbag2-release.git
-    version: release/jazzy/rosbag2_storage_mcap/0.26.9-1
+    version: release/jazzy/rosbag2_storage_mcap/0.26.11-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-rosbag2-storage-sqlite3/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-rosbag2-storage-sqlite3/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rosbag2-storage-sqlite3
 _pkgname=rosbag2_storage_sqlite3
-pkgver=0.26.9
+pkgver=0.26.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rosbag2_storage_sqlite3
     uri: https://github.com/ros2-gbp/rosbag2-release.git
-    version: release/jazzy/rosbag2_storage_sqlite3/0.26.9-1
+    version: release/jazzy/rosbag2_storage_sqlite3/0.26.11-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-rosbag2-storage/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-rosbag2-storage/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rosbag2-storage
 _pkgname=rosbag2_storage
-pkgver=0.26.9
+pkgver=0.26.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rosbag2_storage
     uri: https://github.com/ros2-gbp/rosbag2-release.git
-    version: release/jazzy/rosbag2_storage/0.26.9-1
+    version: release/jazzy/rosbag2_storage/0.26.11-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-rosbag2-test-common/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-rosbag2-test-common/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rosbag2-test-common
 _pkgname=rosbag2_test_common
-pkgver=0.26.9
+pkgver=0.26.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rosbag2_test_common
     uri: https://github.com/ros2-gbp/rosbag2-release.git
-    version: release/jazzy/rosbag2_test_common/0.26.9-1
+    version: release/jazzy/rosbag2_test_common/0.26.11-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-rosbag2-test-msgdefs/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-rosbag2-test-msgdefs/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rosbag2-test-msgdefs
 _pkgname=rosbag2_test_msgdefs
-pkgver=0.26.9
+pkgver=0.26.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rosbag2_test_msgdefs
     uri: https://github.com/ros2-gbp/rosbag2-release.git
-    version: release/jazzy/rosbag2_test_msgdefs/0.26.9-1
+    version: release/jazzy/rosbag2_test_msgdefs/0.26.11-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-rosbag2-tests/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-rosbag2-tests/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rosbag2-tests
 _pkgname=rosbag2_tests
-pkgver=0.26.9
+pkgver=0.26.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rosbag2_tests
     uri: https://github.com/ros2-gbp/rosbag2-release.git
-    version: release/jazzy/rosbag2_tests/0.26.9-1
+    version: release/jazzy/rosbag2_tests/0.26.11-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-rosbag2-transport/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-rosbag2-transport/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rosbag2-transport
 _pkgname=rosbag2_transport
-pkgver=0.26.9
+pkgver=0.26.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rosbag2_transport
     uri: https://github.com/ros2-gbp/rosbag2-release.git
-    version: release/jazzy/rosbag2_transport/0.26.9-1
+    version: release/jazzy/rosbag2_transport/0.26.11-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-rosbag2/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-rosbag2/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rosbag2
 _pkgname=rosbag2
-pkgver=0.26.9
+pkgver=0.26.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rosbag2
     uri: https://github.com/ros2-gbp/rosbag2-release.git
-    version: release/jazzy/rosbag2/0.26.9-1
+    version: release/jazzy/rosbag2/0.26.11-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-rosgraph-msgs/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-rosgraph-msgs/APKBUILD
@@ -1,15 +1,15 @@
 pkgname=ros-jazzy-rosgraph-msgs
 _pkgname=rosgraph_msgs
-pkgver=2.0.3
+pkgver=2.0.4
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
 arch="all"
 license="Apache License 2.0"
 
-depends="ros-jazzy-builtin-interfaces ros-jazzy-ros-workspace ros-jazzy-rosidl-default-runtime"
-makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-jazzy-ament-cmake ros-jazzy-ament-cmake-dev ros-jazzy-ament-lint-common ros-jazzy-ament-lint-common-dev ros-jazzy-builtin-interfaces ros-jazzy-builtin-interfaces-dev ros-jazzy-ros-workspace-dev ros-jazzy-rosidl-default-generators ros-jazzy-rosidl-default-generators-dev ros-jazzy-rosidl-default-runtime-dev"
-depends_dev="ros-jazzy-builtin-interfaces-dev ros-jazzy-ros-workspace-dev ros-jazzy-rosidl-default-runtime-dev"
+depends="ros-jazzy-builtin-interfaces ros-jazzy-rcl-interfaces ros-jazzy-ros-workspace ros-jazzy-rosidl-default-runtime"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-jazzy-ament-cmake ros-jazzy-ament-cmake-dev ros-jazzy-ament-lint-common ros-jazzy-ament-lint-common-dev ros-jazzy-builtin-interfaces ros-jazzy-builtin-interfaces-dev ros-jazzy-rcl-interfaces ros-jazzy-rcl-interfaces-dev ros-jazzy-ros-workspace-dev ros-jazzy-rosidl-default-generators ros-jazzy-rosidl-default-generators-dev ros-jazzy-rosidl-default-runtime-dev"
+depends_dev="ros-jazzy-builtin-interfaces-dev ros-jazzy-rcl-interfaces-dev ros-jazzy-ros-workspace-dev ros-jazzy-rosidl-default-runtime-dev"
 
 subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rosgraph_msgs
     uri: https://github.com/ros2-gbp/rcl_interfaces-release.git
-    version: release/jazzy/rosgraph_msgs/2.0.3-1
+    version: release/jazzy/rosgraph_msgs/2.0.4-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-rosidl-adapter/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-rosidl-adapter/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rosidl-adapter
 _pkgname=rosidl_adapter
-pkgver=4.6.7
+pkgver=4.6.9
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rosidl_adapter
     uri: https://github.com/ros2-gbp/rosidl-release.git
-    version: release/jazzy/rosidl_adapter/4.6.7-1
+    version: release/jazzy/rosidl_adapter/4.6.9-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-rosidl-cli/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-rosidl-cli/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rosidl-cli
 _pkgname=rosidl_cli
-pkgver=4.6.7
+pkgver=4.6.9
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rosidl_cli
     uri: https://github.com/ros2-gbp/rosidl-release.git
-    version: release/jazzy/rosidl_cli/4.6.7-1
+    version: release/jazzy/rosidl_cli/4.6.9-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-rosidl-cmake/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-rosidl-cmake/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rosidl-cmake
 _pkgname=rosidl_cmake
-pkgver=4.6.7
+pkgver=4.6.9
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rosidl_cmake
     uri: https://github.com/ros2-gbp/rosidl-release.git
-    version: release/jazzy/rosidl_cmake/4.6.7-1
+    version: release/jazzy/rosidl_cmake/4.6.9-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-rosidl-core-generators/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-rosidl-core-generators/APKBUILD
@@ -1,15 +1,15 @@
 pkgname=ros-jazzy-rosidl-core-generators
 _pkgname=rosidl_core_generators
-pkgver=0.2.0
-pkgrel=1
+pkgver=0.2.1
+pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
 arch="all"
 license="Apache License 2.0"
 
 depends="ros-jazzy-ros-workspace"
-makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-jazzy-ament-cmake ros-jazzy-ament-cmake-core ros-jazzy-ament-cmake-core-dev ros-jazzy-ament-cmake-dev ros-jazzy-ament-lint-auto ros-jazzy-ament-lint-auto-dev ros-jazzy-ament-lint-common ros-jazzy-ament-lint-common-dev ros-jazzy-ros-workspace-dev ros-jazzy-rosidl-cmake ros-jazzy-rosidl-cmake-dev ros-jazzy-rosidl-generator-c ros-jazzy-rosidl-generator-c-dev ros-jazzy-rosidl-generator-cpp ros-jazzy-rosidl-generator-cpp-dev ros-jazzy-rosidl-generator-py ros-jazzy-rosidl-generator-py-dev ros-jazzy-rosidl-typesupport-c ros-jazzy-rosidl-typesupport-c-dev ros-jazzy-rosidl-typesupport-cpp ros-jazzy-rosidl-typesupport-cpp-dev ros-jazzy-rosidl-typesupport-fastrtps-c ros-jazzy-rosidl-typesupport-fastrtps-c-dev ros-jazzy-rosidl-typesupport-fastrtps-cpp ros-jazzy-rosidl-typesupport-fastrtps-cpp-dev ros-jazzy-rosidl-typesupport-introspection-c ros-jazzy-rosidl-typesupport-introspection-c-dev ros-jazzy-rosidl-typesupport-introspection-cpp ros-jazzy-rosidl-typesupport-introspection-cpp-dev"
-depends_dev="ros-jazzy-ament-cmake-core ros-jazzy-ament-cmake-core-dev ros-jazzy-ros-workspace-dev ros-jazzy-rosidl-cmake ros-jazzy-rosidl-cmake-dev ros-jazzy-rosidl-generator-c ros-jazzy-rosidl-generator-c-dev ros-jazzy-rosidl-generator-cpp ros-jazzy-rosidl-generator-cpp-dev ros-jazzy-rosidl-generator-py ros-jazzy-rosidl-generator-py-dev ros-jazzy-rosidl-typesupport-c ros-jazzy-rosidl-typesupport-c-dev ros-jazzy-rosidl-typesupport-cpp ros-jazzy-rosidl-typesupport-cpp-dev ros-jazzy-rosidl-typesupport-fastrtps-c ros-jazzy-rosidl-typesupport-fastrtps-c-dev ros-jazzy-rosidl-typesupport-fastrtps-cpp ros-jazzy-rosidl-typesupport-fastrtps-cpp-dev ros-jazzy-rosidl-typesupport-introspection-c ros-jazzy-rosidl-typesupport-introspection-c-dev ros-jazzy-rosidl-typesupport-introspection-cpp ros-jazzy-rosidl-typesupport-introspection-cpp-dev"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-jazzy-ament-cmake ros-jazzy-ament-cmake-core ros-jazzy-ament-cmake-core-dev ros-jazzy-ament-cmake-dev ros-jazzy-ament-lint-auto ros-jazzy-ament-lint-auto-dev ros-jazzy-ament-lint-common ros-jazzy-ament-lint-common-dev ros-jazzy-ros-workspace-dev ros-jazzy-rosidl-cmake ros-jazzy-rosidl-cmake-dev ros-jazzy-rosidl-generator-c ros-jazzy-rosidl-generator-c-dev ros-jazzy-rosidl-generator-cpp ros-jazzy-rosidl-generator-cpp-dev ros-jazzy-rosidl-generator-py ros-jazzy-rosidl-generator-py-dev ros-jazzy-rosidl-generator-rs ros-jazzy-rosidl-generator-rs-dev ros-jazzy-rosidl-typesupport-c ros-jazzy-rosidl-typesupport-c-dev ros-jazzy-rosidl-typesupport-cpp ros-jazzy-rosidl-typesupport-cpp-dev ros-jazzy-rosidl-typesupport-fastrtps-c ros-jazzy-rosidl-typesupport-fastrtps-c-dev ros-jazzy-rosidl-typesupport-fastrtps-cpp ros-jazzy-rosidl-typesupport-fastrtps-cpp-dev ros-jazzy-rosidl-typesupport-introspection-c ros-jazzy-rosidl-typesupport-introspection-c-dev ros-jazzy-rosidl-typesupport-introspection-cpp ros-jazzy-rosidl-typesupport-introspection-cpp-dev"
+depends_dev="ros-jazzy-ament-cmake-core ros-jazzy-ament-cmake-core-dev ros-jazzy-ros-workspace-dev ros-jazzy-rosidl-cmake ros-jazzy-rosidl-cmake-dev ros-jazzy-rosidl-generator-c ros-jazzy-rosidl-generator-c-dev ros-jazzy-rosidl-generator-cpp ros-jazzy-rosidl-generator-cpp-dev ros-jazzy-rosidl-generator-py ros-jazzy-rosidl-generator-py-dev ros-jazzy-rosidl-generator-rs ros-jazzy-rosidl-generator-rs-dev ros-jazzy-rosidl-typesupport-c ros-jazzy-rosidl-typesupport-c-dev ros-jazzy-rosidl-typesupport-cpp ros-jazzy-rosidl-typesupport-cpp-dev ros-jazzy-rosidl-typesupport-fastrtps-c ros-jazzy-rosidl-typesupport-fastrtps-c-dev ros-jazzy-rosidl-typesupport-fastrtps-cpp ros-jazzy-rosidl-typesupport-fastrtps-cpp-dev ros-jazzy-rosidl-typesupport-introspection-c ros-jazzy-rosidl-typesupport-introspection-c-dev ros-jazzy-rosidl-typesupport-introspection-cpp ros-jazzy-rosidl-typesupport-introspection-cpp-dev"
 
 subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rosidl_core_generators
     uri: https://github.com/ros2-gbp/rosidl_core-release.git
-    version: release/jazzy/rosidl_core_generators/0.2.0-3
+    version: release/jazzy/rosidl_core_generators/0.2.1-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-rosidl-core-runtime/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-rosidl-core-runtime/APKBUILD
@@ -1,7 +1,7 @@
 pkgname=ros-jazzy-rosidl-core-runtime
 _pkgname=rosidl_core_runtime
-pkgver=0.2.0
-pkgrel=1
+pkgver=0.2.1
+pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
 arch="all"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rosidl_core_runtime
     uri: https://github.com/ros2-gbp/rosidl_core-release.git
-    version: release/jazzy/rosidl_core_runtime/0.2.0-3
+    version: release/jazzy/rosidl_core_runtime/0.2.1-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-rosidl-default-generators/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-rosidl-default-generators/APKBUILD
@@ -1,7 +1,7 @@
 pkgname=ros-jazzy-rosidl-default-generators
 _pkgname=rosidl_default_generators
-pkgver=1.6.0
-pkgrel=1
+pkgver=1.6.1
+pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
 arch="all"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rosidl_default_generators
     uri: https://github.com/ros2-gbp/rosidl_defaults-release.git
-    version: release/jazzy/rosidl_default_generators/1.6.0-3
+    version: release/jazzy/rosidl_default_generators/1.6.1-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-rosidl-default-runtime/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-rosidl-default-runtime/APKBUILD
@@ -1,7 +1,7 @@
 pkgname=ros-jazzy-rosidl-default-runtime
 _pkgname=rosidl_default_runtime
-pkgver=1.6.0
-pkgrel=1
+pkgver=1.6.1
+pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
 arch="all"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rosidl_default_runtime
     uri: https://github.com/ros2-gbp/rosidl_defaults-release.git
-    version: release/jazzy/rosidl_default_runtime/1.6.0-3
+    version: release/jazzy/rosidl_default_runtime/1.6.1-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-rosidl-generator-c/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-rosidl-generator-c/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rosidl-generator-c
 _pkgname=rosidl_generator_c
-pkgver=4.6.7
+pkgver=4.6.9
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rosidl_generator_c
     uri: https://github.com/ros2-gbp/rosidl-release.git
-    version: release/jazzy/rosidl_generator_c/4.6.7-1
+    version: release/jazzy/rosidl_generator_c/4.6.9-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-rosidl-generator-cpp/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-rosidl-generator-cpp/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rosidl-generator-cpp
 _pkgname=rosidl_generator_cpp
-pkgver=4.6.7
+pkgver=4.6.9
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rosidl_generator_cpp
     uri: https://github.com/ros2-gbp/rosidl-release.git
-    version: release/jazzy/rosidl_generator_cpp/4.6.7-1
+    version: release/jazzy/rosidl_generator_cpp/4.6.9-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-rosidl-generator-rs/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-rosidl-generator-rs/APKBUILD
@@ -1,15 +1,15 @@
-pkgname=ros-jazzy-nav2-waypoint-follower
-_pkgname=nav2_waypoint_follower
-pkgver=1.3.12
+pkgname=ros-jazzy-rosidl-generator-rs
+_pkgname=rosidl_generator_rs
+pkgver=0.4.12
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
 arch="all"
-license="Apache-2.0"
+license="Apache License 2.0"
 
-depends="ros-jazzy-cv-bridge ros-jazzy-geographic-msgs ros-jazzy-image-transport ros-jazzy-nav-msgs ros-jazzy-nav2-common ros-jazzy-nav2-core ros-jazzy-nav2-msgs ros-jazzy-nav2-util ros-jazzy-pluginlib ros-jazzy-rclcpp ros-jazzy-rclcpp-action ros-jazzy-rclcpp-lifecycle ros-jazzy-robot-localization ros-jazzy-ros-workspace ros-jazzy-tf2-ros"
-makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-jazzy-ament-cmake ros-jazzy-ament-cmake-dev ros-jazzy-ament-cmake-gtest ros-jazzy-ament-cmake-gtest-dev ros-jazzy-ament-cmake-pytest ros-jazzy-ament-cmake-pytest-dev ros-jazzy-ament-lint-auto ros-jazzy-ament-lint-auto-dev ros-jazzy-ament-lint-common ros-jazzy-ament-lint-common-dev ros-jazzy-cv-bridge ros-jazzy-cv-bridge-dev ros-jazzy-geographic-msgs ros-jazzy-geographic-msgs-dev ros-jazzy-image-transport ros-jazzy-image-transport-dev ros-jazzy-nav-msgs ros-jazzy-nav-msgs-dev ros-jazzy-nav2-common ros-jazzy-nav2-common-dev ros-jazzy-nav2-core ros-jazzy-nav2-core-dev ros-jazzy-nav2-msgs ros-jazzy-nav2-msgs-dev ros-jazzy-nav2-util ros-jazzy-nav2-util-dev ros-jazzy-pluginlib ros-jazzy-pluginlib-dev ros-jazzy-rclcpp ros-jazzy-rclcpp-action ros-jazzy-rclcpp-action-dev ros-jazzy-rclcpp-dev ros-jazzy-rclcpp-lifecycle ros-jazzy-rclcpp-lifecycle-dev ros-jazzy-robot-localization ros-jazzy-robot-localization-dev ros-jazzy-ros-workspace-dev ros-jazzy-tf2-ros ros-jazzy-tf2-ros-dev"
-depends_dev="ros-jazzy-cv-bridge ros-jazzy-cv-bridge-dev ros-jazzy-geographic-msgs ros-jazzy-geographic-msgs-dev ros-jazzy-image-transport ros-jazzy-image-transport-dev ros-jazzy-nav-msgs ros-jazzy-nav-msgs-dev ros-jazzy-nav2-common ros-jazzy-nav2-common-dev ros-jazzy-nav2-core ros-jazzy-nav2-core-dev ros-jazzy-nav2-msgs ros-jazzy-nav2-msgs-dev ros-jazzy-nav2-util ros-jazzy-nav2-util-dev ros-jazzy-pluginlib ros-jazzy-pluginlib-dev ros-jazzy-rclcpp ros-jazzy-rclcpp-action ros-jazzy-rclcpp-action-dev ros-jazzy-rclcpp-dev ros-jazzy-rclcpp-lifecycle ros-jazzy-rclcpp-lifecycle-dev ros-jazzy-robot-localization ros-jazzy-robot-localization-dev ros-jazzy-ros-workspace-dev ros-jazzy-tf2-ros ros-jazzy-tf2-ros-dev"
+depends="ros-jazzy-ros-workspace ros-jazzy-rosidl-generator-c ros-jazzy-rosidl-parser"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-jazzy-ament-cmake ros-jazzy-ament-cmake-dev ros-jazzy-ament-cmake-gtest ros-jazzy-ament-cmake-gtest-dev ros-jazzy-ament-lint-auto ros-jazzy-ament-lint-auto-dev ros-jazzy-ament-lint-common ros-jazzy-ament-lint-common-dev ros-jazzy-ros-environment ros-jazzy-ros-environment-dev ros-jazzy-ros-workspace-dev ros-jazzy-rosidl-generator-c ros-jazzy-rosidl-generator-c-dev ros-jazzy-rosidl-parser-dev ros-jazzy-rosidl-pycommon ros-jazzy-rosidl-pycommon-dev ros-jazzy-rosidl-typesupport-c ros-jazzy-rosidl-typesupport-c-dev ros-jazzy-rosidl-typesupport-interface ros-jazzy-rosidl-typesupport-interface-dev"
+depends_dev="ros-jazzy-ament-cmake ros-jazzy-ament-cmake-dev ros-jazzy-ros-environment ros-jazzy-ros-environment-dev ros-jazzy-ros-workspace-dev ros-jazzy-rosidl-generator-c ros-jazzy-rosidl-generator-c-dev ros-jazzy-rosidl-parser-dev ros-jazzy-rosidl-pycommon ros-jazzy-rosidl-pycommon-dev ros-jazzy-rosidl-typesupport-c ros-jazzy-rosidl-typesupport-c-dev ros-jazzy-rosidl-typesupport-interface ros-jazzy-rosidl-typesupport-interface-dev"
 
 subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
@@ -32,9 +32,9 @@ if [ ! -f /usr/ros/jazzy/setup.sh ]; then
   export AMENT_PREFIX_PATH=/usr/ros/jazzy
 fi
 rosinstall="- git:
-    local-name: nav2_waypoint_follower
-    uri: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/nav2_waypoint_follower/1.3.12-1
+    local-name: rosidl_generator_rs
+    uri: https://github.com/ros2-gbp/rosidl_rust-release.git
+    version: release/jazzy/rosidl_generator_rs/0.4.12-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-rosidl-generator-type-description/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-rosidl-generator-type-description/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rosidl-generator-type-description
 _pkgname=rosidl_generator_type_description
-pkgver=4.6.7
+pkgver=4.6.9
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rosidl_generator_type_description
     uri: https://github.com/ros2-gbp/rosidl-release.git
-    version: release/jazzy/rosidl_generator_type_description/4.6.7-1
+    version: release/jazzy/rosidl_generator_type_description/4.6.9-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-rosidl-parser/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-rosidl-parser/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rosidl-parser
 _pkgname=rosidl_parser
-pkgver=4.6.7
+pkgver=4.6.9
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rosidl_parser
     uri: https://github.com/ros2-gbp/rosidl-release.git
-    version: release/jazzy/rosidl_parser/4.6.7-1
+    version: release/jazzy/rosidl_parser/4.6.9-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-rosidl-pycommon/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-rosidl-pycommon/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rosidl-pycommon
 _pkgname=rosidl_pycommon
-pkgver=4.6.7
+pkgver=4.6.9
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rosidl_pycommon
     uri: https://github.com/ros2-gbp/rosidl-release.git
-    version: release/jazzy/rosidl_pycommon/4.6.7-1
+    version: release/jazzy/rosidl_pycommon/4.6.9-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-rosidl-runtime-c/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-rosidl-runtime-c/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rosidl-runtime-c
 _pkgname=rosidl_runtime_c
-pkgver=4.6.7
+pkgver=4.6.9
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rosidl_runtime_c
     uri: https://github.com/ros2-gbp/rosidl-release.git
-    version: release/jazzy/rosidl_runtime_c/4.6.7-1
+    version: release/jazzy/rosidl_runtime_c/4.6.9-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-rosidl-runtime-cpp/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-rosidl-runtime-cpp/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rosidl-runtime-cpp
 _pkgname=rosidl_runtime_cpp
-pkgver=4.6.7
+pkgver=4.6.9
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rosidl_runtime_cpp
     uri: https://github.com/ros2-gbp/rosidl-release.git
-    version: release/jazzy/rosidl_runtime_cpp/4.6.7-1
+    version: release/jazzy/rosidl_runtime_cpp/4.6.9-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-rosidl-runtime-py/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-rosidl-runtime-py/APKBUILD
@@ -1,7 +1,7 @@
 pkgname=ros-jazzy-rosidl-runtime-py
 _pkgname=rosidl_runtime_py
-pkgver=0.13.1
-pkgrel=1
+pkgver=0.13.2
+pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
 arch="all"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rosidl_runtime_py
     uri: https://github.com/ros2-gbp/rosidl_runtime_py-release.git
-    version: release/jazzy/rosidl_runtime_py/0.13.1-2
+    version: release/jazzy/rosidl_runtime_py/0.13.2-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-rosidl-typesupport-c/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-rosidl-typesupport-c/APKBUILD
@@ -1,7 +1,7 @@
 pkgname=ros-jazzy-rosidl-typesupport-c
 _pkgname=rosidl_typesupport_c
-pkgver=3.2.2
-pkgrel=1
+pkgver=3.2.3
+pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
 arch="all"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rosidl_typesupport_c
     uri: https://github.com/ros2-gbp/rosidl_typesupport-release.git
-    version: release/jazzy/rosidl_typesupport_c/3.2.2-1
+    version: release/jazzy/rosidl_typesupport_c/3.2.3-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-rosidl-typesupport-cpp/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-rosidl-typesupport-cpp/APKBUILD
@@ -1,7 +1,7 @@
 pkgname=ros-jazzy-rosidl-typesupport-cpp
 _pkgname=rosidl_typesupport_cpp
-pkgver=3.2.2
-pkgrel=1
+pkgver=3.2.3
+pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
 arch="all"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rosidl_typesupport_cpp
     uri: https://github.com/ros2-gbp/rosidl_typesupport-release.git
-    version: release/jazzy/rosidl_typesupport_cpp/3.2.2-1
+    version: release/jazzy/rosidl_typesupport_cpp/3.2.3-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-rosidl-typesupport-fastrtps-c/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-rosidl-typesupport-fastrtps-c/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rosidl-typesupport-fastrtps-c
 _pkgname=rosidl_typesupport_fastrtps_c
-pkgver=3.6.3
+pkgver=3.6.4
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rosidl_typesupport_fastrtps_c
     uri: https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release.git
-    version: release/jazzy/rosidl_typesupport_fastrtps_c/3.6.3-1
+    version: release/jazzy/rosidl_typesupport_fastrtps_c/3.6.4-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-rosidl-typesupport-fastrtps-cpp/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-rosidl-typesupport-fastrtps-cpp/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rosidl-typesupport-fastrtps-cpp
 _pkgname=rosidl_typesupport_fastrtps_cpp
-pkgver=3.6.3
+pkgver=3.6.4
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rosidl_typesupport_fastrtps_cpp
     uri: https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release.git
-    version: release/jazzy/rosidl_typesupport_fastrtps_cpp/3.6.3-1
+    version: release/jazzy/rosidl_typesupport_fastrtps_cpp/3.6.4-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-rosidl-typesupport-interface/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-rosidl-typesupport-interface/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rosidl-typesupport-interface
 _pkgname=rosidl_typesupport_interface
-pkgver=4.6.7
+pkgver=4.6.9
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rosidl_typesupport_interface
     uri: https://github.com/ros2-gbp/rosidl-release.git
-    version: release/jazzy/rosidl_typesupport_interface/4.6.7-1
+    version: release/jazzy/rosidl_typesupport_interface/4.6.9-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-rosidl-typesupport-introspection-c/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-rosidl-typesupport-introspection-c/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rosidl-typesupport-introspection-c
 _pkgname=rosidl_typesupport_introspection_c
-pkgver=4.6.7
+pkgver=4.6.9
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rosidl_typesupport_introspection_c
     uri: https://github.com/ros2-gbp/rosidl-release.git
-    version: release/jazzy/rosidl_typesupport_introspection_c/4.6.7-1
+    version: release/jazzy/rosidl_typesupport_introspection_c/4.6.9-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-rosidl-typesupport-introspection-cpp/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-rosidl-typesupport-introspection-cpp/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rosidl-typesupport-introspection-cpp
 _pkgname=rosidl_typesupport_introspection_cpp
-pkgver=4.6.7
+pkgver=4.6.9
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rosidl_typesupport_introspection_cpp
     uri: https://github.com/ros2-gbp/rosidl-release.git
-    version: release/jazzy/rosidl_typesupport_introspection_cpp/4.6.7-1
+    version: release/jazzy/rosidl_typesupport_introspection_cpp/4.6.9-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-rqt-gui-cpp/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-rqt-gui-cpp/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rqt-gui-cpp
 _pkgname=rqt_gui_cpp
-pkgver=1.6.3
+pkgver=1.6.4
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="http://ros.org/wiki/rqt_gui_cpp"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rqt_gui_cpp
     uri: https://github.com/ros2-gbp/rqt-release.git
-    version: release/jazzy/rqt_gui_cpp/1.6.3-1
+    version: release/jazzy/rqt_gui_cpp/1.6.4-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-rqt-gui-py/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-rqt-gui-py/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rqt-gui-py
 _pkgname=rqt_gui_py
-pkgver=1.6.3
+pkgver=1.6.4
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="http://ros.org/wiki/rqt_gui_py"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rqt_gui_py
     uri: https://github.com/ros2-gbp/rqt-release.git
-    version: release/jazzy/rqt_gui_py/1.6.3-1
+    version: release/jazzy/rqt_gui_py/1.6.4-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-rqt-gui/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-rqt-gui/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rqt-gui
 _pkgname=rqt_gui
-pkgver=1.6.3
+pkgver=1.6.4
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="http://ros.org/wiki/rqt_gui"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rqt_gui
     uri: https://github.com/ros2-gbp/rqt-release.git
-    version: release/jazzy/rqt_gui/1.6.3-1
+    version: release/jazzy/rqt_gui/1.6.4-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-rqt-msg/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-rqt-msg/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rqt-msg
 _pkgname=rqt_msg
-pkgver=1.5.2
+pkgver=1.5.3
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="http://wiki.ros.org/rqt_msg"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rqt_msg
     uri: https://github.com/ros2-gbp/rqt_msg-release.git
-    version: release/jazzy/rqt_msg/1.5.2-1
+    version: release/jazzy/rqt_msg/1.5.3-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-rqt-py-common/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-rqt-py-common/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rqt-py-common
 _pkgname=rqt_py_common
-pkgver=1.6.3
+pkgver=1.6.4
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="http://ros.org/wiki/rqt_py_common"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rqt_py_common
     uri: https://github.com/ros2-gbp/rqt-release.git
-    version: release/jazzy/rqt_py_common/1.6.3-1
+    version: release/jazzy/rqt_py_common/1.6.4-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-rqt-reconfigure/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-rqt-reconfigure/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rqt-reconfigure
 _pkgname=rqt_reconfigure
-pkgver=1.6.3
+pkgver=1.6.4
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="http://wiki.ros.org/rqt_reconfigure"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rqt_reconfigure
     uri: https://github.com/ros2-gbp/rqt_reconfigure-release.git
-    version: release/jazzy/rqt_reconfigure/1.6.3-1
+    version: release/jazzy/rqt_reconfigure/1.6.4-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-rviz-assimp-vendor/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-rviz-assimp-vendor/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rviz-assimp-vendor
 _pkgname=rviz_assimp_vendor
-pkgver=14.1.19
+pkgver=14.1.23
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="http://assimp.sourceforge.net/index.html"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rviz_assimp_vendor
     uri: https://github.com/ros2-gbp/rviz-release.git
-    version: release/jazzy/rviz_assimp_vendor/14.1.19-1
+    version: release/jazzy/rviz_assimp_vendor/14.1.23-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-rviz-common/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-rviz-common/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rviz-common
 _pkgname=rviz_common
-pkgver=14.1.19
+pkgver=14.1.23
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://github.com/ros2/rviz/blob/ros2/README.md"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rviz_common
     uri: https://github.com/ros2-gbp/rviz-release.git
-    version: release/jazzy/rviz_common/14.1.19-1
+    version: release/jazzy/rviz_common/14.1.23-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-rviz-default-plugins/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-rviz-default-plugins/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rviz-default-plugins
 _pkgname=rviz_default_plugins
-pkgver=14.1.19
+pkgver=14.1.23
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://github.com/ros2/rviz/blob/ros2/README.md"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rviz_default_plugins
     uri: https://github.com/ros2-gbp/rviz-release.git
-    version: release/jazzy/rviz_default_plugins/14.1.19-1
+    version: release/jazzy/rviz_default_plugins/14.1.23-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-rviz-ogre-vendor/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-rviz-ogre-vendor/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rviz-ogre-vendor
 _pkgname=rviz_ogre_vendor
-pkgver=14.1.19
+pkgver=14.1.23
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://www.ogre3d.org/"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rviz_ogre_vendor
     uri: https://github.com/ros2-gbp/rviz-release.git
-    version: release/jazzy/rviz_ogre_vendor/14.1.19-1
+    version: release/jazzy/rviz_ogre_vendor/14.1.23-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-rviz-rendering-tests/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-rviz-rendering-tests/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rviz-rendering-tests
 _pkgname=rviz_rendering_tests
-pkgver=14.1.19
+pkgver=14.1.23
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://github.com/ros2/rviz"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rviz_rendering_tests
     uri: https://github.com/ros2-gbp/rviz-release.git
-    version: release/jazzy/rviz_rendering_tests/14.1.19-1
+    version: release/jazzy/rviz_rendering_tests/14.1.23-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-rviz-rendering/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-rviz-rendering/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rviz-rendering
 _pkgname=rviz_rendering
-pkgver=14.1.19
+pkgver=14.1.23
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://github.com/ros2/rviz/blob/ros2/README.md"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rviz_rendering
     uri: https://github.com/ros2-gbp/rviz-release.git
-    version: release/jazzy/rviz_rendering/14.1.19-1
+    version: release/jazzy/rviz_rendering/14.1.23-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-rviz-visual-testing-framework/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-rviz-visual-testing-framework/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rviz-visual-testing-framework
 _pkgname=rviz_visual_testing_framework
-pkgver=14.1.19
+pkgver=14.1.23
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="http://ros.org/wiki/rviz2"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rviz_visual_testing_framework
     uri: https://github.com/ros2-gbp/rviz-release.git
-    version: release/jazzy/rviz_visual_testing_framework/14.1.19-1
+    version: release/jazzy/rviz_visual_testing_framework/14.1.23-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-rviz2/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-rviz2/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rviz2
 _pkgname=rviz2
-pkgver=14.1.19
+pkgver=14.1.23
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://github.com/ros2/rviz/blob/ros2/README.md"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rviz2
     uri: https://github.com/ros2-gbp/rviz-release.git
-    version: release/jazzy/rviz2/14.1.19-1
+    version: release/jazzy/rviz2/14.1.23-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-sensor-msgs-py/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-sensor-msgs-py/APKBUILD
@@ -1,7 +1,7 @@
 pkgname=ros-jazzy-sensor-msgs-py
 _pkgname=sensor_msgs_py
-pkgver=5.3.6
-pkgrel=1
+pkgver=5.3.8
+pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
 arch="all"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: sensor_msgs_py
     uri: https://github.com/ros2-gbp/common_interfaces-release.git
-    version: release/jazzy/sensor_msgs_py/5.3.6-1
+    version: release/jazzy/sensor_msgs_py/5.3.8-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-sensor-msgs/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-sensor-msgs/APKBUILD
@@ -1,7 +1,7 @@
 pkgname=ros-jazzy-sensor-msgs
 _pkgname=sensor_msgs
-pkgver=5.3.6
-pkgrel=1
+pkgver=5.3.8
+pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
 arch="all"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: sensor_msgs
     uri: https://github.com/ros2-gbp/common_interfaces-release.git
-    version: release/jazzy/sensor_msgs/5.3.6-1
+    version: release/jazzy/sensor_msgs/5.3.8-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-service-msgs/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-service-msgs/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-service-msgs
 _pkgname=service_msgs
-pkgver=2.0.3
+pkgver=2.0.4
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: service_msgs
     uri: https://github.com/ros2-gbp/rcl_interfaces-release.git
-    version: release/jazzy/service_msgs/2.0.3-1
+    version: release/jazzy/service_msgs/2.0.4-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-shape-msgs/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-shape-msgs/APKBUILD
@@ -1,7 +1,7 @@
 pkgname=ros-jazzy-shape-msgs
 _pkgname=shape_msgs
-pkgver=5.3.6
-pkgrel=1
+pkgver=5.3.8
+pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
 arch="all"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: shape_msgs
     uri: https://github.com/ros2-gbp/common_interfaces-release.git
-    version: release/jazzy/shape_msgs/5.3.6-1
+    version: release/jazzy/shape_msgs/5.3.8-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-smclib/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-smclib/APKBUILD
@@ -1,7 +1,7 @@
 pkgname=ros-jazzy-smclib
 _pkgname=smclib
-pkgver=4.1.2
-pkgrel=1
+pkgver=4.2.0
+pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="http://smc.sourceforge.net/"
 arch="all"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: smclib
     uri: https://github.com/ros2-gbp/bond_core-release.git
-    version: release/jazzy/smclib/4.1.2-1
+    version: release/jazzy/smclib/4.2.0-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-spdlog-vendor/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-spdlog-vendor/APKBUILD
@@ -1,7 +1,7 @@
 pkgname=ros-jazzy-spdlog-vendor
 _pkgname=spdlog_vendor
-pkgver=1.6.1
-pkgrel=1
+pkgver=1.6.2
+pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://github.com/gabime/spdlog"
 arch="all"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: spdlog_vendor
     uri: https://github.com/ros2-gbp/spdlog_vendor-release.git
-    version: release/jazzy/spdlog_vendor/1.6.1-1
+    version: release/jazzy/spdlog_vendor/1.6.2-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-sqlite3-vendor/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-sqlite3-vendor/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-sqlite3-vendor
 _pkgname=sqlite3_vendor
-pkgver=0.26.9
+pkgver=0.26.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: sqlite3_vendor
     uri: https://github.com/ros2-gbp/rosbag2-release.git
-    version: release/jazzy/sqlite3_vendor/0.26.9-1
+    version: release/jazzy/sqlite3_vendor/0.26.11-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-sros2-cmake/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-sros2-cmake/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-sros2-cmake
 _pkgname=sros2_cmake
-pkgver=0.13.5
+pkgver=0.13.6
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: sros2_cmake
     uri: https://github.com/ros2-gbp/sros2-release.git
-    version: release/jazzy/sros2_cmake/0.13.5-1
+    version: release/jazzy/sros2_cmake/0.13.6-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-sros2/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-sros2/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-sros2
 _pkgname=sros2
-pkgver=0.13.5
+pkgver=0.13.6
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -8,7 +8,7 @@ arch="all"
 license="Apache License 2.0"
 
 depends="py3-argcomplete py3-cryptography py3-importlib-resources py3-lxml ros-jazzy-ament-index-python ros-jazzy-rclpy ros-jazzy-ros-workspace ros-jazzy-ros2cli"
-makedepends="chrpath py3-pytest7 py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-jazzy-ament-copyright ros-jazzy-ament-copyright-dev ros-jazzy-ament-flake8 ros-jazzy-ament-flake8-dev ros-jazzy-ament-index-python-dev ros-jazzy-ament-mypy ros-jazzy-ament-mypy-dev ros-jazzy-ament-pep257 ros-jazzy-ament-pep257-dev ros-jazzy-rclpy-dev ros-jazzy-ros-testing ros-jazzy-ros-testing-dev ros-jazzy-ros-workspace-dev ros-jazzy-ros2cli-dev ros-jazzy-test-msgs ros-jazzy-test-msgs-dev"
+makedepends="chrpath py3-pytest-timeout py3-pytest7 py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-jazzy-ament-copyright ros-jazzy-ament-copyright-dev ros-jazzy-ament-flake8 ros-jazzy-ament-flake8-dev ros-jazzy-ament-index-python-dev ros-jazzy-ament-mypy ros-jazzy-ament-mypy-dev ros-jazzy-ament-pep257 ros-jazzy-ament-pep257-dev ros-jazzy-rclpy-dev ros-jazzy-ros-testing ros-jazzy-ros-testing-dev ros-jazzy-ros-workspace-dev ros-jazzy-ros2cli-dev ros-jazzy-test-msgs ros-jazzy-test-msgs-dev"
 depends_dev="ros-jazzy-ament-index-python-dev ros-jazzy-rclpy-dev ros-jazzy-ros-workspace-dev ros-jazzy-ros2cli-dev"
 
 subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: sros2
     uri: https://github.com/ros2-gbp/sros2-release.git
-    version: release/jazzy/sros2/0.13.5-1
+    version: release/jazzy/sros2/0.13.6-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-statistics-msgs/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-statistics-msgs/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-statistics-msgs
 _pkgname=statistics_msgs
-pkgver=2.0.3
+pkgver=2.0.4
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: statistics_msgs
     uri: https://github.com/ros2-gbp/rcl_interfaces-release.git
-    version: release/jazzy/statistics_msgs/2.0.3-1
+    version: release/jazzy/statistics_msgs/2.0.4-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-std-msgs/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-std-msgs/APKBUILD
@@ -1,7 +1,7 @@
 pkgname=ros-jazzy-std-msgs
 _pkgname=std_msgs
-pkgver=5.3.6
-pkgrel=1
+pkgver=5.3.8
+pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
 arch="all"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: std_msgs
     uri: https://github.com/ros2-gbp/common_interfaces-release.git
-    version: release/jazzy/std_msgs/5.3.6-1
+    version: release/jazzy/std_msgs/5.3.8-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-std-srvs/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-std-srvs/APKBUILD
@@ -1,7 +1,7 @@
 pkgname=ros-jazzy-std-srvs
 _pkgname=std_srvs
-pkgver=5.3.6
-pkgrel=1
+pkgver=5.3.8
+pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
 arch="all"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: std_srvs
     uri: https://github.com/ros2-gbp/common_interfaces-release.git
-    version: release/jazzy/std_srvs/5.3.6-1
+    version: release/jazzy/std_srvs/5.3.8-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-stereo-image-proc/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-stereo-image-proc/APKBUILD
@@ -1,9 +1,9 @@
 pkgname=ros-jazzy-stereo-image-proc
 _pkgname=stereo_image_proc
-pkgver=5.0.11
-pkgrel=1
+pkgver=5.0.13
+pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
-url="https://index.ros.org/p/stereo_image_proc/github-ros-perception-image_pipeline/"
+url="https://index.ros.org/p/stereo_image_proc/"
 arch="all"
 license="BSD"
 
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: stereo_image_proc
     uri: https://github.com/ros2-gbp/image_pipeline-release.git
-    version: release/jazzy/stereo_image_proc/5.0.11-1
+    version: release/jazzy/stereo_image_proc/5.0.13-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-stereo-msgs/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-stereo-msgs/APKBUILD
@@ -1,7 +1,7 @@
 pkgname=ros-jazzy-stereo-msgs
 _pkgname=stereo_msgs
-pkgver=5.3.6
-pkgrel=1
+pkgver=5.3.8
+pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
 arch="all"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: stereo_msgs
     uri: https://github.com/ros2-gbp/common_interfaces-release.git
-    version: release/jazzy/stereo_msgs/5.3.6-1
+    version: release/jazzy/stereo_msgs/5.3.8-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-test-interface-files/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-test-interface-files/APKBUILD
@@ -1,7 +1,7 @@
 pkgname=ros-jazzy-test-interface-files
 _pkgname=test_interface_files
-pkgver=0.11.0
-pkgrel=1
+pkgver=0.11.1
+pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
 arch="all"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: test_interface_files
     uri: https://github.com/ros2-gbp/test_interface_files-release.git
-    version: release/jazzy/test_interface_files/0.11.0-3
+    version: release/jazzy/test_interface_files/0.11.1-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-test-msgs/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-test-msgs/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-test-msgs
 _pkgname=test_msgs
-pkgver=2.0.3
+pkgver=2.0.4
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: test_msgs
     uri: https://github.com/ros2-gbp/rcl_interfaces-release.git
-    version: release/jazzy/test_msgs/2.0.3-1
+    version: release/jazzy/test_msgs/2.0.4-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-tf2-bullet/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-tf2-bullet/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-tf2-bullet
 _pkgname=tf2_bullet
-pkgver=0.36.19
+pkgver=0.36.22
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="http://www.ros.org/wiki/tf2_bullet"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: tf2_bullet
     uri: https://github.com/ros2-gbp/geometry2-release.git
-    version: release/jazzy/tf2_bullet/0.36.19-1
+    version: release/jazzy/tf2_bullet/0.36.22-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-tf2-eigen-kdl/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-tf2-eigen-kdl/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-tf2-eigen-kdl
 _pkgname=tf2_eigen_kdl
-pkgver=0.36.19
+pkgver=0.36.22
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: tf2_eigen_kdl
     uri: https://github.com/ros2-gbp/geometry2-release.git
-    version: release/jazzy/tf2_eigen_kdl/0.36.19-1
+    version: release/jazzy/tf2_eigen_kdl/0.36.22-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-tf2-eigen/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-tf2-eigen/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-tf2-eigen
 _pkgname=tf2_eigen
-pkgver=0.36.19
+pkgver=0.36.22
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: tf2_eigen
     uri: https://github.com/ros2-gbp/geometry2-release.git
-    version: release/jazzy/tf2_eigen/0.36.19-1
+    version: release/jazzy/tf2_eigen/0.36.22-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-tf2-geometry-msgs/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-tf2-geometry-msgs/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-tf2-geometry-msgs
 _pkgname=tf2_geometry_msgs
-pkgver=0.36.19
+pkgver=0.36.22
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="http://www.ros.org/wiki/tf2_ros"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: tf2_geometry_msgs
     uri: https://github.com/ros2-gbp/geometry2-release.git
-    version: release/jazzy/tf2_geometry_msgs/0.36.19-1
+    version: release/jazzy/tf2_geometry_msgs/0.36.22-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-tf2-kdl/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-tf2-kdl/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-tf2-kdl
 _pkgname=tf2_kdl
-pkgver=0.36.19
+pkgver=0.36.22
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="http://ros.org/wiki/tf2"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: tf2_kdl
     uri: https://github.com/ros2-gbp/geometry2-release.git
-    version: release/jazzy/tf2_kdl/0.36.19-1
+    version: release/jazzy/tf2_kdl/0.36.22-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-tf2-msgs/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-tf2-msgs/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-tf2-msgs
 _pkgname=tf2_msgs
-pkgver=0.36.19
+pkgver=0.36.22
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="http://www.ros.org/wiki/tf2_msgs"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: tf2_msgs
     uri: https://github.com/ros2-gbp/geometry2-release.git
-    version: release/jazzy/tf2_msgs/0.36.19-1
+    version: release/jazzy/tf2_msgs/0.36.22-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-tf2-py/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-tf2-py/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-tf2-py
 _pkgname=tf2_py
-pkgver=0.36.19
+pkgver=0.36.22
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="http://ros.org/wiki/tf2_py"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: tf2_py
     uri: https://github.com/ros2-gbp/geometry2-release.git
-    version: release/jazzy/tf2_py/0.36.19-1
+    version: release/jazzy/tf2_py/0.36.22-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-tf2-ros-py/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-tf2-ros-py/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-tf2-ros-py
 _pkgname=tf2_ros_py
-pkgver=0.36.19
+pkgver=0.36.22
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="http://www.ros.org/wiki/tf2_ros"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: tf2_ros_py
     uri: https://github.com/ros2-gbp/geometry2-release.git
-    version: release/jazzy/tf2_ros_py/0.36.19-1
+    version: release/jazzy/tf2_ros_py/0.36.22-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-tf2-ros/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-tf2-ros/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-tf2-ros
 _pkgname=tf2_ros
-pkgver=0.36.19
+pkgver=0.36.22
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="http://www.ros.org/wiki/tf2_ros"
@@ -8,7 +8,7 @@ arch="all"
 license="BSD"
 
 depends="ros-jazzy-builtin-interfaces ros-jazzy-geometry-msgs ros-jazzy-message-filters ros-jazzy-rcl-interfaces ros-jazzy-rclcpp ros-jazzy-rclcpp-action ros-jazzy-rclcpp-components ros-jazzy-ros-workspace ros-jazzy-tf2 ros-jazzy-tf2-msgs"
-makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-jazzy-ament-cmake ros-jazzy-ament-cmake-dev ros-jazzy-ament-cmake-gtest ros-jazzy-ament-cmake-gtest-dev ros-jazzy-ament-lint-auto ros-jazzy-ament-lint-auto-dev ros-jazzy-ament-lint-common ros-jazzy-ament-lint-common-dev ros-jazzy-builtin-interfaces ros-jazzy-builtin-interfaces-dev ros-jazzy-geometry-msgs ros-jazzy-geometry-msgs-dev ros-jazzy-message-filters ros-jazzy-message-filters-dev ros-jazzy-rcl-interfaces ros-jazzy-rcl-interfaces-dev ros-jazzy-rclcpp ros-jazzy-rclcpp-action ros-jazzy-rclcpp-action-dev ros-jazzy-rclcpp-components ros-jazzy-rclcpp-components-dev ros-jazzy-rclcpp-dev ros-jazzy-ros-workspace-dev ros-jazzy-rosgraph-msgs ros-jazzy-rosgraph-msgs-dev ros-jazzy-tf2 ros-jazzy-tf2-dev ros-jazzy-tf2-msgs ros-jazzy-tf2-msgs-dev"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-jazzy-ament-cmake ros-jazzy-ament-cmake-dev ros-jazzy-ament-cmake-gen-version-h ros-jazzy-ament-cmake-gen-version-h-dev ros-jazzy-ament-cmake-gtest ros-jazzy-ament-cmake-gtest-dev ros-jazzy-ament-lint-auto ros-jazzy-ament-lint-auto-dev ros-jazzy-ament-lint-common ros-jazzy-ament-lint-common-dev ros-jazzy-builtin-interfaces ros-jazzy-builtin-interfaces-dev ros-jazzy-geometry-msgs ros-jazzy-geometry-msgs-dev ros-jazzy-message-filters ros-jazzy-message-filters-dev ros-jazzy-rcl-interfaces ros-jazzy-rcl-interfaces-dev ros-jazzy-rclcpp ros-jazzy-rclcpp-action ros-jazzy-rclcpp-action-dev ros-jazzy-rclcpp-components ros-jazzy-rclcpp-components-dev ros-jazzy-rclcpp-dev ros-jazzy-ros-workspace-dev ros-jazzy-rosgraph-msgs ros-jazzy-rosgraph-msgs-dev ros-jazzy-tf2 ros-jazzy-tf2-dev ros-jazzy-tf2-msgs ros-jazzy-tf2-msgs-dev"
 depends_dev="ros-jazzy-builtin-interfaces ros-jazzy-builtin-interfaces-dev ros-jazzy-geometry-msgs ros-jazzy-geometry-msgs-dev ros-jazzy-message-filters ros-jazzy-message-filters-dev ros-jazzy-rcl-interfaces ros-jazzy-rcl-interfaces-dev ros-jazzy-rclcpp ros-jazzy-rclcpp-action ros-jazzy-rclcpp-action-dev ros-jazzy-rclcpp-components ros-jazzy-rclcpp-components-dev ros-jazzy-rclcpp-dev ros-jazzy-ros-workspace-dev ros-jazzy-tf2 ros-jazzy-tf2-dev ros-jazzy-tf2-msgs ros-jazzy-tf2-msgs-dev"
 
 subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: tf2_ros
     uri: https://github.com/ros2-gbp/geometry2-release.git
-    version: release/jazzy/tf2_ros/0.36.19-1
+    version: release/jazzy/tf2_ros/0.36.22-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-tf2-sensor-msgs/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-tf2-sensor-msgs/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-tf2-sensor-msgs
 _pkgname=tf2_sensor_msgs
-pkgver=0.36.19
+pkgver=0.36.22
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="http://www.ros.org/wiki/tf2_ros"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: tf2_sensor_msgs
     uri: https://github.com/ros2-gbp/geometry2-release.git
-    version: release/jazzy/tf2_sensor_msgs/0.36.19-1
+    version: release/jazzy/tf2_sensor_msgs/0.36.22-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-tf2-tools/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-tf2-tools/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-tf2-tools
 _pkgname=tf2_tools
-pkgver=0.36.19
+pkgver=0.36.22
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="http://www.ros.org/wiki/tf2_tools"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: tf2_tools
     uri: https://github.com/ros2-gbp/geometry2-release.git
-    version: release/jazzy/tf2_tools/0.36.19-1
+    version: release/jazzy/tf2_tools/0.36.22-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-tf2/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-tf2/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-tf2
 _pkgname=tf2
-pkgver=0.36.19
+pkgver=0.36.22
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="http://www.ros.org/wiki/tf2"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: tf2
     uri: https://github.com/ros2-gbp/geometry2-release.git
-    version: release/jazzy/tf2/0.36.19-1
+    version: release/jazzy/tf2/0.36.22-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-theora-image-transport/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-theora-image-transport/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-theora-image-transport
 _pkgname=theora_image_transport
-pkgver=4.0.6
+pkgver=4.0.7
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="http://www.ros.org/wiki/image_transport_plugins"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: theora_image_transport
     uri: https://github.com/ros2-gbp/image_transport_plugins-release.git
-    version: release/jazzy/theora_image_transport/4.0.6-1
+    version: release/jazzy/theora_image_transport/4.0.7-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-tlsf/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-tlsf/APKBUILD
@@ -1,7 +1,7 @@
 pkgname=ros-jazzy-tlsf
 _pkgname=tlsf
-pkgver=0.9.0
-pkgrel=1
+pkgver=0.9.1
+pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
 arch="all"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: tlsf
     uri: https://github.com/ros2-gbp/tlsf-release.git
-    version: release/jazzy/tlsf/0.9.0-3
+    version: release/jazzy/tlsf/0.9.1-2
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-topic-monitor/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-topic-monitor/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-topic-monitor
 _pkgname=topic_monitor
-pkgver=0.33.9
+pkgver=0.33.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: topic_monitor
     uri: https://github.com/ros2-gbp/demos-release.git
-    version: release/jazzy/topic_monitor/0.33.9-1
+    version: release/jazzy/topic_monitor/0.33.11-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-tracetools-image-pipeline/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-tracetools-image-pipeline/APKBUILD
@@ -1,7 +1,7 @@
 pkgname=ros-jazzy-tracetools-image-pipeline
 _pkgname=tracetools_image_pipeline
-pkgver=5.0.11
-pkgrel=1
+pkgver=5.0.13
+pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
 arch="all"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: tracetools_image_pipeline
     uri: https://github.com/ros2-gbp/image_pipeline-release.git
-    version: release/jazzy/tracetools_image_pipeline/5.0.11-1
+    version: release/jazzy/tracetools_image_pipeline/5.0.13-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-tracetools/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-tracetools/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-tracetools
 _pkgname=tracetools
-pkgver=8.2.5
+pkgver=8.2.6
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://docs.ros.org/en/rolling/p/tracetools/"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: tracetools
     uri: https://github.com/ros2-gbp/ros2_tracing-release.git
-    version: release/jazzy/tracetools/8.2.5-1
+    version: release/jazzy/tracetools/8.2.6-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-trajectory-msgs/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-trajectory-msgs/APKBUILD
@@ -1,7 +1,7 @@
 pkgname=ros-jazzy-trajectory-msgs
 _pkgname=trajectory_msgs
-pkgver=5.3.6
-pkgrel=1
+pkgver=5.3.8
+pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
 arch="all"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: trajectory_msgs
     uri: https://github.com/ros2-gbp/common_interfaces-release.git
-    version: release/jazzy/trajectory_msgs/5.3.6-1
+    version: release/jazzy/trajectory_msgs/5.3.8-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-turtlesim/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-turtlesim/APKBUILD
@@ -1,7 +1,7 @@
 pkgname=ros-jazzy-turtlesim
 _pkgname=turtlesim
-pkgver=1.8.3
-pkgrel=1
+pkgver=1.8.4
+pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="http://www.ros.org/wiki/turtlesim"
 arch="all"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: turtlesim
     uri: https://github.com/ros2-gbp/ros_tutorials-release.git
-    version: release/jazzy/turtlesim/1.8.3-1
+    version: release/jazzy/turtlesim/1.8.4-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-type-description-interfaces/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-type-description-interfaces/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-type-description-interfaces
 _pkgname=type_description_interfaces
-pkgver=2.0.3
+pkgver=2.0.4
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: type_description_interfaces
     uri: https://github.com/ros2-gbp/rcl_interfaces-release.git
-    version: release/jazzy/type_description_interfaces/2.0.3-1
+    version: release/jazzy/type_description_interfaces/2.0.4-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-unique-identifier-msgs/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-unique-identifier-msgs/APKBUILD
@@ -1,7 +1,7 @@
 pkgname=ros-jazzy-unique-identifier-msgs
 _pkgname=unique_identifier_msgs
-pkgver=2.5.0
-pkgrel=1
+pkgver=2.5.1
+pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="http://ros.org/wiki/unique_identifier_msgs"
 arch="all"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: unique_identifier_msgs
     uri: https://github.com/ros2-gbp/unique_identifier_msgs-release.git
-    version: release/jazzy/unique_identifier_msgs/2.5.0-3
+    version: release/jazzy/unique_identifier_msgs/2.5.1-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-urdf-parser-plugin/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-urdf-parser-plugin/APKBUILD
@@ -1,7 +1,7 @@
 pkgname=ros-jazzy-urdf-parser-plugin
 _pkgname=urdf_parser_plugin
-pkgver=2.10.0
-pkgrel=1
+pkgver=2.10.1
+pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://github.com/ros2/urdf"
 arch="all"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: urdf_parser_plugin
     uri: https://github.com/ros2-gbp/urdf-release.git
-    version: release/jazzy/urdf_parser_plugin/2.10.0-3
+    version: release/jazzy/urdf_parser_plugin/2.10.1-2
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-urdf/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-urdf/APKBUILD
@@ -1,7 +1,7 @@
 pkgname=ros-jazzy-urdf
 _pkgname=urdf
-pkgver=2.10.0
-pkgrel=1
+pkgver=2.10.1
+pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://github.com/ros2/urdf"
 arch="all"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: urdf
     uri: https://github.com/ros2-gbp/urdf-release.git
-    version: release/jazzy/urdf/2.10.0-3
+    version: release/jazzy/urdf/2.10.1-2
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-urdfdom-headers/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-urdfdom-headers/APKBUILD
@@ -1,7 +1,7 @@
 pkgname=ros-jazzy-urdfdom-headers
 _pkgname=urdfdom_headers
-pkgver=1.1.2
-pkgrel=1
+pkgver=1.1.3
+pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="http://ros.org/wiki/urdf"
 arch="all"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: urdfdom_headers
     uri: https://github.com/ros2-gbp/urdfdom_headers-release.git
-    version: release/jazzy/urdfdom_headers/1.1.2-1
+    version: release/jazzy/urdfdom_headers/1.1.3-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-visualization-msgs/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-visualization-msgs/APKBUILD
@@ -1,7 +1,7 @@
 pkgname=ros-jazzy-visualization-msgs
 _pkgname=visualization_msgs
-pkgver=5.3.6
-pkgrel=1
+pkgver=5.3.8
+pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
 arch="all"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: visualization_msgs
     uri: https://github.com/ros2-gbp/common_interfaces-release.git
-    version: release/jazzy/visualization_msgs/5.3.6-1
+    version: release/jazzy/visualization_msgs/5.3.8-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-zstd-image-transport/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-zstd-image-transport/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-zstd-image-transport
 _pkgname=zstd_image_transport
-pkgver=4.0.6
+pkgver=4.0.7
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="http://www.ros.org/wiki/image_transport_plugins"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: zstd_image_transport
     uri: https://github.com/ros2-gbp/image_transport_plugins-release.git
-    version: release/jazzy/zstd_image_transport/4.0.6-1
+    version: release/jazzy/zstd_image_transport/4.0.7-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-zstd-vendor/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-zstd-vendor/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-zstd-vendor
 _pkgname=zstd_vendor
-pkgver=0.26.9
+pkgver=0.26.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://facebook.github.io/zstd/"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: zstd_vendor
     uri: https://github.com/ros2-gbp/rosbag2-release.git
-    version: release/jazzy/zstd_vendor/0.26.9-1
+    version: release/jazzy/zstd_vendor/0.26.11-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-action-msgs/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-action-msgs/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-action-msgs
 _pkgname=action_msgs
-pkgver=2.0.3
+pkgver=2.0.4
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: action_msgs
     uri: https://github.com/ros2-gbp/rcl_interfaces-release.git
-    version: release/jazzy/action_msgs/2.0.3-1
+    version: release/jazzy/action_msgs/2.0.4-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-action-tutorials-cpp/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-action-tutorials-cpp/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-action-tutorials-cpp
 _pkgname=action_tutorials_cpp
-pkgver=0.33.9
+pkgver=0.33.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: action_tutorials_cpp
     uri: https://github.com/ros2-gbp/demos-release.git
-    version: release/jazzy/action_tutorials_cpp/0.33.9-1
+    version: release/jazzy/action_tutorials_cpp/0.33.11-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-action-tutorials-interfaces/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-action-tutorials-interfaces/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-action-tutorials-interfaces
 _pkgname=action_tutorials_interfaces
-pkgver=0.33.9
+pkgver=0.33.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: action_tutorials_interfaces
     uri: https://github.com/ros2-gbp/demos-release.git
-    version: release/jazzy/action_tutorials_interfaces/0.33.9-1
+    version: release/jazzy/action_tutorials_interfaces/0.33.11-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-action-tutorials-py/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-action-tutorials-py/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-action-tutorials-py
 _pkgname=action_tutorials_py
-pkgver=0.33.9
+pkgver=0.33.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: action_tutorials_py
     uri: https://github.com/ros2-gbp/demos-release.git
-    version: release/jazzy/action_tutorials_py/0.33.9-1
+    version: release/jazzy/action_tutorials_py/0.33.11-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-actionlib-msgs/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-actionlib-msgs/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-actionlib-msgs
 _pkgname=actionlib_msgs
-pkgver=5.3.7
+pkgver=5.3.8
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: actionlib_msgs
     uri: https://github.com/ros2-gbp/common_interfaces-release.git
-    version: release/jazzy/actionlib_msgs/5.3.7-1
+    version: release/jazzy/actionlib_msgs/5.3.8-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-ament-clang-format/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-ament-clang-format/APKBUILD
@@ -1,13 +1,13 @@
 pkgname=ros-jazzy-ament-clang-format
 _pkgname=ament_clang_format
-pkgver=0.17.4
+pkgver=0.17.5
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
 arch="all"
 license="Apache License 2.0"
 
-depends="clang py3-yaml ros-jazzy-ros-workspace"
+depends="clang-extra-tools py3-yaml ros-jazzy-ros-workspace"
 makedepends="chrpath py3-pytest7 py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-jazzy-ament-copyright ros-jazzy-ament-copyright-dev ros-jazzy-ament-flake8 ros-jazzy-ament-flake8-dev ros-jazzy-ament-pep257 ros-jazzy-ament-pep257-dev ros-jazzy-ros-workspace-dev"
 depends_dev="ros-jazzy-ros-workspace-dev"
 
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ament_clang_format
     uri: https://github.com/ros2-gbp/ament_lint-release.git
-    version: release/jazzy/ament_clang_format/0.17.4-1
+    version: release/jazzy/ament_clang_format/0.17.5-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-ament-cmake-clang-format/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-ament-cmake-clang-format/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-ament-cmake-clang-format
 _pkgname=ament_cmake_clang_format
-pkgver=0.17.4
+pkgver=0.17.5
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ament_cmake_clang_format
     uri: https://github.com/ros2-gbp/ament_lint-release.git
-    version: release/jazzy/ament_cmake_clang_format/0.17.4-1
+    version: release/jazzy/ament_cmake_clang_format/0.17.5-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-ament-cmake-copyright/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-ament-cmake-copyright/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-ament-cmake-copyright
 _pkgname=ament_cmake_copyright
-pkgver=0.17.4
+pkgver=0.17.5
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ament_cmake_copyright
     uri: https://github.com/ros2-gbp/ament_lint-release.git
-    version: release/jazzy/ament_cmake_copyright/0.17.4-1
+    version: release/jazzy/ament_cmake_copyright/0.17.5-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-ament-cmake-cppcheck/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-ament-cmake-cppcheck/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-ament-cmake-cppcheck
 _pkgname=ament_cmake_cppcheck
-pkgver=0.17.4
+pkgver=0.17.5
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ament_cmake_cppcheck
     uri: https://github.com/ros2-gbp/ament_lint-release.git
-    version: release/jazzy/ament_cmake_cppcheck/0.17.4-1
+    version: release/jazzy/ament_cmake_cppcheck/0.17.5-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-ament-cmake-cpplint/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-ament-cmake-cpplint/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-ament-cmake-cpplint
 _pkgname=ament_cmake_cpplint
-pkgver=0.17.4
+pkgver=0.17.5
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ament_cmake_cpplint
     uri: https://github.com/ros2-gbp/ament_lint-release.git
-    version: release/jazzy/ament_cmake_cpplint/0.17.4-1
+    version: release/jazzy/ament_cmake_cpplint/0.17.5-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-ament-cmake-flake8/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-ament-cmake-flake8/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-ament-cmake-flake8
 _pkgname=ament_cmake_flake8
-pkgver=0.17.4
+pkgver=0.17.5
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ament_cmake_flake8
     uri: https://github.com/ros2-gbp/ament_lint-release.git
-    version: release/jazzy/ament_cmake_flake8/0.17.4-1
+    version: release/jazzy/ament_cmake_flake8/0.17.5-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-ament-cmake-lint-cmake/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-ament-cmake-lint-cmake/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-ament-cmake-lint-cmake
 _pkgname=ament_cmake_lint_cmake
-pkgver=0.17.4
+pkgver=0.17.5
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ament_cmake_lint_cmake
     uri: https://github.com/ros2-gbp/ament_lint-release.git
-    version: release/jazzy/ament_cmake_lint_cmake/0.17.4-1
+    version: release/jazzy/ament_cmake_lint_cmake/0.17.5-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-ament-cmake-pep257/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-ament-cmake-pep257/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-ament-cmake-pep257
 _pkgname=ament_cmake_pep257
-pkgver=0.17.4
+pkgver=0.17.5
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ament_cmake_pep257
     uri: https://github.com/ros2-gbp/ament_lint-release.git
-    version: release/jazzy/ament_cmake_pep257/0.17.4-1
+    version: release/jazzy/ament_cmake_pep257/0.17.5-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-ament-cmake-ros/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-ament-cmake-ros/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-ament-cmake-ros
 _pkgname=ament_cmake_ros
-pkgver=0.12.0
+pkgver=0.12.1
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ament_cmake_ros
     uri: https://github.com/ros2-gbp/ament_cmake_ros-release.git
-    version: release/jazzy/ament_cmake_ros/0.12.0-3
+    version: release/jazzy/ament_cmake_ros/0.12.1-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-ament-cmake-uncrustify/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-ament-cmake-uncrustify/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-ament-cmake-uncrustify
 _pkgname=ament_cmake_uncrustify
-pkgver=0.17.4
+pkgver=0.17.5
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ament_cmake_uncrustify
     uri: https://github.com/ros2-gbp/ament_lint-release.git
-    version: release/jazzy/ament_cmake_uncrustify/0.17.4-1
+    version: release/jazzy/ament_cmake_uncrustify/0.17.5-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-ament-cmake-xmllint/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-ament-cmake-xmllint/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-ament-cmake-xmllint
 _pkgname=ament_cmake_xmllint
-pkgver=0.17.4
+pkgver=0.17.5
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ament_cmake_xmllint
     uri: https://github.com/ros2-gbp/ament_lint-release.git
-    version: release/jazzy/ament_cmake_xmllint/0.17.4-1
+    version: release/jazzy/ament_cmake_xmllint/0.17.5-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-ament-copyright/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-ament-copyright/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-ament-copyright
 _pkgname=ament_copyright
-pkgver=0.17.4
+pkgver=0.17.5
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ament_copyright
     uri: https://github.com/ros2-gbp/ament_lint-release.git
-    version: release/jazzy/ament_copyright/0.17.4-1
+    version: release/jazzy/ament_copyright/0.17.5-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-ament-cppcheck/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-ament-cppcheck/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-ament-cppcheck
 _pkgname=ament_cppcheck
-pkgver=0.17.4
+pkgver=0.17.5
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ament_cppcheck
     uri: https://github.com/ros2-gbp/ament_lint-release.git
-    version: release/jazzy/ament_cppcheck/0.17.4-1
+    version: release/jazzy/ament_cppcheck/0.17.5-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-ament-cpplint/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-ament-cpplint/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-ament-cpplint
 _pkgname=ament_cpplint
-pkgver=0.17.4
+pkgver=0.17.5
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ament_cpplint
     uri: https://github.com/ros2-gbp/ament_lint-release.git
-    version: release/jazzy/ament_cpplint/0.17.4-1
+    version: release/jazzy/ament_cpplint/0.17.5-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-ament-flake8/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-ament-flake8/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-ament-flake8
 _pkgname=ament_flake8
-pkgver=0.17.4
+pkgver=0.17.5
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ament_flake8
     uri: https://github.com/ros2-gbp/ament_lint-release.git
-    version: release/jazzy/ament_flake8/0.17.4-1
+    version: release/jazzy/ament_flake8/0.17.5-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-ament-index-cpp/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-ament-index-cpp/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-ament-index-cpp
 _pkgname=ament_index_cpp
-pkgver=1.8.3
+pkgver=1.8.4
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ament_index_cpp
     uri: https://github.com/ros2-gbp/ament_index-release.git
-    version: release/jazzy/ament_index_cpp/1.8.3-1
+    version: release/jazzy/ament_index_cpp/1.8.4-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-ament-index-python/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-ament-index-python/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-ament-index-python
 _pkgname=ament_index_python
-pkgver=1.8.3
+pkgver=1.8.4
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ament_index_python
     uri: https://github.com/ros2-gbp/ament_index-release.git
-    version: release/jazzy/ament_index_python/1.8.3-1
+    version: release/jazzy/ament_index_python/1.8.4-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-ament-lint-auto/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-ament-lint-auto/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-ament-lint-auto
 _pkgname=ament_lint_auto
-pkgver=0.17.4
+pkgver=0.17.5
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ament_lint_auto
     uri: https://github.com/ros2-gbp/ament_lint-release.git
-    version: release/jazzy/ament_lint_auto/0.17.4-1
+    version: release/jazzy/ament_lint_auto/0.17.5-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-ament-lint-cmake/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-ament-lint-cmake/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-ament-lint-cmake
 _pkgname=ament_lint_cmake
-pkgver=0.17.4
+pkgver=0.17.5
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ament_lint_cmake
     uri: https://github.com/ros2-gbp/ament_lint-release.git
-    version: release/jazzy/ament_lint_cmake/0.17.4-1
+    version: release/jazzy/ament_lint_cmake/0.17.5-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-ament-lint-common/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-ament-lint-common/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-ament-lint-common
 _pkgname=ament_lint_common
-pkgver=0.17.4
+pkgver=0.17.5
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ament_lint_common
     uri: https://github.com/ros2-gbp/ament_lint-release.git
-    version: release/jazzy/ament_lint_common/0.17.4-1
+    version: release/jazzy/ament_lint_common/0.17.5-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-ament-lint/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-ament-lint/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-ament-lint
 _pkgname=ament_lint
-pkgver=0.17.4
+pkgver=0.17.5
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ament_lint
     uri: https://github.com/ros2-gbp/ament_lint-release.git
-    version: release/jazzy/ament_lint/0.17.4-1
+    version: release/jazzy/ament_lint/0.17.5-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-ament-mypy/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-ament-mypy/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-ament-mypy
 _pkgname=ament_mypy
-pkgver=0.17.4
+pkgver=0.17.5
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ament_mypy
     uri: https://github.com/ros2-gbp/ament_lint-release.git
-    version: release/jazzy/ament_mypy/0.17.4-1
+    version: release/jazzy/ament_mypy/0.17.5-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-ament-pep257/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-ament-pep257/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-ament-pep257
 _pkgname=ament_pep257
-pkgver=0.17.4
+pkgver=0.17.5
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ament_pep257
     uri: https://github.com/ros2-gbp/ament_lint-release.git
-    version: release/jazzy/ament_pep257/0.17.4-1
+    version: release/jazzy/ament_pep257/0.17.5-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-ament-pycodestyle/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-ament-pycodestyle/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-ament-pycodestyle
 _pkgname=ament_pycodestyle
-pkgver=0.17.4
+pkgver=0.17.5
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ament_pycodestyle
     uri: https://github.com/ros2-gbp/ament_lint-release.git
-    version: release/jazzy/ament_pycodestyle/0.17.4-1
+    version: release/jazzy/ament_pycodestyle/0.17.5-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-ament-uncrustify/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-ament-uncrustify/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-ament-uncrustify
 _pkgname=ament_uncrustify
-pkgver=0.17.4
+pkgver=0.17.5
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ament_uncrustify
     uri: https://github.com/ros2-gbp/ament_lint-release.git
-    version: release/jazzy/ament_uncrustify/0.17.4-1
+    version: release/jazzy/ament_uncrustify/0.17.5-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-ament-xmllint/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-ament-xmllint/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-ament-xmllint
 _pkgname=ament_xmllint
-pkgver=0.17.4
+pkgver=0.17.5
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ament_xmllint
     uri: https://github.com/ros2-gbp/ament_lint-release.git
-    version: release/jazzy/ament_xmllint/0.17.4-1
+    version: release/jazzy/ament_xmllint/0.17.5-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-behaviortree-cpp/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-behaviortree-cpp/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-behaviortree-cpp
 _pkgname=behaviortree_cpp
-pkgver=4.9.0
+pkgver=4.9.1
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: behaviortree_cpp
     uri: https://github.com/ros2-gbp/behaviortree_cpp_v4-release.git
-    version: release/jazzy/behaviortree_cpp/4.9.0-1
+    version: release/jazzy/behaviortree_cpp/4.9.1-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-builtin-interfaces/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-builtin-interfaces/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-builtin-interfaces
 _pkgname=builtin_interfaces
-pkgver=2.0.3
+pkgver=2.0.4
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: builtin_interfaces
     uri: https://github.com/ros2-gbp/rcl_interfaces-release.git
-    version: release/jazzy/builtin_interfaces/2.0.3-1
+    version: release/jazzy/builtin_interfaces/2.0.4-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-camera-calibration-parsers/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-camera-calibration-parsers/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-camera-calibration-parsers
 _pkgname=camera_calibration_parsers
-pkgver=5.1.7
+pkgver=5.1.8
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="http://ros.org/wiki/camera_calibration_parsers"
@@ -8,7 +8,7 @@ arch="all"
 license="BSD"
 
 depends="ros-jazzy-rclcpp ros-jazzy-ros-workspace ros-jazzy-sensor-msgs ros-jazzy-yaml-cpp-vendor"
-makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-jazzy-ament-cmake-gtest ros-jazzy-ament-cmake-gtest-dev ros-jazzy-ament-cmake-ros ros-jazzy-ament-cmake-ros-dev ros-jazzy-ament-lint-auto ros-jazzy-ament-lint-auto-dev ros-jazzy-ament-lint-common ros-jazzy-ament-lint-common-dev ros-jazzy-rclcpp ros-jazzy-rclcpp-dev ros-jazzy-ros-workspace-dev ros-jazzy-sensor-msgs ros-jazzy-sensor-msgs-dev ros-jazzy-yaml-cpp-vendor ros-jazzy-yaml-cpp-vendor-dev"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-jazzy-ament-cmake-gen-version-h ros-jazzy-ament-cmake-gen-version-h-dev ros-jazzy-ament-cmake-gtest ros-jazzy-ament-cmake-gtest-dev ros-jazzy-ament-cmake-ros ros-jazzy-ament-cmake-ros-dev ros-jazzy-ament-lint-auto ros-jazzy-ament-lint-auto-dev ros-jazzy-ament-lint-common ros-jazzy-ament-lint-common-dev ros-jazzy-rclcpp ros-jazzy-rclcpp-dev ros-jazzy-ros-workspace-dev ros-jazzy-sensor-msgs ros-jazzy-sensor-msgs-dev ros-jazzy-yaml-cpp-vendor ros-jazzy-yaml-cpp-vendor-dev"
 depends_dev="ros-jazzy-rclcpp ros-jazzy-rclcpp-dev ros-jazzy-ros-workspace-dev ros-jazzy-sensor-msgs ros-jazzy-sensor-msgs-dev ros-jazzy-yaml-cpp-vendor ros-jazzy-yaml-cpp-vendor-dev"
 
 subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: camera_calibration_parsers
     uri: https://github.com/ros2-gbp/image_common-release.git
-    version: release/jazzy/camera_calibration_parsers/5.1.7-1
+    version: release/jazzy/camera_calibration_parsers/5.1.8-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-camera-calibration/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-camera-calibration/APKBUILD
@@ -1,9 +1,9 @@
 pkgname=ros-jazzy-camera-calibration
 _pkgname=camera_calibration
-pkgver=5.0.11
+pkgver=5.0.13
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
-url="https://index.ros.org/p/camera_calibration/github-ros-perception-image_pipeline/"
+url="https://index.ros.org/p/camera_calibration/"
 arch="all"
 license="BSD"
 
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: camera_calibration
     uri: https://github.com/ros2-gbp/image_pipeline-release.git
-    version: release/jazzy/camera_calibration/5.0.11-1
+    version: release/jazzy/camera_calibration/5.0.13-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-camera-info-manager/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-camera-info-manager/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-camera-info-manager
 _pkgname=camera_info_manager
-pkgver=5.1.7
+pkgver=5.1.8
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="http://ros.org/wiki/camera_info_manager"
@@ -8,7 +8,7 @@ arch="all"
 license="BSD"
 
 depends="ros-jazzy-ament-index-cpp ros-jazzy-camera-calibration-parsers ros-jazzy-rclcpp ros-jazzy-rclcpp-lifecycle ros-jazzy-rcpputils ros-jazzy-ros-workspace ros-jazzy-sensor-msgs"
-makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-jazzy-ament-cmake-gtest ros-jazzy-ament-cmake-gtest-dev ros-jazzy-ament-cmake-ros ros-jazzy-ament-cmake-ros-dev ros-jazzy-ament-index-cpp ros-jazzy-ament-index-cpp-dev ros-jazzy-ament-lint-auto ros-jazzy-ament-lint-auto-dev ros-jazzy-ament-lint-common ros-jazzy-ament-lint-common-dev ros-jazzy-camera-calibration-parsers ros-jazzy-camera-calibration-parsers-dev ros-jazzy-rclcpp ros-jazzy-rclcpp-dev ros-jazzy-rclcpp-lifecycle ros-jazzy-rclcpp-lifecycle-dev ros-jazzy-rcpputils ros-jazzy-rcpputils-dev ros-jazzy-ros-workspace-dev ros-jazzy-sensor-msgs ros-jazzy-sensor-msgs-dev"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-jazzy-ament-cmake-gen-version-h ros-jazzy-ament-cmake-gen-version-h-dev ros-jazzy-ament-cmake-gtest ros-jazzy-ament-cmake-gtest-dev ros-jazzy-ament-cmake-ros ros-jazzy-ament-cmake-ros-dev ros-jazzy-ament-index-cpp ros-jazzy-ament-index-cpp-dev ros-jazzy-ament-lint-auto ros-jazzy-ament-lint-auto-dev ros-jazzy-ament-lint-common ros-jazzy-ament-lint-common-dev ros-jazzy-camera-calibration-parsers ros-jazzy-camera-calibration-parsers-dev ros-jazzy-rclcpp ros-jazzy-rclcpp-dev ros-jazzy-rclcpp-lifecycle ros-jazzy-rclcpp-lifecycle-dev ros-jazzy-rcpputils ros-jazzy-rcpputils-dev ros-jazzy-ros-workspace-dev ros-jazzy-sensor-msgs ros-jazzy-sensor-msgs-dev"
 depends_dev="ros-jazzy-ament-index-cpp ros-jazzy-ament-index-cpp-dev ros-jazzy-camera-calibration-parsers ros-jazzy-camera-calibration-parsers-dev ros-jazzy-rclcpp ros-jazzy-rclcpp-dev ros-jazzy-rclcpp-lifecycle ros-jazzy-rclcpp-lifecycle-dev ros-jazzy-rcpputils ros-jazzy-rcpputils-dev ros-jazzy-ros-workspace-dev ros-jazzy-sensor-msgs ros-jazzy-sensor-msgs-dev"
 
 subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: camera_info_manager
     uri: https://github.com/ros2-gbp/image_common-release.git
-    version: release/jazzy/camera_info_manager/5.1.7-1
+    version: release/jazzy/camera_info_manager/5.1.8-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-class-loader/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-class-loader/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-class-loader
 _pkgname=class_loader
-pkgver=2.7.0
+pkgver=2.7.1
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="http://ros.org/wiki/class_loader"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: class_loader
     uri: https://github.com/ros2-gbp/class_loader-release.git
-    version: release/jazzy/class_loader/2.7.0-3
+    version: release/jazzy/class_loader/2.7.1-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-common-interfaces/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-common-interfaces/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-common-interfaces
 _pkgname=common_interfaces
-pkgver=5.3.7
+pkgver=5.3.8
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: common_interfaces
     uri: https://github.com/ros2-gbp/common_interfaces-release.git
-    version: release/jazzy/common_interfaces/5.3.7-1
+    version: release/jazzy/common_interfaces/5.3.8-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-composition-interfaces/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-composition-interfaces/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-composition-interfaces
 _pkgname=composition_interfaces
-pkgver=2.0.3
+pkgver=2.0.4
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: composition_interfaces
     uri: https://github.com/ros2-gbp/rcl_interfaces-release.git
-    version: release/jazzy/composition_interfaces/2.0.3-1
+    version: release/jazzy/composition_interfaces/2.0.4-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-composition/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-composition/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-composition
 _pkgname=composition
-pkgver=0.33.9
+pkgver=0.33.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: composition
     uri: https://github.com/ros2-gbp/demos-release.git
-    version: release/jazzy/composition/0.33.9-1
+    version: release/jazzy/composition/0.33.11-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-compressed-depth-image-transport/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-compressed-depth-image-transport/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-compressed-depth-image-transport
 _pkgname=compressed_depth_image_transport
-pkgver=4.0.6
+pkgver=4.0.7
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="http://www.ros.org/wiki/image_transport_plugins"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: compressed_depth_image_transport
     uri: https://github.com/ros2-gbp/image_transport_plugins-release.git
-    version: release/jazzy/compressed_depth_image_transport/4.0.6-1
+    version: release/jazzy/compressed_depth_image_transport/4.0.7-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-compressed-image-transport/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-compressed-image-transport/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-compressed-image-transport
 _pkgname=compressed_image_transport
-pkgver=4.0.6
+pkgver=4.0.7
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="http://www.ros.org/wiki/image_transport_plugins"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: compressed_image_transport
     uri: https://github.com/ros2-gbp/image_transport_plugins-release.git
-    version: release/jazzy/compressed_image_transport/4.0.6-1
+    version: release/jazzy/compressed_image_transport/4.0.7-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-console-bridge-vendor/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-console-bridge-vendor/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-console-bridge-vendor
 _pkgname=console_bridge_vendor
-pkgver=1.7.1
+pkgver=1.7.2
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://github.com/ros/console_bridge"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: console_bridge_vendor
     uri: https://github.com/ros2-gbp/console_bridge_vendor-release.git
-    version: release/jazzy/console_bridge_vendor/1.7.1-3
+    version: release/jazzy/console_bridge_vendor/1.7.2-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-costmap-queue/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-costmap-queue/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-costmap-queue
 _pkgname=costmap_queue
-pkgver=1.3.11
+pkgver=1.3.12
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: costmap_queue
     uri: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/costmap_queue/1.3.11-1
+    version: release/jazzy/costmap_queue/1.3.12-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-demo-nodes-cpp-native/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-demo-nodes-cpp-native/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-demo-nodes-cpp-native
 _pkgname=demo_nodes_cpp_native
-pkgver=0.33.9
+pkgver=0.33.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: demo_nodes_cpp_native
     uri: https://github.com/ros2-gbp/demos-release.git
-    version: release/jazzy/demo_nodes_cpp_native/0.33.9-1
+    version: release/jazzy/demo_nodes_cpp_native/0.33.11-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-demo-nodes-cpp/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-demo-nodes-cpp/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-demo-nodes-cpp
 _pkgname=demo_nodes_cpp
-pkgver=0.33.9
+pkgver=0.33.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: demo_nodes_cpp
     uri: https://github.com/ros2-gbp/demos-release.git
-    version: release/jazzy/demo_nodes_cpp/0.33.9-1
+    version: release/jazzy/demo_nodes_cpp/0.33.11-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-demo-nodes-py/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-demo-nodes-py/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-demo-nodes-py
 _pkgname=demo_nodes_py
-pkgver=0.33.9
+pkgver=0.33.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: demo_nodes_py
     uri: https://github.com/ros2-gbp/demos-release.git
-    version: release/jazzy/demo_nodes_py/0.33.9-1
+    version: release/jazzy/demo_nodes_py/0.33.11-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-depth-image-proc/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-depth-image-proc/APKBUILD
@@ -1,14 +1,14 @@
 pkgname=ros-jazzy-depth-image-proc
 _pkgname=depth_image_proc
-pkgver=5.0.11
+pkgver=5.0.13
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
-url="https://index.ros.org/p/depth_image_proc/github-ros-perception-image_pipeline/"
+url="https://index.ros.org/p/depth_image_proc/"
 arch="all"
 license="BSD"
 
 depends="ros-jazzy-cv-bridge ros-jazzy-image-geometry ros-jazzy-image-proc ros-jazzy-image-transport ros-jazzy-message-filters ros-jazzy-rclcpp ros-jazzy-rclcpp-components ros-jazzy-ros-workspace ros-jazzy-sensor-msgs ros-jazzy-stereo-msgs ros-jazzy-tf2 ros-jazzy-tf2-eigen ros-jazzy-tf2-ros"
-makedepends="chrpath opencv-dev py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-jazzy-ament-cmake-auto ros-jazzy-ament-cmake-auto-dev ros-jazzy-ament-lint-auto ros-jazzy-ament-lint-auto-dev ros-jazzy-ament-lint-common ros-jazzy-ament-lint-common-dev ros-jazzy-class-loader ros-jazzy-class-loader-dev ros-jazzy-cv-bridge ros-jazzy-cv-bridge-dev ros-jazzy-image-geometry ros-jazzy-image-geometry-dev ros-jazzy-image-proc ros-jazzy-image-proc-dev ros-jazzy-image-transport ros-jazzy-image-transport-dev ros-jazzy-message-filters ros-jazzy-message-filters-dev ros-jazzy-rclcpp ros-jazzy-rclcpp-components ros-jazzy-rclcpp-components-dev ros-jazzy-rclcpp-dev ros-jazzy-ros-workspace-dev ros-jazzy-sensor-msgs ros-jazzy-sensor-msgs-dev ros-jazzy-stereo-msgs ros-jazzy-stereo-msgs-dev ros-jazzy-tf2 ros-jazzy-tf2-dev ros-jazzy-tf2-eigen ros-jazzy-tf2-eigen-dev ros-jazzy-tf2-ros ros-jazzy-tf2-ros-dev"
+makedepends="chrpath opencv-dev py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-jazzy-ament-cmake-auto ros-jazzy-ament-cmake-auto-dev ros-jazzy-ament-cmake-gtest ros-jazzy-ament-cmake-gtest-dev ros-jazzy-ament-lint-auto ros-jazzy-ament-lint-auto-dev ros-jazzy-ament-lint-common ros-jazzy-ament-lint-common-dev ros-jazzy-class-loader ros-jazzy-class-loader-dev ros-jazzy-cv-bridge ros-jazzy-cv-bridge-dev ros-jazzy-image-geometry ros-jazzy-image-geometry-dev ros-jazzy-image-proc ros-jazzy-image-proc-dev ros-jazzy-image-transport ros-jazzy-image-transport-dev ros-jazzy-message-filters ros-jazzy-message-filters-dev ros-jazzy-rclcpp ros-jazzy-rclcpp-components ros-jazzy-rclcpp-components-dev ros-jazzy-rclcpp-dev ros-jazzy-ros-workspace-dev ros-jazzy-sensor-msgs ros-jazzy-sensor-msgs-dev ros-jazzy-stereo-msgs ros-jazzy-stereo-msgs-dev ros-jazzy-tf2 ros-jazzy-tf2-dev ros-jazzy-tf2-eigen ros-jazzy-tf2-eigen-dev ros-jazzy-tf2-ros ros-jazzy-tf2-ros-dev"
 depends_dev="opencv-dev ros-jazzy-cv-bridge ros-jazzy-cv-bridge-dev ros-jazzy-image-geometry ros-jazzy-image-geometry-dev ros-jazzy-image-proc ros-jazzy-image-proc-dev ros-jazzy-image-transport ros-jazzy-image-transport-dev ros-jazzy-message-filters ros-jazzy-message-filters-dev ros-jazzy-rclcpp ros-jazzy-rclcpp-components ros-jazzy-rclcpp-components-dev ros-jazzy-rclcpp-dev ros-jazzy-ros-workspace-dev ros-jazzy-sensor-msgs ros-jazzy-sensor-msgs-dev ros-jazzy-stereo-msgs ros-jazzy-stereo-msgs-dev ros-jazzy-tf2 ros-jazzy-tf2-dev ros-jazzy-tf2-eigen ros-jazzy-tf2-eigen-dev ros-jazzy-tf2-ros ros-jazzy-tf2-ros-dev"
 
 subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: depth_image_proc
     uri: https://github.com/ros2-gbp/image_pipeline-release.git
-    version: release/jazzy/depth_image_proc/5.0.11-1
+    version: release/jazzy/depth_image_proc/5.0.13-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-diagnostic-msgs/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-diagnostic-msgs/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-diagnostic-msgs
 _pkgname=diagnostic_msgs
-pkgver=5.3.7
+pkgver=5.3.8
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: diagnostic_msgs
     uri: https://github.com/ros2-gbp/common_interfaces-release.git
-    version: release/jazzy/diagnostic_msgs/5.3.7-1
+    version: release/jazzy/diagnostic_msgs/5.3.8-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-diagnostic-updater/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-diagnostic-updater/APKBUILD
@@ -1,9 +1,9 @@
 pkgname=ros-jazzy-diagnostic-updater
 _pkgname=diagnostic_updater
-pkgver=4.2.6
+pkgver=4.2.7
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
-url="http://www.ros.org/wiki/diagnostic_updater"
+url="https://index.ros.org/p/diagnostic_updater/"
 arch="all"
 license="BSD-3-Clause"
 
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: diagnostic_updater
     uri: https://github.com/ros2-gbp/diagnostics-release.git
-    version: release/jazzy/diagnostic_updater/4.2.6-1
+    version: release/jazzy/diagnostic_updater/4.2.7-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-domain-coordinator/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-domain-coordinator/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-domain-coordinator
 _pkgname=domain_coordinator
-pkgver=0.12.0
+pkgver=0.12.1
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: domain_coordinator
     uri: https://github.com/ros2-gbp/ament_cmake_ros-release.git
-    version: release/jazzy/domain_coordinator/0.12.0-3
+    version: release/jazzy/domain_coordinator/0.12.1-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-dummy-map-server/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-dummy-map-server/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-dummy-map-server
 _pkgname=dummy_map_server
-pkgver=0.33.9
+pkgver=0.33.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: dummy_map_server
     uri: https://github.com/ros2-gbp/demos-release.git
-    version: release/jazzy/dummy_map_server/0.33.9-1
+    version: release/jazzy/dummy_map_server/0.33.11-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-dummy-robot-bringup/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-dummy-robot-bringup/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-dummy-robot-bringup
 _pkgname=dummy_robot_bringup
-pkgver=0.33.9
+pkgver=0.33.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: dummy_robot_bringup
     uri: https://github.com/ros2-gbp/demos-release.git
-    version: release/jazzy/dummy_robot_bringup/0.33.9-1
+    version: release/jazzy/dummy_robot_bringup/0.33.11-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-dummy-sensors/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-dummy-sensors/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-dummy-sensors
 _pkgname=dummy_sensors
-pkgver=0.33.9
+pkgver=0.33.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: dummy_sensors
     uri: https://github.com/ros2-gbp/demos-release.git
-    version: release/jazzy/dummy_sensors/0.33.9-1
+    version: release/jazzy/dummy_sensors/0.33.11-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-dwb-core/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-dwb-core/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-dwb-core
 _pkgname=dwb_core
-pkgver=1.3.11
+pkgver=1.3.12
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: dwb_core
     uri: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/dwb_core/1.3.11-1
+    version: release/jazzy/dwb_core/1.3.12-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-dwb-critics/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-dwb-critics/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-dwb-critics
 _pkgname=dwb_critics
-pkgver=1.3.11
+pkgver=1.3.12
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: dwb_critics
     uri: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/dwb_critics/1.3.11-1
+    version: release/jazzy/dwb_critics/1.3.12-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-dwb-msgs/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-dwb-msgs/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-dwb-msgs
 _pkgname=dwb_msgs
-pkgver=1.3.11
+pkgver=1.3.12
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: dwb_msgs
     uri: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/dwb_msgs/1.3.11-1
+    version: release/jazzy/dwb_msgs/1.3.12-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-dwb-plugins/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-dwb-plugins/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-dwb-plugins
 _pkgname=dwb_plugins
-pkgver=1.3.11
+pkgver=1.3.12
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: dwb_plugins
     uri: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/dwb_plugins/1.3.11-1
+    version: release/jazzy/dwb_plugins/1.3.12-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-eigen3-cmake-module/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-eigen3-cmake-module/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-eigen3-cmake-module
 _pkgname=eigen3_cmake_module
-pkgver=0.3.0
+pkgver=0.3.1
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: eigen3_cmake_module
     uri: https://github.com/ros2-gbp/eigen3_cmake_module-release.git
-    version: release/jazzy/eigen3_cmake_module/0.3.0-3
+    version: release/jazzy/eigen3_cmake_module/0.3.1-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-example-interfaces/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-example-interfaces/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-example-interfaces
 _pkgname=example_interfaces
-pkgver=0.12.0
+pkgver=0.12.1
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: example_interfaces
     uri: https://github.com/ros2-gbp/example_interfaces-release.git
-    version: release/jazzy/example_interfaces/0.12.0-3
+    version: release/jazzy/example_interfaces/0.12.1-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-fastrtps-cmake-module/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-fastrtps-cmake-module/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-fastrtps-cmake-module
 _pkgname=fastrtps_cmake_module
-pkgver=3.6.3
+pkgver=3.6.4
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: fastrtps_cmake_module
     uri: https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release.git
-    version: release/jazzy/fastrtps_cmake_module/3.6.3-1
+    version: release/jazzy/fastrtps_cmake_module/3.6.4-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-geometry-msgs/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-geometry-msgs/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-geometry-msgs
 _pkgname=geometry_msgs
-pkgver=5.3.7
+pkgver=5.3.8
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: geometry_msgs
     uri: https://github.com/ros2-gbp/common_interfaces-release.git
-    version: release/jazzy/geometry_msgs/5.3.7-1
+    version: release/jazzy/geometry_msgs/5.3.8-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-geometry2/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-geometry2/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-geometry2
 _pkgname=geometry2
-pkgver=0.36.19
+pkgver=0.36.22
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="http://www.ros.org/wiki/geometry2"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: geometry2
     uri: https://github.com/ros2-gbp/geometry2-release.git
-    version: release/jazzy/geometry2/0.36.19-1
+    version: release/jazzy/geometry2/0.36.22-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-gz-cmake-vendor/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-gz-cmake-vendor/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-gz-cmake-vendor
 _pkgname=gz_cmake_vendor
-pkgver=0.0.11
+pkgver=0.0.12
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://github.com/gazebosim/gz-cmake"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: gz_cmake_vendor
     uri: https://github.com/ros2-gbp/gz_cmake_vendor-release.git
-    version: release/jazzy/gz_cmake_vendor/0.0.11-1
+    version: release/jazzy/gz_cmake_vendor/0.0.12-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-gz-math-vendor/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-gz-math-vendor/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-gz-math-vendor
 _pkgname=gz_math_vendor
-pkgver=0.0.8
+pkgver=0.0.9
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://github.com/gazebosim/gz-math"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: gz_math_vendor
     uri: https://github.com/ros2-gbp/gz_math_vendor-release.git
-    version: release/jazzy/gz_math_vendor/0.0.8-1
+    version: release/jazzy/gz_math_vendor/0.0.9-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-image-common/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-image-common/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-image-common
 _pkgname=image_common
-pkgver=5.1.7
+pkgver=5.1.8
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="http://www.ros.org/wiki/image_common"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: image_common
     uri: https://github.com/ros2-gbp/image_common-release.git
-    version: release/jazzy/image_common/5.1.7-1
+    version: release/jazzy/image_common/5.1.8-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-image-pipeline/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-image-pipeline/APKBUILD
@@ -1,9 +1,9 @@
 pkgname=ros-jazzy-image-pipeline
 _pkgname=image_pipeline
-pkgver=5.0.11
+pkgver=5.0.13
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
-url="https://index.ros.org/p/image_pipeline/github-ros-perception-image_pipeline/"
+url="https://index.ros.org/p/image_pipeline/"
 arch="all"
 license="BSD"
 
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: image_pipeline
     uri: https://github.com/ros2-gbp/image_pipeline-release.git
-    version: release/jazzy/image_pipeline/5.0.11-1
+    version: release/jazzy/image_pipeline/5.0.13-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-image-proc/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-image-proc/APKBUILD
@@ -1,9 +1,9 @@
 pkgname=ros-jazzy-image-proc
 _pkgname=image_proc
-pkgver=5.0.11
+pkgver=5.0.13
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
-url="https://index.ros.org/p/image_proc/github-ros-perception-image_pipeline/"
+url="https://index.ros.org/p/image_proc/"
 arch="all"
 license="BSD"
 
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: image_proc
     uri: https://github.com/ros2-gbp/image_pipeline-release.git
-    version: release/jazzy/image_proc/5.0.11-1
+    version: release/jazzy/image_proc/5.0.13-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-image-publisher/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-image-publisher/APKBUILD
@@ -1,9 +1,9 @@
 pkgname=ros-jazzy-image-publisher
 _pkgname=image_publisher
-pkgver=5.0.11
+pkgver=5.0.13
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
-url="https://index.ros.org/p/image_publisher/github-ros-perception-image_pipeline/"
+url="https://index.ros.org/p/image_publisher/"
 arch="all"
 license="BSD"
 
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: image_publisher
     uri: https://github.com/ros2-gbp/image_pipeline-release.git
-    version: release/jazzy/image_publisher/5.0.11-1
+    version: release/jazzy/image_publisher/5.0.13-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-image-rotate/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-image-rotate/APKBUILD
@@ -1,9 +1,9 @@
 pkgname=ros-jazzy-image-rotate
 _pkgname=image_rotate
-pkgver=5.0.11
+pkgver=5.0.13
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
-url="https://index.ros.org/p/image_rotate/github-ros-perception-image_pipeline/"
+url="https://index.ros.org/p/image_rotate/"
 arch="all"
 license="BSD"
 
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: image_rotate
     uri: https://github.com/ros2-gbp/image_pipeline-release.git
-    version: release/jazzy/image_rotate/5.0.11-1
+    version: release/jazzy/image_rotate/5.0.13-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-image-tools/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-image-tools/APKBUILD
@@ -1,15 +1,15 @@
 pkgname=ros-jazzy-image-tools
 _pkgname=image_tools
-pkgver=0.33.9
+pkgver=0.33.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
 arch="all"
 license="Apache License 2.0"
 
-depends="ros-jazzy-rclcpp ros-jazzy-rclcpp-components ros-jazzy-ros-workspace ros-jazzy-sensor-msgs ros-jazzy-std-msgs"
+depends="libopencv_core libopencv_highgui libopencv_imgcodecs libopencv_imgproc libopencv_videoio ros-jazzy-rclcpp ros-jazzy-rclcpp-components ros-jazzy-ros-workspace ros-jazzy-sensor-msgs ros-jazzy-std-msgs"
 makedepends="chrpath opencv-dev py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-jazzy-ament-cmake ros-jazzy-ament-cmake-dev ros-jazzy-ament-cmake-pytest ros-jazzy-ament-cmake-pytest-dev ros-jazzy-ament-lint-auto ros-jazzy-ament-lint-auto-dev ros-jazzy-ament-lint-common ros-jazzy-ament-lint-common-dev ros-jazzy-launch ros-jazzy-launch-dev ros-jazzy-launch-ros ros-jazzy-launch-ros-dev ros-jazzy-launch-testing ros-jazzy-launch-testing-ament-cmake ros-jazzy-launch-testing-ament-cmake-dev ros-jazzy-launch-testing-dev ros-jazzy-launch-testing-ros ros-jazzy-launch-testing-ros-dev ros-jazzy-rclcpp ros-jazzy-rclcpp-components ros-jazzy-rclcpp-components-dev ros-jazzy-rclcpp-dev ros-jazzy-rmw-implementation-cmake ros-jazzy-rmw-implementation-cmake-dev ros-jazzy-ros-workspace-dev ros-jazzy-sensor-msgs ros-jazzy-sensor-msgs-dev ros-jazzy-std-msgs ros-jazzy-std-msgs-dev"
-depends_dev="opencv-dev ros-jazzy-rclcpp-components-dev ros-jazzy-rclcpp-dev ros-jazzy-ros-workspace-dev ros-jazzy-sensor-msgs-dev ros-jazzy-std-msgs-dev"
+depends_dev="ros-jazzy-rclcpp-components-dev ros-jazzy-rclcpp-dev ros-jazzy-ros-workspace-dev ros-jazzy-sensor-msgs-dev ros-jazzy-std-msgs-dev"
 
 subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: image_tools
     uri: https://github.com/ros2-gbp/demos-release.git
-    version: release/jazzy/image_tools/0.33.9-1
+    version: release/jazzy/image_tools/0.33.11-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-image-transport-plugins/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-image-transport-plugins/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-image-transport-plugins
 _pkgname=image_transport_plugins
-pkgver=4.0.6
+pkgver=4.0.7
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="http://www.ros.org/wiki/image_transport_plugins"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: image_transport_plugins
     uri: https://github.com/ros2-gbp/image_transport_plugins-release.git
-    version: release/jazzy/image_transport_plugins/4.0.6-1
+    version: release/jazzy/image_transport_plugins/4.0.7-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-image-transport/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-image-transport/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-image-transport
 _pkgname=image_transport
-pkgver=5.1.7
+pkgver=5.1.8
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="http://ros.org/wiki/image_transport"
@@ -8,7 +8,7 @@ arch="all"
 license="BSD"
 
 depends="ros-jazzy-message-filters ros-jazzy-pluginlib ros-jazzy-rclcpp ros-jazzy-rclcpp-components ros-jazzy-ros-workspace ros-jazzy-sensor-msgs"
-makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-jazzy-ament-cmake-gtest ros-jazzy-ament-cmake-gtest-dev ros-jazzy-ament-cmake-ros ros-jazzy-ament-cmake-ros-dev ros-jazzy-ament-lint-auto ros-jazzy-ament-lint-auto-dev ros-jazzy-ament-lint-common ros-jazzy-ament-lint-common-dev ros-jazzy-message-filters ros-jazzy-message-filters-dev ros-jazzy-pluginlib ros-jazzy-pluginlib-dev ros-jazzy-rclcpp ros-jazzy-rclcpp-components ros-jazzy-rclcpp-components-dev ros-jazzy-rclcpp-dev ros-jazzy-ros-workspace-dev ros-jazzy-sensor-msgs ros-jazzy-sensor-msgs-dev"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-jazzy-ament-cmake-gen-version-h ros-jazzy-ament-cmake-gen-version-h-dev ros-jazzy-ament-cmake-gtest ros-jazzy-ament-cmake-gtest-dev ros-jazzy-ament-cmake-ros ros-jazzy-ament-cmake-ros-dev ros-jazzy-ament-lint-auto ros-jazzy-ament-lint-auto-dev ros-jazzy-ament-lint-common ros-jazzy-ament-lint-common-dev ros-jazzy-message-filters ros-jazzy-message-filters-dev ros-jazzy-pluginlib ros-jazzy-pluginlib-dev ros-jazzy-rclcpp ros-jazzy-rclcpp-components ros-jazzy-rclcpp-components-dev ros-jazzy-rclcpp-dev ros-jazzy-ros-workspace-dev ros-jazzy-sensor-msgs ros-jazzy-sensor-msgs-dev"
 depends_dev="ros-jazzy-message-filters ros-jazzy-message-filters-dev ros-jazzy-pluginlib ros-jazzy-pluginlib-dev ros-jazzy-rclcpp ros-jazzy-rclcpp-components ros-jazzy-rclcpp-components-dev ros-jazzy-rclcpp-dev ros-jazzy-ros-workspace-dev ros-jazzy-sensor-msgs ros-jazzy-sensor-msgs-dev"
 
 subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: image_transport
     uri: https://github.com/ros2-gbp/image_common-release.git
-    version: release/jazzy/image_transport/5.1.7-1
+    version: release/jazzy/image_transport/5.1.8-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-image-view/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-image-view/APKBUILD
@@ -1,9 +1,9 @@
 pkgname=ros-jazzy-image-view
 _pkgname=image_view
-pkgver=5.0.11
+pkgver=5.0.13
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
-url="https://index.ros.org/p/image_view/github-ros-perception-image_pipeline/"
+url="https://index.ros.org/p/image_view/"
 arch="all"
 license="BSD"
 
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: image_view
     uri: https://github.com/ros2-gbp/image_pipeline-release.git
-    version: release/jazzy/image_view/5.0.11-1
+    version: release/jazzy/image_view/5.0.13-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-intra-process-demo/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-intra-process-demo/APKBUILD
@@ -1,15 +1,15 @@
 pkgname=ros-jazzy-intra-process-demo
 _pkgname=intra_process_demo
-pkgver=0.33.9
+pkgver=0.33.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
 arch="all"
 license="Apache License 2.0"
 
-depends="ros-jazzy-rclcpp ros-jazzy-ros-workspace ros-jazzy-sensor-msgs"
+depends="libopencv_core libopencv_highgui libopencv_imgproc libopencv_videoio ros-jazzy-rclcpp ros-jazzy-ros-workspace ros-jazzy-sensor-msgs"
 makedepends="chrpath opencv-dev py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-jazzy-ament-cmake ros-jazzy-ament-cmake-dev ros-jazzy-ament-cmake-pytest ros-jazzy-ament-cmake-pytest-dev ros-jazzy-ament-lint-auto ros-jazzy-ament-lint-auto-dev ros-jazzy-ament-lint-common ros-jazzy-ament-lint-common-dev ros-jazzy-launch ros-jazzy-launch-dev ros-jazzy-launch-testing ros-jazzy-launch-testing-ament-cmake ros-jazzy-launch-testing-ament-cmake-dev ros-jazzy-launch-testing-dev ros-jazzy-rclcpp ros-jazzy-rclcpp-dev ros-jazzy-rmw-implementation-cmake ros-jazzy-rmw-implementation-cmake-dev ros-jazzy-ros-workspace-dev ros-jazzy-sensor-msgs ros-jazzy-sensor-msgs-dev ros-jazzy-std-msgs ros-jazzy-std-msgs-dev"
-depends_dev="opencv-dev ros-jazzy-rclcpp-dev ros-jazzy-ros-workspace-dev ros-jazzy-sensor-msgs-dev"
+depends_dev="ros-jazzy-rclcpp-dev ros-jazzy-ros-workspace-dev ros-jazzy-sensor-msgs-dev"
 
 subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: intra_process_demo
     uri: https://github.com/ros2-gbp/demos-release.git
-    version: release/jazzy/intra_process_demo/0.33.9-1
+    version: release/jazzy/intra_process_demo/0.33.11-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-launch-ros/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-launch-ros/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-launch-ros
 _pkgname=launch_ros
-pkgver=0.26.11
+pkgver=0.26.12
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: launch_ros
     uri: https://github.com/ros2-gbp/launch_ros-release.git
-    version: release/jazzy/launch_ros/0.26.11-1
+    version: release/jazzy/launch_ros/0.26.12-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-launch-testing-ament-cmake/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-launch-testing-ament-cmake/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-launch-testing-ament-cmake
 _pkgname=launch_testing_ament_cmake
-pkgver=3.4.10
+pkgver=3.4.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: launch_testing_ament_cmake
     uri: https://github.com/ros2-gbp/launch-release.git
-    version: release/jazzy/launch_testing_ament_cmake/3.4.10-1
+    version: release/jazzy/launch_testing_ament_cmake/3.4.11-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-launch-testing-ros/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-launch-testing-ros/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-launch-testing-ros
 _pkgname=launch_testing_ros
-pkgver=0.26.11
+pkgver=0.26.12
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: launch_testing_ros
     uri: https://github.com/ros2-gbp/launch_ros-release.git
-    version: release/jazzy/launch_testing_ros/0.26.11-1
+    version: release/jazzy/launch_testing_ros/0.26.12-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-launch-testing/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-launch-testing/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-launch-testing
 _pkgname=launch_testing
-pkgver=3.4.10
+pkgver=3.4.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: launch_testing
     uri: https://github.com/ros2-gbp/launch-release.git
-    version: release/jazzy/launch_testing/3.4.10-1
+    version: release/jazzy/launch_testing/3.4.11-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-launch-testing/disable-failing-test.patch
+++ b/v3.23/ros/jazzy/ros-jazzy-launch-testing/disable-failing-test.patch
@@ -1,6 +1,6 @@
 diff --git a/test/launch_testing/test_io_handler_and_assertions.py b/test/launch_testing/test_io_handler_and_assertions.py
 deleted file mode 100644
-index 68f262f..0000000
+index d6bcea5..0000000
 --- a/test/launch_testing/test_io_handler_and_assertions.py
 +++ /dev/null
 @@ -1,188 +0,0 @@
@@ -112,7 +112,7 @@ index 68f262f..0000000
 -        matches = [t for t in text_lines if 'Called with arguments' in t]
 -        print('Called with arguments: {}'.format(matches))
 -
--        # Two process have args, because thats how process names are passed down
+-        # Two process have args, because that's how process names are passed down
 -        self.assertEqual(2, len(matches))
 -
 -        matches_extra = [t for t in matches if '--extra' in t]

--- a/v3.23/ros/jazzy/ros-jazzy-launch-xml/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-launch-xml/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-launch-xml
 _pkgname=launch_xml
-pkgver=3.4.10
+pkgver=3.4.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: launch_xml
     uri: https://github.com/ros2-gbp/launch-release.git
-    version: release/jazzy/launch_xml/3.4.10-1
+    version: release/jazzy/launch_xml/3.4.11-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-launch-yaml/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-launch-yaml/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-launch-yaml
 _pkgname=launch_yaml
-pkgver=3.4.10
+pkgver=3.4.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: launch_yaml
     uri: https://github.com/ros2-gbp/launch-release.git
-    version: release/jazzy/launch_yaml/3.4.10-1
+    version: release/jazzy/launch_yaml/3.4.11-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-launch/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-launch/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-launch
 _pkgname=launch
-pkgver=3.4.10
+pkgver=3.4.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: launch
     uri: https://github.com/ros2-gbp/launch-release.git
-    version: release/jazzy/launch/3.4.10-1
+    version: release/jazzy/launch/3.4.11-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-liblz4-vendor/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-liblz4-vendor/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-liblz4-vendor
 _pkgname=liblz4_vendor
-pkgver=0.26.9
+pkgver=0.26.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://github.com/lz4/lz4/"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: liblz4_vendor
     uri: https://github.com/ros2-gbp/rosbag2-release.git
-    version: release/jazzy/liblz4_vendor/0.26.9-1
+    version: release/jazzy/liblz4_vendor/0.26.11-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-libyaml-vendor/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-libyaml-vendor/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-libyaml-vendor
 _pkgname=libyaml_vendor
-pkgver=1.6.3
+pkgver=1.6.4
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://github.com/yaml/libyaml"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: libyaml_vendor
     uri: https://github.com/ros2-gbp/libyaml_vendor-release.git
-    version: release/jazzy/libyaml_vendor/1.6.3-2
+    version: release/jazzy/libyaml_vendor/1.6.4-2
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-lifecycle-msgs/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-lifecycle-msgs/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-lifecycle-msgs
 _pkgname=lifecycle_msgs
-pkgver=2.0.3
+pkgver=2.0.4
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: lifecycle_msgs
     uri: https://github.com/ros2-gbp/rcl_interfaces-release.git
-    version: release/jazzy/lifecycle_msgs/2.0.3-1
+    version: release/jazzy/lifecycle_msgs/2.0.4-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-lifecycle/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-lifecycle/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-lifecycle
 _pkgname=lifecycle
-pkgver=0.33.9
+pkgver=0.33.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: lifecycle
     uri: https://github.com/ros2-gbp/demos-release.git
-    version: release/jazzy/lifecycle/0.33.9-1
+    version: release/jazzy/lifecycle/0.33.11-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-logging-demo/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-logging-demo/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-logging-demo
 _pkgname=logging_demo
-pkgver=0.33.9
+pkgver=0.33.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: logging_demo
     uri: https://github.com/ros2-gbp/demos-release.git
-    version: release/jazzy/logging_demo/0.33.9-1
+    version: release/jazzy/logging_demo/0.33.11-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-mcap-vendor/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-mcap-vendor/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-mcap-vendor
 _pkgname=mcap_vendor
-pkgver=0.26.9
+pkgver=0.26.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: mcap_vendor
     uri: https://github.com/ros2-gbp/rosbag2-release.git
-    version: release/jazzy/mcap_vendor/0.26.9-1
+    version: release/jazzy/mcap_vendor/0.26.11-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-message-filters/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-message-filters/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-message-filters
 _pkgname=message_filters
-pkgver=4.11.11
+pkgver=4.11.17
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://github.com/ros2/message_filters"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: message_filters
     uri: https://github.com/ros2-gbp/ros2_message_filters-release.git
-    version: release/jazzy/message_filters/4.11.11-1
+    version: release/jazzy/message_filters/4.11.17-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-mimick-vendor/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-mimick-vendor/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-mimick-vendor
 _pkgname=mimick_vendor
-pkgver=0.6.2
+pkgver=0.6.3
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://github.com/Snaipe/Mimick"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: mimick_vendor
     uri: https://github.com/ros2-gbp/mimick_vendor-release.git
-    version: release/jazzy/mimick_vendor/0.6.2-1
+    version: release/jazzy/mimick_vendor/0.6.3-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-nav-2d-msgs/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-nav-2d-msgs/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-nav-2d-msgs
 _pkgname=nav_2d_msgs
-pkgver=1.3.11
+pkgver=1.3.12
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: nav_2d_msgs
     uri: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/nav_2d_msgs/1.3.11-1
+    version: release/jazzy/nav_2d_msgs/1.3.12-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-nav-2d-utils/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-nav-2d-utils/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-nav-2d-utils
 _pkgname=nav_2d_utils
-pkgver=1.3.11
+pkgver=1.3.12
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: nav_2d_utils
     uri: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/nav_2d_utils/1.3.11-1
+    version: release/jazzy/nav_2d_utils/1.3.12-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-nav-msgs/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-nav-msgs/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-nav-msgs
 _pkgname=nav_msgs
-pkgver=5.3.7
+pkgver=5.3.8
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: nav_msgs
     uri: https://github.com/ros2-gbp/common_interfaces-release.git
-    version: release/jazzy/nav_msgs/5.3.7-1
+    version: release/jazzy/nav_msgs/5.3.8-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-nav2-amcl/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-nav2-amcl/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-nav2-amcl
 _pkgname=nav2_amcl
-pkgver=1.3.11
+pkgver=1.3.12
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: nav2_amcl
     uri: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/nav2_amcl/1.3.11-1
+    version: release/jazzy/nav2_amcl/1.3.12-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-nav2-behavior-tree/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-nav2-behavior-tree/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-nav2-behavior-tree
 _pkgname=nav2_behavior_tree
-pkgver=1.3.11
+pkgver=1.3.12
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: nav2_behavior_tree
     uri: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/nav2_behavior_tree/1.3.11-1
+    version: release/jazzy/nav2_behavior_tree/1.3.12-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-nav2-behaviors/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-nav2-behaviors/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-nav2-behaviors
 _pkgname=nav2_behaviors
-pkgver=1.3.11
+pkgver=1.3.12
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: nav2_behaviors
     uri: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/nav2_behaviors/1.3.11-1
+    version: release/jazzy/nav2_behaviors/1.3.12-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-nav2-bt-navigator/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-nav2-bt-navigator/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-nav2-bt-navigator
 _pkgname=nav2_bt_navigator
-pkgver=1.3.11
+pkgver=1.3.12
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: nav2_bt_navigator
     uri: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/nav2_bt_navigator/1.3.11-1
+    version: release/jazzy/nav2_bt_navigator/1.3.12-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-nav2-collision-monitor/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-nav2-collision-monitor/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-nav2-collision-monitor
 _pkgname=nav2_collision_monitor
-pkgver=1.3.11
+pkgver=1.3.12
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: nav2_collision_monitor
     uri: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/nav2_collision_monitor/1.3.11-1
+    version: release/jazzy/nav2_collision_monitor/1.3.12-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-nav2-common/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-nav2-common/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-nav2-common
 _pkgname=nav2_common
-pkgver=1.3.11
+pkgver=1.3.12
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: nav2_common
     uri: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/nav2_common/1.3.11-1
+    version: release/jazzy/nav2_common/1.3.12-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-nav2-constrained-smoother/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-nav2-constrained-smoother/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-nav2-constrained-smoother
 _pkgname=nav2_constrained_smoother
-pkgver=1.3.11
+pkgver=1.3.12
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: nav2_constrained_smoother
     uri: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/nav2_constrained_smoother/1.3.11-1
+    version: release/jazzy/nav2_constrained_smoother/1.3.12-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-nav2-controller/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-nav2-controller/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-nav2-controller
 _pkgname=nav2_controller
-pkgver=1.3.11
+pkgver=1.3.12
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: nav2_controller
     uri: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/nav2_controller/1.3.11-1
+    version: release/jazzy/nav2_controller/1.3.12-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-nav2-core/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-nav2-core/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-nav2-core
 _pkgname=nav2_core
-pkgver=1.3.11
+pkgver=1.3.12
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: nav2_core
     uri: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/nav2_core/1.3.11-1
+    version: release/jazzy/nav2_core/1.3.12-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-nav2-costmap-2d/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-nav2-costmap-2d/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-nav2-costmap-2d
 _pkgname=nav2_costmap_2d
-pkgver=1.3.11
+pkgver=1.3.12
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: nav2_costmap_2d
     uri: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/nav2_costmap_2d/1.3.11-1
+    version: release/jazzy/nav2_costmap_2d/1.3.12-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-nav2-dwb-controller/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-nav2-dwb-controller/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-nav2-dwb-controller
 _pkgname=nav2_dwb_controller
-pkgver=1.3.11
+pkgver=1.3.12
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: nav2_dwb_controller
     uri: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/nav2_dwb_controller/1.3.11-1
+    version: release/jazzy/nav2_dwb_controller/1.3.12-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-nav2-graceful-controller/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-nav2-graceful-controller/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-nav2-graceful-controller
 _pkgname=nav2_graceful_controller
-pkgver=1.3.11
+pkgver=1.3.12
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: nav2_graceful_controller
     uri: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/nav2_graceful_controller/1.3.11-1
+    version: release/jazzy/nav2_graceful_controller/1.3.12-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-nav2-lifecycle-manager/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-nav2-lifecycle-manager/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-nav2-lifecycle-manager
 _pkgname=nav2_lifecycle_manager
-pkgver=1.3.11
+pkgver=1.3.12
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: nav2_lifecycle_manager
     uri: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/nav2_lifecycle_manager/1.3.11-1
+    version: release/jazzy/nav2_lifecycle_manager/1.3.12-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-nav2-map-server/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-nav2-map-server/APKBUILD
@@ -1,15 +1,15 @@
 pkgname=ros-jazzy-nav2-map-server
 _pkgname=nav2_map_server
-pkgver=1.3.11
+pkgver=1.3.12
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
 arch="all"
 license="Apache-2.0"
 
-depends="graphicsmagick ros-jazzy-launch-ros ros-jazzy-launch-testing ros-jazzy-nav-msgs ros-jazzy-nav2-msgs ros-jazzy-nav2-util ros-jazzy-rclcpp ros-jazzy-rclcpp-lifecycle ros-jazzy-ros-workspace ros-jazzy-std-msgs ros-jazzy-tf2 ros-jazzy-yaml-cpp-vendor"
-makedepends="chrpath graphicsmagick graphicsmagick-dev py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-jazzy-ament-cmake ros-jazzy-ament-cmake-dev ros-jazzy-ament-cmake-gtest ros-jazzy-ament-cmake-gtest-dev ros-jazzy-ament-cmake-pytest ros-jazzy-ament-cmake-pytest-dev ros-jazzy-ament-lint-auto ros-jazzy-ament-lint-auto-dev ros-jazzy-ament-lint-common ros-jazzy-ament-lint-common-dev ros-jazzy-launch ros-jazzy-launch-dev ros-jazzy-launch-ros ros-jazzy-launch-ros-dev ros-jazzy-launch-testing ros-jazzy-launch-testing-dev ros-jazzy-nav-msgs ros-jazzy-nav-msgs-dev ros-jazzy-nav2-common ros-jazzy-nav2-common-dev ros-jazzy-nav2-msgs ros-jazzy-nav2-msgs-dev ros-jazzy-nav2-util ros-jazzy-nav2-util-dev ros-jazzy-rclcpp ros-jazzy-rclcpp-dev ros-jazzy-rclcpp-lifecycle ros-jazzy-rclcpp-lifecycle-dev ros-jazzy-ros-workspace-dev ros-jazzy-std-msgs ros-jazzy-std-msgs-dev ros-jazzy-tf2 ros-jazzy-tf2-dev ros-jazzy-yaml-cpp-vendor ros-jazzy-yaml-cpp-vendor-dev"
-depends_dev="graphicsmagick graphicsmagick-dev ros-jazzy-launch-ros ros-jazzy-launch-ros-dev ros-jazzy-launch-testing ros-jazzy-launch-testing-dev ros-jazzy-nav-msgs ros-jazzy-nav-msgs-dev ros-jazzy-nav2-msgs ros-jazzy-nav2-msgs-dev ros-jazzy-nav2-util ros-jazzy-nav2-util-dev ros-jazzy-rclcpp ros-jazzy-rclcpp-dev ros-jazzy-rclcpp-lifecycle ros-jazzy-rclcpp-lifecycle-dev ros-jazzy-ros-workspace-dev ros-jazzy-std-msgs ros-jazzy-std-msgs-dev ros-jazzy-tf2 ros-jazzy-tf2-dev ros-jazzy-yaml-cpp-vendor ros-jazzy-yaml-cpp-vendor-dev"
+depends="graphicsmagick graphicsmagick-c++ ros-jazzy-launch-ros ros-jazzy-launch-testing ros-jazzy-nav-msgs ros-jazzy-nav2-msgs ros-jazzy-nav2-util ros-jazzy-rclcpp ros-jazzy-rclcpp-lifecycle ros-jazzy-ros-workspace ros-jazzy-std-msgs ros-jazzy-tf2 ros-jazzy-yaml-cpp-vendor"
+makedepends="chrpath graphicsmagick graphicsmagick-c++ graphicsmagick-dev py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-jazzy-ament-cmake ros-jazzy-ament-cmake-dev ros-jazzy-ament-cmake-gtest ros-jazzy-ament-cmake-gtest-dev ros-jazzy-ament-cmake-pytest ros-jazzy-ament-cmake-pytest-dev ros-jazzy-ament-lint-auto ros-jazzy-ament-lint-auto-dev ros-jazzy-ament-lint-common ros-jazzy-ament-lint-common-dev ros-jazzy-launch ros-jazzy-launch-dev ros-jazzy-launch-ros ros-jazzy-launch-ros-dev ros-jazzy-launch-testing ros-jazzy-launch-testing-dev ros-jazzy-nav-msgs ros-jazzy-nav-msgs-dev ros-jazzy-nav2-common ros-jazzy-nav2-common-dev ros-jazzy-nav2-msgs ros-jazzy-nav2-msgs-dev ros-jazzy-nav2-util ros-jazzy-nav2-util-dev ros-jazzy-rclcpp ros-jazzy-rclcpp-dev ros-jazzy-rclcpp-lifecycle ros-jazzy-rclcpp-lifecycle-dev ros-jazzy-ros-workspace-dev ros-jazzy-std-msgs ros-jazzy-std-msgs-dev ros-jazzy-tf2 ros-jazzy-tf2-dev ros-jazzy-yaml-cpp-vendor ros-jazzy-yaml-cpp-vendor-dev"
+depends_dev="graphicsmagick graphicsmagick-c++ graphicsmagick-dev ros-jazzy-launch-ros ros-jazzy-launch-ros-dev ros-jazzy-launch-testing ros-jazzy-launch-testing-dev ros-jazzy-nav-msgs ros-jazzy-nav-msgs-dev ros-jazzy-nav2-msgs ros-jazzy-nav2-msgs-dev ros-jazzy-nav2-util ros-jazzy-nav2-util-dev ros-jazzy-rclcpp ros-jazzy-rclcpp-dev ros-jazzy-rclcpp-lifecycle ros-jazzy-rclcpp-lifecycle-dev ros-jazzy-ros-workspace-dev ros-jazzy-std-msgs ros-jazzy-std-msgs-dev ros-jazzy-tf2 ros-jazzy-tf2-dev ros-jazzy-yaml-cpp-vendor ros-jazzy-yaml-cpp-vendor-dev"
 
 subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: nav2_map_server
     uri: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/nav2_map_server/1.3.11-1
+    version: release/jazzy/nav2_map_server/1.3.12-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-nav2-mppi-controller/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-nav2-mppi-controller/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-nav2-mppi-controller
 _pkgname=nav2_mppi_controller
-pkgver=1.3.11
+pkgver=1.3.12
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: nav2_mppi_controller
     uri: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/nav2_mppi_controller/1.3.11-1
+    version: release/jazzy/nav2_mppi_controller/1.3.12-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-nav2-msgs/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-nav2-msgs/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-nav2-msgs
 _pkgname=nav2_msgs
-pkgver=1.3.11
+pkgver=1.3.12
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: nav2_msgs
     uri: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/nav2_msgs/1.3.11-1
+    version: release/jazzy/nav2_msgs/1.3.12-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-nav2-navfn-planner/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-nav2-navfn-planner/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-nav2-navfn-planner
 _pkgname=nav2_navfn_planner
-pkgver=1.3.11
+pkgver=1.3.12
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: nav2_navfn_planner
     uri: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/nav2_navfn_planner/1.3.11-1
+    version: release/jazzy/nav2_navfn_planner/1.3.12-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-nav2-planner/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-nav2-planner/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-nav2-planner
 _pkgname=nav2_planner
-pkgver=1.3.11
+pkgver=1.3.12
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: nav2_planner
     uri: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/nav2_planner/1.3.11-1
+    version: release/jazzy/nav2_planner/1.3.12-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-nav2-regulated-pure-pursuit-controller/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-nav2-regulated-pure-pursuit-controller/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-nav2-regulated-pure-pursuit-controller
 _pkgname=nav2_regulated_pure_pursuit_controller
-pkgver=1.3.11
+pkgver=1.3.12
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: nav2_regulated_pure_pursuit_controller
     uri: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/nav2_regulated_pure_pursuit_controller/1.3.11-1
+    version: release/jazzy/nav2_regulated_pure_pursuit_controller/1.3.12-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-nav2-rotation-shim-controller/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-nav2-rotation-shim-controller/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-nav2-rotation-shim-controller
 _pkgname=nav2_rotation_shim_controller
-pkgver=1.3.11
+pkgver=1.3.12
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: nav2_rotation_shim_controller
     uri: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/nav2_rotation_shim_controller/1.3.11-1
+    version: release/jazzy/nav2_rotation_shim_controller/1.3.12-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-nav2-route/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-nav2-route/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-nav2-route
 _pkgname=nav2_route
-pkgver=1.3.11
+pkgver=1.3.12
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: nav2_route
     uri: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/nav2_route/1.3.11-1
+    version: release/jazzy/nav2_route/1.3.12-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-nav2-rviz-plugins/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-nav2-rviz-plugins/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-nav2-rviz-plugins
 _pkgname=nav2_rviz_plugins
-pkgver=1.3.11
+pkgver=1.3.12
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: nav2_rviz_plugins
     uri: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/nav2_rviz_plugins/1.3.11-1
+    version: release/jazzy/nav2_rviz_plugins/1.3.12-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-nav2-simple-commander/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-nav2-simple-commander/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-nav2-simple-commander
 _pkgname=nav2_simple_commander
-pkgver=1.3.11
+pkgver=1.3.12
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: nav2_simple_commander
     uri: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/nav2_simple_commander/1.3.11-1
+    version: release/jazzy/nav2_simple_commander/1.3.12-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-nav2-smac-planner/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-nav2-smac-planner/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-nav2-smac-planner
 _pkgname=nav2_smac_planner
-pkgver=1.3.11
+pkgver=1.3.12
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: nav2_smac_planner
     uri: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/nav2_smac_planner/1.3.11-1
+    version: release/jazzy/nav2_smac_planner/1.3.12-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-nav2-smoother/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-nav2-smoother/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-nav2-smoother
 _pkgname=nav2_smoother
-pkgver=1.3.11
+pkgver=1.3.12
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: nav2_smoother
     uri: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/nav2_smoother/1.3.11-1
+    version: release/jazzy/nav2_smoother/1.3.12-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-nav2-theta-star-planner/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-nav2-theta-star-planner/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-nav2-theta-star-planner
 _pkgname=nav2_theta_star_planner
-pkgver=1.3.11
+pkgver=1.3.12
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: nav2_theta_star_planner
     uri: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/nav2_theta_star_planner/1.3.11-1
+    version: release/jazzy/nav2_theta_star_planner/1.3.12-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-nav2-util/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-nav2-util/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-nav2-util
 _pkgname=nav2_util
-pkgver=1.3.11
+pkgver=1.3.12
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: nav2_util
     uri: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/nav2_util/1.3.11-1
+    version: release/jazzy/nav2_util/1.3.12-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-nav2-velocity-smoother/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-nav2-velocity-smoother/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-nav2-velocity-smoother
 _pkgname=nav2_velocity_smoother
-pkgver=1.3.11
+pkgver=1.3.12
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: nav2_velocity_smoother
     uri: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/nav2_velocity_smoother/1.3.11-1
+    version: release/jazzy/nav2_velocity_smoother/1.3.12-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-nav2-voxel-grid/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-nav2-voxel-grid/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-nav2-voxel-grid
 _pkgname=nav2_voxel_grid
-pkgver=1.3.11
+pkgver=1.3.12
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: nav2_voxel_grid
     uri: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/nav2_voxel_grid/1.3.11-1
+    version: release/jazzy/nav2_voxel_grid/1.3.12-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-nav2-waypoint-follower/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-nav2-waypoint-follower/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-nav2-waypoint-follower
 _pkgname=nav2_waypoint_follower
-pkgver=1.3.11
+pkgver=1.3.12
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: nav2_waypoint_follower
     uri: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/nav2_waypoint_follower/1.3.11-1
+    version: release/jazzy/nav2_waypoint_follower/1.3.12-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-navigation2/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-navigation2/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-navigation2
 _pkgname=navigation2
-pkgver=1.3.11
+pkgver=1.3.12
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: navigation2
     uri: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/navigation2/1.3.11-1
+    version: release/jazzy/navigation2/1.3.12-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-opennav-docking-bt/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-opennav-docking-bt/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-opennav-docking-bt
 _pkgname=opennav_docking_bt
-pkgver=1.3.11
+pkgver=1.3.12
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: opennav_docking_bt
     uri: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/opennav_docking_bt/1.3.11-1
+    version: release/jazzy/opennav_docking_bt/1.3.12-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-opennav-docking-core/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-opennav-docking-core/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-opennav-docking-core
 _pkgname=opennav_docking_core
-pkgver=1.3.11
+pkgver=1.3.12
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: opennav_docking_core
     uri: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/opennav_docking_core/1.3.11-1
+    version: release/jazzy/opennav_docking_core/1.3.12-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-opennav-docking/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-opennav-docking/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-opennav-docking
 _pkgname=opennav_docking
-pkgver=1.3.11
+pkgver=1.3.12
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: opennav_docking
     uri: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/opennav_docking/1.3.11-1
+    version: release/jazzy/opennav_docking/1.3.12-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-orocos-kdl-vendor/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-orocos-kdl-vendor/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-orocos-kdl-vendor
 _pkgname=orocos_kdl_vendor
-pkgver=0.5.1
+pkgver=0.5.2
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://github.com/orocos/orocos_kinematics_dynamics"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: orocos_kdl_vendor
     uri: https://github.com/ros2-gbp/orocos_kdl_vendor-release.git
-    version: release/jazzy/orocos_kdl_vendor/0.5.1-2
+    version: release/jazzy/orocos_kdl_vendor/0.5.2-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-pcl-conversions/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-pcl-conversions/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-pcl-conversions
 _pkgname=pcl_conversions
-pkgver=2.6.4
+pkgver=2.6.5
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="http://wiki.ros.org/pcl_conversions"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: pcl_conversions
     uri: https://github.com/ros2-gbp/perception_pcl-release.git
-    version: release/jazzy/pcl_conversions/2.6.4-1
+    version: release/jazzy/pcl_conversions/2.6.5-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-pcl-ros/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-pcl-ros/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-pcl-ros
 _pkgname=pcl_ros
-pkgver=2.6.4
+pkgver=2.6.5
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="http://ros.org/wiki/perception_pcl"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: pcl_ros
     uri: https://github.com/ros2-gbp/perception_pcl-release.git
-    version: release/jazzy/pcl_ros/2.6.4-1
+    version: release/jazzy/pcl_ros/2.6.5-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-pendulum-control/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-pendulum-control/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-pendulum-control
 _pkgname=pendulum_control
-pkgver=0.33.9
+pkgver=0.33.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: pendulum_control
     uri: https://github.com/ros2-gbp/demos-release.git
-    version: release/jazzy/pendulum_control/0.33.9-1
+    version: release/jazzy/pendulum_control/0.33.11-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-pendulum-msgs/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-pendulum-msgs/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-pendulum-msgs
 _pkgname=pendulum_msgs
-pkgver=0.33.9
+pkgver=0.33.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: pendulum_msgs
     uri: https://github.com/ros2-gbp/demos-release.git
-    version: release/jazzy/pendulum_msgs/0.33.9-1
+    version: release/jazzy/pendulum_msgs/0.33.11-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-perception-pcl/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-perception-pcl/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-perception-pcl
 _pkgname=perception_pcl
-pkgver=2.6.4
+pkgver=2.6.5
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="http://ros.org/wiki/perception_pcl"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: perception_pcl
     uri: https://github.com/ros2-gbp/perception_pcl-release.git
-    version: release/jazzy/perception_pcl/2.6.4-1
+    version: release/jazzy/perception_pcl/2.6.5-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-performance-test-fixture/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-performance-test-fixture/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-performance-test-fixture
 _pkgname=performance_test_fixture
-pkgver=0.2.1
+pkgver=0.2.2
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: performance_test_fixture
     uri: https://github.com/ros2-gbp/performance_test_fixture-release.git
-    version: release/jazzy/performance_test_fixture/0.2.1-2
+    version: release/jazzy/performance_test_fixture/0.2.2-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-pluginlib/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-pluginlib/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-pluginlib
 _pkgname=pluginlib
-pkgver=5.4.4
+pkgver=5.4.5
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="http://www.ros.org/wiki/pluginlib"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: pluginlib
     uri: https://github.com/ros2-gbp/pluginlib-release.git
-    version: release/jazzy/pluginlib/5.4.4-1
+    version: release/jazzy/pluginlib/5.4.5-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-point-cloud-transport/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-point-cloud-transport/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-point-cloud-transport
 _pkgname=point_cloud_transport
-pkgver=4.0.7
+pkgver=4.0.9
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://github.com/ros-perception/point_cloud_transport"
@@ -8,7 +8,7 @@ arch="all"
 license="BSD"
 
 depends="ros-jazzy-message-filters ros-jazzy-pluginlib ros-jazzy-rclcpp ros-jazzy-rclcpp-components ros-jazzy-rcpputils ros-jazzy-rmw ros-jazzy-ros-workspace ros-jazzy-sensor-msgs"
-makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-jazzy-ament-cmake-ros ros-jazzy-ament-cmake-ros-dev ros-jazzy-ament-lint-auto ros-jazzy-ament-lint-auto-dev ros-jazzy-ament-lint-common ros-jazzy-ament-lint-common-dev ros-jazzy-message-filters ros-jazzy-message-filters-dev ros-jazzy-pluginlib ros-jazzy-pluginlib-dev ros-jazzy-rclcpp ros-jazzy-rclcpp-components ros-jazzy-rclcpp-components-dev ros-jazzy-rclcpp-dev ros-jazzy-rcpputils ros-jazzy-rcpputils-dev ros-jazzy-rmw ros-jazzy-rmw-dev ros-jazzy-ros-workspace-dev ros-jazzy-sensor-msgs ros-jazzy-sensor-msgs-dev"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-jazzy-ament-cmake-gen-version-h ros-jazzy-ament-cmake-gen-version-h-dev ros-jazzy-ament-cmake-ros ros-jazzy-ament-cmake-ros-dev ros-jazzy-ament-lint-auto ros-jazzy-ament-lint-auto-dev ros-jazzy-ament-lint-common ros-jazzy-ament-lint-common-dev ros-jazzy-message-filters ros-jazzy-message-filters-dev ros-jazzy-pluginlib ros-jazzy-pluginlib-dev ros-jazzy-rclcpp ros-jazzy-rclcpp-components ros-jazzy-rclcpp-components-dev ros-jazzy-rclcpp-dev ros-jazzy-rcpputils ros-jazzy-rcpputils-dev ros-jazzy-rmw ros-jazzy-rmw-dev ros-jazzy-ros-workspace-dev ros-jazzy-sensor-msgs ros-jazzy-sensor-msgs-dev"
 depends_dev="ros-jazzy-message-filters ros-jazzy-message-filters-dev ros-jazzy-pluginlib ros-jazzy-pluginlib-dev ros-jazzy-rclcpp ros-jazzy-rclcpp-components ros-jazzy-rclcpp-components-dev ros-jazzy-rclcpp-dev ros-jazzy-rcpputils ros-jazzy-rcpputils-dev ros-jazzy-rmw ros-jazzy-rmw-dev ros-jazzy-ros-workspace-dev ros-jazzy-sensor-msgs ros-jazzy-sensor-msgs-dev"
 
 subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: point_cloud_transport
     uri: https://github.com/ros2-gbp/point_cloud_transport-release.git
-    version: release/jazzy/point_cloud_transport/4.0.7-1
+    version: release/jazzy/point_cloud_transport/4.0.9-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-python-orocos-kdl-vendor/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-python-orocos-kdl-vendor/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-python-orocos-kdl-vendor
 _pkgname=python_orocos_kdl_vendor
-pkgver=0.5.1
+pkgver=0.5.2
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://github.com/orocos/orocos_kinematics_dynamics"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: python_orocos_kdl_vendor
     uri: https://github.com/ros2-gbp/orocos_kdl_vendor-release.git
-    version: release/jazzy/python_orocos_kdl_vendor/0.5.1-2
+    version: release/jazzy/python_orocos_kdl_vendor/0.5.2-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-qt-dotgraph/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-qt-dotgraph/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-qt-dotgraph
 _pkgname=qt_dotgraph
-pkgver=2.7.5
+pkgver=2.7.6
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="http://ros.org/wiki/qt_dotgraph"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: qt_dotgraph
     uri: https://github.com/ros2-gbp/qt_gui_core-release.git
-    version: release/jazzy/qt_dotgraph/2.7.5-1
+    version: release/jazzy/qt_dotgraph/2.7.6-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-qt-gui-cpp/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-qt-gui-cpp/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-qt-gui-cpp
 _pkgname=qt_gui_cpp
-pkgver=2.7.5
+pkgver=2.7.6
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="http://ros.org/wiki/qt_gui_cpp"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: qt_gui_cpp
     uri: https://github.com/ros2-gbp/qt_gui_core-release.git
-    version: release/jazzy/qt_gui_cpp/2.7.5-1
+    version: release/jazzy/qt_gui_cpp/2.7.6-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-qt-gui-py-common/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-qt-gui-py-common/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-qt-gui-py-common
 _pkgname=qt_gui_py_common
-pkgver=2.7.5
+pkgver=2.7.6
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="http://ros.org/wiki/qt_gui_py_common"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: qt_gui_py_common
     uri: https://github.com/ros2-gbp/qt_gui_core-release.git
-    version: release/jazzy/qt_gui_py_common/2.7.5-1
+    version: release/jazzy/qt_gui_py_common/2.7.6-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-qt-gui/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-qt-gui/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-qt-gui
 _pkgname=qt_gui
-pkgver=2.7.5
+pkgver=2.7.6
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="http://ros.org/wiki/qt_gui"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: qt_gui
     uri: https://github.com/ros2-gbp/qt_gui_core-release.git
-    version: release/jazzy/qt_gui/2.7.5-1
+    version: release/jazzy/qt_gui/2.7.6-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-quality-of-service-demo-cpp/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-quality-of-service-demo-cpp/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-quality-of-service-demo-cpp
 _pkgname=quality_of_service_demo_cpp
-pkgver=0.33.9
+pkgver=0.33.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: quality_of_service_demo_cpp
     uri: https://github.com/ros2-gbp/demos-release.git
-    version: release/jazzy/quality_of_service_demo_cpp/0.33.9-1
+    version: release/jazzy/quality_of_service_demo_cpp/0.33.11-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-quality-of-service-demo-py/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-quality-of-service-demo-py/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-quality-of-service-demo-py
 _pkgname=quality_of_service_demo_py
-pkgver=0.33.9
+pkgver=0.33.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: quality_of_service_demo_py
     uri: https://github.com/ros2-gbp/demos-release.git
-    version: release/jazzy/quality_of_service_demo_py/0.33.9-1
+    version: release/jazzy/quality_of_service_demo_py/0.33.11-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-rcl-action/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-rcl-action/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rcl-action
 _pkgname=rcl_action
-pkgver=9.2.9
+pkgver=9.2.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rcl_action
     uri: https://github.com/ros2-gbp/rcl-release.git
-    version: release/jazzy/rcl_action/9.2.9-1
+    version: release/jazzy/rcl_action/9.2.11-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-rcl-interfaces/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-rcl-interfaces/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rcl-interfaces
 _pkgname=rcl_interfaces
-pkgver=2.0.3
+pkgver=2.0.4
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rcl_interfaces
     uri: https://github.com/ros2-gbp/rcl_interfaces-release.git
-    version: release/jazzy/rcl_interfaces/2.0.3-1
+    version: release/jazzy/rcl_interfaces/2.0.4-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-rcl-lifecycle/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-rcl-lifecycle/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rcl-lifecycle
 _pkgname=rcl_lifecycle
-pkgver=9.2.9
+pkgver=9.2.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rcl_lifecycle
     uri: https://github.com/ros2-gbp/rcl-release.git
-    version: release/jazzy/rcl_lifecycle/9.2.9-1
+    version: release/jazzy/rcl_lifecycle/9.2.11-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-rcl-yaml-param-parser/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-rcl-yaml-param-parser/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rcl-yaml-param-parser
 _pkgname=rcl_yaml_param_parser
-pkgver=9.2.9
+pkgver=9.2.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rcl_yaml_param_parser
     uri: https://github.com/ros2-gbp/rcl-release.git
-    version: release/jazzy/rcl_yaml_param_parser/9.2.9-1
+    version: release/jazzy/rcl_yaml_param_parser/9.2.11-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-rcl/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-rcl/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rcl
 _pkgname=rcl
-pkgver=9.2.9
+pkgver=9.2.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rcl
     uri: https://github.com/ros2-gbp/rcl-release.git
-    version: release/jazzy/rcl/9.2.9-1
+    version: release/jazzy/rcl/9.2.11-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-rclcpp-action/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-rclcpp-action/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rclcpp-action
 _pkgname=rclcpp_action
-pkgver=28.1.17
+pkgver=28.1.21
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rclcpp_action
     uri: https://github.com/ros2-gbp/rclcpp-release.git
-    version: release/jazzy/rclcpp_action/28.1.17-3
+    version: release/jazzy/rclcpp_action/28.1.21-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-rclcpp-components/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-rclcpp-components/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rclcpp-components
 _pkgname=rclcpp_components
-pkgver=28.1.17
+pkgver=28.1.21
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rclcpp_components
     uri: https://github.com/ros2-gbp/rclcpp-release.git
-    version: release/jazzy/rclcpp_components/28.1.17-3
+    version: release/jazzy/rclcpp_components/28.1.21-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-rclcpp-lifecycle/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-rclcpp-lifecycle/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rclcpp-lifecycle
 _pkgname=rclcpp_lifecycle
-pkgver=28.1.17
+pkgver=28.1.21
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rclcpp_lifecycle
     uri: https://github.com/ros2-gbp/rclcpp-release.git
-    version: release/jazzy/rclcpp_lifecycle/28.1.17-3
+    version: release/jazzy/rclcpp_lifecycle/28.1.21-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-rclcpp/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-rclcpp/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rclcpp
 _pkgname=rclcpp
-pkgver=28.1.17
+pkgver=28.1.21
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rclcpp
     uri: https://github.com/ros2-gbp/rclcpp-release.git
-    version: release/jazzy/rclcpp/28.1.17-3
+    version: release/jazzy/rclcpp/28.1.21-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-rclpy/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-rclpy/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rclpy
 _pkgname=rclpy
-pkgver=7.1.10
+pkgver=7.1.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rclpy
     uri: https://github.com/ros2-gbp/rclpy-release.git
-    version: release/jazzy/rclpy/7.1.10-1
+    version: release/jazzy/rclpy/7.1.11-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-rclpy/disable-flaky-test.patch
+++ b/v3.23/ros/jazzy/ros-jazzy-rclpy/disable-flaky-test.patch
@@ -1,5 +1,5 @@
 diff --git a/test/test_timer.py b/test/test_timer.py
-index 394f750..dbe095c 100644
+index 9ca7363..3ff1326 100644
 --- a/test/test_timer.py
 +++ b/test/test_timer.py
 @@ -101,54 +101,54 @@ def test_number_callbacks(period):
@@ -39,7 +39,7 @@ index 394f750..dbe095c 100644
 -                        executor.spin_once(timeout_sec=period / 10)
 -                    assert [] == callbacks
 -
--                    # Reenable timer and make sure callbacks are received again
+-                    # Re-enable timer and make sure callbacks are received again
 -                    timer.reset()
 -                    assert not timer.is_canceled()
 -                    begin_time = time.time()
@@ -87,7 +87,7 @@ index 394f750..dbe095c 100644
 +#                         executor.spin_once(timeout_sec=period / 10)
 +#                     assert [] == callbacks
 +#
-+#                     # Reenable timer and make sure callbacks are received again
++#                     # Re-enable timer and make sure callbacks are received again
 +#                     timer.reset()
 +#                     assert not timer.is_canceled()
 +#                     begin_time = time.time()

--- a/v3.23/ros/jazzy/ros-jazzy-rcpputils/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-rcpputils/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rcpputils
 _pkgname=rcpputils
-pkgver=2.11.3
+pkgver=2.11.4
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rcpputils
     uri: https://github.com/ros2-gbp/rcpputils-release.git
-    version: release/jazzy/rcpputils/2.11.3-1
+    version: release/jazzy/rcpputils/2.11.4-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-rcutils/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-rcutils/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rcutils
 _pkgname=rcutils
-pkgver=6.7.5
+pkgver=6.7.6
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rcutils
     uri: https://github.com/ros2-gbp/rcutils-release.git
-    version: release/jazzy/rcutils/6.7.5-1
+    version: release/jazzy/rcutils/6.7.6-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-rmw-fastrtps-cpp/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-rmw-fastrtps-cpp/APKBUILD
@@ -1,15 +1,15 @@
 pkgname=ros-jazzy-rmw-fastrtps-cpp
 _pkgname=rmw_fastrtps_cpp
-pkgver=8.4.3
-pkgrel=1
+pkgver=8.4.4
+pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
 arch="all"
 license="Apache License 2.0"
 
 depends="ros-jazzy-rcpputils ros-jazzy-rcutils ros-jazzy-rmw ros-jazzy-rmw-fastrtps-shared-cpp ros-jazzy-ros-workspace ros-jazzy-rosidl-dynamic-typesupport ros-jazzy-rosidl-dynamic-typesupport-fastrtps ros-jazzy-tracetools"
-makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-jazzy-ament-cmake ros-jazzy-ament-cmake-dev ros-jazzy-ament-cmake-gtest ros-jazzy-ament-cmake-gtest-dev ros-jazzy-ament-cmake-ros ros-jazzy-ament-cmake-ros-dev ros-jazzy-ament-lint-auto ros-jazzy-ament-lint-auto-dev ros-jazzy-ament-lint-common ros-jazzy-ament-lint-common-dev ros-jazzy-fastcdr ros-jazzy-fastcdr-dev ros-jazzy-fastrtps ros-jazzy-fastrtps-cmake-module ros-jazzy-fastrtps-cmake-module-dev ros-jazzy-fastrtps-dev ros-jazzy-osrf-testing-tools-cpp ros-jazzy-osrf-testing-tools-cpp-dev ros-jazzy-rcpputils ros-jazzy-rcpputils-dev ros-jazzy-rcutils ros-jazzy-rcutils-dev ros-jazzy-rmw ros-jazzy-rmw-dds-common ros-jazzy-rmw-dds-common-dev ros-jazzy-rmw-dev ros-jazzy-rmw-fastrtps-shared-cpp ros-jazzy-rmw-fastrtps-shared-cpp-dev ros-jazzy-ros-workspace-dev ros-jazzy-rosidl-dynamic-typesupport ros-jazzy-rosidl-dynamic-typesupport-dev ros-jazzy-rosidl-dynamic-typesupport-fastrtps ros-jazzy-rosidl-dynamic-typesupport-fastrtps-dev ros-jazzy-rosidl-runtime-c ros-jazzy-rosidl-runtime-c-dev ros-jazzy-rosidl-runtime-cpp ros-jazzy-rosidl-runtime-cpp-dev ros-jazzy-rosidl-typesupport-fastrtps-c ros-jazzy-rosidl-typesupport-fastrtps-c-dev ros-jazzy-rosidl-typesupport-fastrtps-cpp ros-jazzy-rosidl-typesupport-fastrtps-cpp-dev ros-jazzy-test-msgs ros-jazzy-test-msgs-dev ros-jazzy-tracetools ros-jazzy-tracetools-dev"
-depends_dev="ros-jazzy-ament-cmake ros-jazzy-ament-cmake-dev ros-jazzy-fastcdr ros-jazzy-fastcdr-dev ros-jazzy-fastrtps ros-jazzy-fastrtps-cmake-module ros-jazzy-fastrtps-cmake-module-dev ros-jazzy-fastrtps-dev ros-jazzy-rcpputils-dev ros-jazzy-rcutils ros-jazzy-rcutils-dev ros-jazzy-rmw ros-jazzy-rmw-dds-common ros-jazzy-rmw-dds-common-dev ros-jazzy-rmw-dev ros-jazzy-rmw-fastrtps-shared-cpp ros-jazzy-rmw-fastrtps-shared-cpp-dev ros-jazzy-ros-workspace-dev ros-jazzy-rosidl-dynamic-typesupport ros-jazzy-rosidl-dynamic-typesupport-dev ros-jazzy-rosidl-dynamic-typesupport-fastrtps-dev ros-jazzy-rosidl-runtime-c ros-jazzy-rosidl-runtime-c-dev ros-jazzy-rosidl-runtime-cpp ros-jazzy-rosidl-runtime-cpp-dev ros-jazzy-rosidl-typesupport-fastrtps-c ros-jazzy-rosidl-typesupport-fastrtps-c-dev ros-jazzy-rosidl-typesupport-fastrtps-cpp ros-jazzy-rosidl-typesupport-fastrtps-cpp-dev ros-jazzy-tracetools ros-jazzy-tracetools-dev"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-jazzy-ament-cmake-gtest ros-jazzy-ament-cmake-gtest-dev ros-jazzy-ament-cmake-ros ros-jazzy-ament-cmake-ros-dev ros-jazzy-ament-lint-auto ros-jazzy-ament-lint-auto-dev ros-jazzy-ament-lint-common ros-jazzy-ament-lint-common-dev ros-jazzy-fastcdr ros-jazzy-fastcdr-dev ros-jazzy-fastrtps ros-jazzy-fastrtps-cmake-module ros-jazzy-fastrtps-cmake-module-dev ros-jazzy-fastrtps-dev ros-jazzy-osrf-testing-tools-cpp ros-jazzy-osrf-testing-tools-cpp-dev ros-jazzy-rcpputils ros-jazzy-rcpputils-dev ros-jazzy-rcutils ros-jazzy-rcutils-dev ros-jazzy-rmw ros-jazzy-rmw-dds-common ros-jazzy-rmw-dds-common-dev ros-jazzy-rmw-dev ros-jazzy-rmw-fastrtps-shared-cpp ros-jazzy-rmw-fastrtps-shared-cpp-dev ros-jazzy-ros-workspace-dev ros-jazzy-rosidl-dynamic-typesupport ros-jazzy-rosidl-dynamic-typesupport-dev ros-jazzy-rosidl-dynamic-typesupport-fastrtps ros-jazzy-rosidl-dynamic-typesupport-fastrtps-dev ros-jazzy-rosidl-runtime-c ros-jazzy-rosidl-runtime-c-dev ros-jazzy-rosidl-runtime-cpp ros-jazzy-rosidl-runtime-cpp-dev ros-jazzy-rosidl-typesupport-fastrtps-c ros-jazzy-rosidl-typesupport-fastrtps-c-dev ros-jazzy-rosidl-typesupport-fastrtps-cpp ros-jazzy-rosidl-typesupport-fastrtps-cpp-dev ros-jazzy-test-msgs ros-jazzy-test-msgs-dev ros-jazzy-tracetools ros-jazzy-tracetools-dev"
+depends_dev="ros-jazzy-fastcdr ros-jazzy-fastcdr-dev ros-jazzy-fastrtps ros-jazzy-fastrtps-cmake-module ros-jazzy-fastrtps-cmake-module-dev ros-jazzy-fastrtps-dev ros-jazzy-rcpputils-dev ros-jazzy-rcutils ros-jazzy-rcutils-dev ros-jazzy-rmw ros-jazzy-rmw-dds-common ros-jazzy-rmw-dds-common-dev ros-jazzy-rmw-dev ros-jazzy-rmw-fastrtps-shared-cpp ros-jazzy-rmw-fastrtps-shared-cpp-dev ros-jazzy-ros-workspace-dev ros-jazzy-rosidl-dynamic-typesupport ros-jazzy-rosidl-dynamic-typesupport-dev ros-jazzy-rosidl-dynamic-typesupport-fastrtps-dev ros-jazzy-rosidl-runtime-c ros-jazzy-rosidl-runtime-c-dev ros-jazzy-rosidl-runtime-cpp ros-jazzy-rosidl-runtime-cpp-dev ros-jazzy-rosidl-typesupport-fastrtps-c ros-jazzy-rosidl-typesupport-fastrtps-c-dev ros-jazzy-rosidl-typesupport-fastrtps-cpp ros-jazzy-rosidl-typesupport-fastrtps-cpp-dev ros-jazzy-tracetools ros-jazzy-tracetools-dev"
 
 subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rmw_fastrtps_cpp
     uri: https://github.com/ros2-gbp/rmw_fastrtps-release.git
-    version: release/jazzy/rmw_fastrtps_cpp/8.4.3-1
+    version: release/jazzy/rmw_fastrtps_cpp/8.4.4-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-rmw-fastrtps-dynamic-cpp/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-rmw-fastrtps-dynamic-cpp/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rmw-fastrtps-dynamic-cpp
 _pkgname=rmw_fastrtps_dynamic_cpp
-pkgver=8.4.3
+pkgver=8.4.4
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -8,8 +8,8 @@ arch="all"
 license="Apache License 2.0"
 
 depends="ros-jazzy-ros-workspace"
-makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-jazzy-ament-cmake ros-jazzy-ament-cmake-dev ros-jazzy-ament-cmake-gtest ros-jazzy-ament-cmake-gtest-dev ros-jazzy-ament-cmake-ros ros-jazzy-ament-cmake-ros-dev ros-jazzy-ament-lint-auto ros-jazzy-ament-lint-auto-dev ros-jazzy-ament-lint-common ros-jazzy-ament-lint-common-dev ros-jazzy-fastcdr ros-jazzy-fastcdr-dev ros-jazzy-fastrtps ros-jazzy-fastrtps-cmake-module ros-jazzy-fastrtps-cmake-module-dev ros-jazzy-fastrtps-dev ros-jazzy-osrf-testing-tools-cpp ros-jazzy-osrf-testing-tools-cpp-dev ros-jazzy-rcpputils ros-jazzy-rcpputils-dev ros-jazzy-rcutils ros-jazzy-rcutils-dev ros-jazzy-rmw ros-jazzy-rmw-dds-common ros-jazzy-rmw-dds-common-dev ros-jazzy-rmw-dev ros-jazzy-rmw-fastrtps-shared-cpp ros-jazzy-rmw-fastrtps-shared-cpp-dev ros-jazzy-ros-workspace-dev ros-jazzy-rosidl-runtime-c ros-jazzy-rosidl-runtime-c-dev ros-jazzy-rosidl-typesupport-introspection-c ros-jazzy-rosidl-typesupport-introspection-c-dev ros-jazzy-rosidl-typesupport-introspection-cpp ros-jazzy-rosidl-typesupport-introspection-cpp-dev ros-jazzy-test-msgs ros-jazzy-test-msgs-dev"
-depends_dev="ros-jazzy-ament-cmake ros-jazzy-ament-cmake-dev ros-jazzy-fastcdr ros-jazzy-fastcdr-dev ros-jazzy-fastrtps ros-jazzy-fastrtps-cmake-module ros-jazzy-fastrtps-cmake-module-dev ros-jazzy-fastrtps-dev ros-jazzy-rcpputils ros-jazzy-rcpputils-dev ros-jazzy-rcutils ros-jazzy-rcutils-dev ros-jazzy-rmw ros-jazzy-rmw-dds-common ros-jazzy-rmw-dds-common-dev ros-jazzy-rmw-dev ros-jazzy-rmw-fastrtps-shared-cpp ros-jazzy-rmw-fastrtps-shared-cpp-dev ros-jazzy-ros-workspace-dev ros-jazzy-rosidl-runtime-c ros-jazzy-rosidl-runtime-c-dev ros-jazzy-rosidl-typesupport-introspection-c ros-jazzy-rosidl-typesupport-introspection-c-dev ros-jazzy-rosidl-typesupport-introspection-cpp ros-jazzy-rosidl-typesupport-introspection-cpp-dev"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-jazzy-ament-cmake-gtest ros-jazzy-ament-cmake-gtest-dev ros-jazzy-ament-cmake-ros ros-jazzy-ament-cmake-ros-dev ros-jazzy-ament-lint-auto ros-jazzy-ament-lint-auto-dev ros-jazzy-ament-lint-common ros-jazzy-ament-lint-common-dev ros-jazzy-fastcdr ros-jazzy-fastcdr-dev ros-jazzy-fastrtps ros-jazzy-fastrtps-cmake-module ros-jazzy-fastrtps-cmake-module-dev ros-jazzy-fastrtps-dev ros-jazzy-osrf-testing-tools-cpp ros-jazzy-osrf-testing-tools-cpp-dev ros-jazzy-rcpputils ros-jazzy-rcpputils-dev ros-jazzy-rcutils ros-jazzy-rcutils-dev ros-jazzy-rmw ros-jazzy-rmw-dds-common ros-jazzy-rmw-dds-common-dev ros-jazzy-rmw-dev ros-jazzy-rmw-fastrtps-shared-cpp ros-jazzy-rmw-fastrtps-shared-cpp-dev ros-jazzy-ros-workspace-dev ros-jazzy-rosidl-runtime-c ros-jazzy-rosidl-runtime-c-dev ros-jazzy-rosidl-typesupport-introspection-c ros-jazzy-rosidl-typesupport-introspection-c-dev ros-jazzy-rosidl-typesupport-introspection-cpp ros-jazzy-rosidl-typesupport-introspection-cpp-dev ros-jazzy-test-msgs ros-jazzy-test-msgs-dev"
+depends_dev="ros-jazzy-fastcdr ros-jazzy-fastcdr-dev ros-jazzy-fastrtps ros-jazzy-fastrtps-cmake-module ros-jazzy-fastrtps-cmake-module-dev ros-jazzy-fastrtps-dev ros-jazzy-rcpputils ros-jazzy-rcpputils-dev ros-jazzy-rcutils ros-jazzy-rcutils-dev ros-jazzy-rmw ros-jazzy-rmw-dds-common ros-jazzy-rmw-dds-common-dev ros-jazzy-rmw-dev ros-jazzy-rmw-fastrtps-shared-cpp ros-jazzy-rmw-fastrtps-shared-cpp-dev ros-jazzy-ros-workspace-dev ros-jazzy-rosidl-runtime-c ros-jazzy-rosidl-runtime-c-dev ros-jazzy-rosidl-typesupport-introspection-c ros-jazzy-rosidl-typesupport-introspection-c-dev ros-jazzy-rosidl-typesupport-introspection-cpp ros-jazzy-rosidl-typesupport-introspection-cpp-dev"
 
 subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rmw_fastrtps_dynamic_cpp
     uri: https://github.com/ros2-gbp/rmw_fastrtps-release.git
-    version: release/jazzy/rmw_fastrtps_dynamic_cpp/8.4.3-1
+    version: release/jazzy/rmw_fastrtps_dynamic_cpp/8.4.4-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-rmw-fastrtps-shared-cpp/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-rmw-fastrtps-shared-cpp/APKBUILD
@@ -1,15 +1,15 @@
 pkgname=ros-jazzy-rmw-fastrtps-shared-cpp
 _pkgname=rmw_fastrtps_shared_cpp
-pkgver=8.4.3
-pkgrel=1
+pkgver=8.4.4
+pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
 arch="all"
 license="Apache License 2.0"
 
 depends="ros-jazzy-ros-workspace"
-makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-jazzy-ament-cmake ros-jazzy-ament-cmake-dev ros-jazzy-ament-cmake-ros ros-jazzy-ament-cmake-ros-dev ros-jazzy-ament-lint-auto ros-jazzy-ament-lint-auto-dev ros-jazzy-ament-lint-common ros-jazzy-ament-lint-common-dev ros-jazzy-fastcdr ros-jazzy-fastcdr-dev ros-jazzy-fastrtps ros-jazzy-fastrtps-cmake-module ros-jazzy-fastrtps-cmake-module-dev ros-jazzy-fastrtps-dev ros-jazzy-osrf-testing-tools-cpp ros-jazzy-osrf-testing-tools-cpp-dev ros-jazzy-rcpputils ros-jazzy-rcpputils-dev ros-jazzy-rcutils ros-jazzy-rcutils-dev ros-jazzy-rmw ros-jazzy-rmw-dds-common ros-jazzy-rmw-dds-common-dev ros-jazzy-rmw-dev ros-jazzy-ros-workspace-dev ros-jazzy-rosidl-dynamic-typesupport ros-jazzy-rosidl-dynamic-typesupport-dev ros-jazzy-rosidl-runtime-c ros-jazzy-rosidl-runtime-c-dev ros-jazzy-rosidl-typesupport-introspection-c ros-jazzy-rosidl-typesupport-introspection-c-dev ros-jazzy-rosidl-typesupport-introspection-cpp ros-jazzy-rosidl-typesupport-introspection-cpp-dev ros-jazzy-tracetools ros-jazzy-tracetools-dev"
-depends_dev="ros-jazzy-ament-cmake ros-jazzy-ament-cmake-dev ros-jazzy-fastcdr ros-jazzy-fastcdr-dev ros-jazzy-fastrtps ros-jazzy-fastrtps-cmake-module ros-jazzy-fastrtps-cmake-module-dev ros-jazzy-fastrtps-dev ros-jazzy-rcpputils ros-jazzy-rcpputils-dev ros-jazzy-rcutils ros-jazzy-rcutils-dev ros-jazzy-rmw ros-jazzy-rmw-dds-common ros-jazzy-rmw-dds-common-dev ros-jazzy-rmw-dev ros-jazzy-ros-workspace-dev ros-jazzy-rosidl-dynamic-typesupport ros-jazzy-rosidl-dynamic-typesupport-dev ros-jazzy-rosidl-typesupport-introspection-c ros-jazzy-rosidl-typesupport-introspection-c-dev ros-jazzy-rosidl-typesupport-introspection-cpp ros-jazzy-rosidl-typesupport-introspection-cpp-dev ros-jazzy-tracetools ros-jazzy-tracetools-dev"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-jazzy-ament-cmake-ros ros-jazzy-ament-cmake-ros-dev ros-jazzy-ament-lint-auto ros-jazzy-ament-lint-auto-dev ros-jazzy-ament-lint-common ros-jazzy-ament-lint-common-dev ros-jazzy-fastcdr ros-jazzy-fastcdr-dev ros-jazzy-fastrtps ros-jazzy-fastrtps-cmake-module ros-jazzy-fastrtps-cmake-module-dev ros-jazzy-fastrtps-dev ros-jazzy-osrf-testing-tools-cpp ros-jazzy-osrf-testing-tools-cpp-dev ros-jazzy-rcpputils ros-jazzy-rcpputils-dev ros-jazzy-rcutils ros-jazzy-rcutils-dev ros-jazzy-rmw ros-jazzy-rmw-dds-common ros-jazzy-rmw-dds-common-dev ros-jazzy-rmw-dev ros-jazzy-ros-workspace-dev ros-jazzy-rosidl-dynamic-typesupport ros-jazzy-rosidl-dynamic-typesupport-dev ros-jazzy-rosidl-runtime-c ros-jazzy-rosidl-runtime-c-dev ros-jazzy-rosidl-typesupport-introspection-c ros-jazzy-rosidl-typesupport-introspection-c-dev ros-jazzy-rosidl-typesupport-introspection-cpp ros-jazzy-rosidl-typesupport-introspection-cpp-dev ros-jazzy-tracetools ros-jazzy-tracetools-dev"
+depends_dev="ros-jazzy-fastcdr ros-jazzy-fastcdr-dev ros-jazzy-fastrtps ros-jazzy-fastrtps-cmake-module ros-jazzy-fastrtps-cmake-module-dev ros-jazzy-fastrtps-dev ros-jazzy-rcpputils ros-jazzy-rcpputils-dev ros-jazzy-rcutils ros-jazzy-rcutils-dev ros-jazzy-rmw ros-jazzy-rmw-dds-common ros-jazzy-rmw-dds-common-dev ros-jazzy-rmw-dev ros-jazzy-ros-workspace-dev ros-jazzy-rosidl-dynamic-typesupport ros-jazzy-rosidl-dynamic-typesupport-dev ros-jazzy-rosidl-typesupport-introspection-c ros-jazzy-rosidl-typesupport-introspection-c-dev ros-jazzy-rosidl-typesupport-introspection-cpp ros-jazzy-rosidl-typesupport-introspection-cpp-dev ros-jazzy-tracetools ros-jazzy-tracetools-dev"
 
 subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rmw_fastrtps_shared_cpp
     uri: https://github.com/ros2-gbp/rmw_fastrtps-release.git
-    version: release/jazzy/rmw_fastrtps_shared_cpp/8.4.3-1
+    version: release/jazzy/rmw_fastrtps_shared_cpp/8.4.4-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-robot-state-publisher/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-robot-state-publisher/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-robot-state-publisher
 _pkgname=robot_state_publisher
-pkgver=3.3.3
+pkgver=3.3.4
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: robot_state_publisher
     uri: https://github.com/ros2-gbp/robot_state_publisher-release.git
-    version: release/jazzy/robot_state_publisher/3.3.3-3
+    version: release/jazzy/robot_state_publisher/3.3.4-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-ros-testing/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-ros-testing/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-ros-testing
 _pkgname=ros_testing
-pkgver=0.6.0
+pkgver=0.6.1
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ros_testing
     uri: https://github.com/ros2-gbp/ros_testing-release.git
-    version: release/jazzy/ros_testing/0.6.0-3
+    version: release/jazzy/ros_testing/0.6.1-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-ros2action/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-ros2action/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-ros2action
 _pkgname=ros2action
-pkgver=0.32.9
+pkgver=0.32.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ros2action
     uri: https://github.com/ros2-gbp/ros2cli-release.git
-    version: release/jazzy/ros2action/0.32.9-1
+    version: release/jazzy/ros2action/0.32.11-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-ros2bag/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-ros2bag/APKBUILD
@@ -1,15 +1,15 @@
 pkgname=ros-jazzy-ros2bag
 _pkgname=ros2bag
-pkgver=0.26.9
+pkgver=0.26.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
 arch="all"
 license="Apache License 2.0"
 
-depends="py3-yaml ros-jazzy-ament-index-python ros-jazzy-rclpy ros-jazzy-ros-workspace ros-jazzy-ros2cli ros-jazzy-rosbag2-py"
+depends="py3-yaml ros-jazzy-ament-index-python ros-jazzy-rclpy ros-jazzy-ros-workspace ros-jazzy-ros2cli ros-jazzy-rosbag2-py ros-jazzy-rosbag2-storage-default-plugins"
 makedepends="chrpath py3-pytest7 py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-jazzy-ament-copyright ros-jazzy-ament-copyright-dev ros-jazzy-ament-flake8 ros-jazzy-ament-flake8-dev ros-jazzy-ament-index-python-dev ros-jazzy-ament-pep257 ros-jazzy-ament-pep257-dev ros-jazzy-launch-testing ros-jazzy-launch-testing-dev ros-jazzy-launch-testing-ros ros-jazzy-launch-testing-ros-dev ros-jazzy-rclpy-dev ros-jazzy-ros-workspace-dev ros-jazzy-ros2cli-dev ros-jazzy-rosbag2-py-dev ros-jazzy-rosbag2-storage-default-plugins ros-jazzy-rosbag2-storage-default-plugins-dev ros-jazzy-rosbag2-test-common ros-jazzy-rosbag2-test-common-dev"
-depends_dev="ros-jazzy-ament-index-python-dev ros-jazzy-rclpy-dev ros-jazzy-ros-workspace-dev ros-jazzy-ros2cli-dev ros-jazzy-rosbag2-py-dev"
+depends_dev="ros-jazzy-ament-index-python-dev ros-jazzy-rclpy-dev ros-jazzy-ros-workspace-dev ros-jazzy-ros2cli-dev ros-jazzy-rosbag2-py-dev ros-jazzy-rosbag2-storage-default-plugins-dev"
 
 subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ros2bag
     uri: https://github.com/ros2-gbp/rosbag2-release.git
-    version: release/jazzy/ros2bag/0.26.9-1
+    version: release/jazzy/ros2bag/0.26.11-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-ros2cli-test-interfaces/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-ros2cli-test-interfaces/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-ros2cli-test-interfaces
 _pkgname=ros2cli_test_interfaces
-pkgver=0.32.9
+pkgver=0.32.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ros2cli_test_interfaces
     uri: https://github.com/ros2-gbp/ros2cli-release.git
-    version: release/jazzy/ros2cli_test_interfaces/0.32.9-1
+    version: release/jazzy/ros2cli_test_interfaces/0.32.11-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-ros2cli/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-ros2cli/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-ros2cli
 _pkgname=ros2cli
-pkgver=0.32.9
+pkgver=0.32.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ros2cli
     uri: https://github.com/ros2-gbp/ros2cli-release.git
-    version: release/jazzy/ros2cli/0.32.9-1
+    version: release/jazzy/ros2cli/0.32.11-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-ros2component/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-ros2component/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-ros2component
 _pkgname=ros2component
-pkgver=0.32.9
+pkgver=0.32.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ros2component
     uri: https://github.com/ros2-gbp/ros2cli-release.git
-    version: release/jazzy/ros2component/0.32.9-1
+    version: release/jazzy/ros2component/0.32.11-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-ros2doctor/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-ros2doctor/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-ros2doctor
 _pkgname=ros2doctor
-pkgver=0.32.9
+pkgver=0.32.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ros2doctor
     uri: https://github.com/ros2-gbp/ros2cli-release.git
-    version: release/jazzy/ros2doctor/0.32.9-1
+    version: release/jazzy/ros2doctor/0.32.11-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-ros2interface/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-ros2interface/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-ros2interface
 _pkgname=ros2interface
-pkgver=0.32.9
+pkgver=0.32.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ros2interface
     uri: https://github.com/ros2-gbp/ros2cli-release.git
-    version: release/jazzy/ros2interface/0.32.9-1
+    version: release/jazzy/ros2interface/0.32.11-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-ros2launch/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-ros2launch/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-ros2launch
 _pkgname=ros2launch
-pkgver=0.26.11
+pkgver=0.26.12
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ros2launch
     uri: https://github.com/ros2-gbp/launch_ros-release.git
-    version: release/jazzy/ros2launch/0.26.11-1
+    version: release/jazzy/ros2launch/0.26.12-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-ros2lifecycle-test-fixtures/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-ros2lifecycle-test-fixtures/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-ros2lifecycle-test-fixtures
 _pkgname=ros2lifecycle_test_fixtures
-pkgver=0.32.9
+pkgver=0.32.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ros2lifecycle_test_fixtures
     uri: https://github.com/ros2-gbp/ros2cli-release.git
-    version: release/jazzy/ros2lifecycle_test_fixtures/0.32.9-1
+    version: release/jazzy/ros2lifecycle_test_fixtures/0.32.11-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-ros2lifecycle/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-ros2lifecycle/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-ros2lifecycle
 _pkgname=ros2lifecycle
-pkgver=0.32.9
+pkgver=0.32.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ros2lifecycle
     uri: https://github.com/ros2-gbp/ros2cli-release.git
-    version: release/jazzy/ros2lifecycle/0.32.9-1
+    version: release/jazzy/ros2lifecycle/0.32.11-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-ros2multicast/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-ros2multicast/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-ros2multicast
 _pkgname=ros2multicast
-pkgver=0.32.9
+pkgver=0.32.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ros2multicast
     uri: https://github.com/ros2-gbp/ros2cli-release.git
-    version: release/jazzy/ros2multicast/0.32.9-1
+    version: release/jazzy/ros2multicast/0.32.11-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-ros2node/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-ros2node/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-ros2node
 _pkgname=ros2node
-pkgver=0.32.9
+pkgver=0.32.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ros2node
     uri: https://github.com/ros2-gbp/ros2cli-release.git
-    version: release/jazzy/ros2node/0.32.9-1
+    version: release/jazzy/ros2node/0.32.11-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-ros2param/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-ros2param/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-ros2param
 _pkgname=ros2param
-pkgver=0.32.9
+pkgver=0.32.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ros2param
     uri: https://github.com/ros2-gbp/ros2cli-release.git
-    version: release/jazzy/ros2param/0.32.9-1
+    version: release/jazzy/ros2param/0.32.11-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-ros2pkg/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-ros2pkg/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-ros2pkg
 _pkgname=ros2pkg
-pkgver=0.32.9
+pkgver=0.32.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ros2pkg
     uri: https://github.com/ros2-gbp/ros2cli-release.git
-    version: release/jazzy/ros2pkg/0.32.9-1
+    version: release/jazzy/ros2pkg/0.32.11-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-ros2plugin/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-ros2plugin/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-ros2plugin
 _pkgname=ros2plugin
-pkgver=5.4.4
+pkgver=5.4.5
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ros2plugin
     uri: https://github.com/ros2-gbp/pluginlib-release.git
-    version: release/jazzy/ros2plugin/5.4.4-1
+    version: release/jazzy/ros2plugin/5.4.5-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-ros2run/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-ros2run/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-ros2run
 _pkgname=ros2run
-pkgver=0.32.9
+pkgver=0.32.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ros2run
     uri: https://github.com/ros2-gbp/ros2cli-release.git
-    version: release/jazzy/ros2run/0.32.9-1
+    version: release/jazzy/ros2run/0.32.11-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-ros2service/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-ros2service/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-ros2service
 _pkgname=ros2service
-pkgver=0.32.9
+pkgver=0.32.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ros2service
     uri: https://github.com/ros2-gbp/ros2cli-release.git
-    version: release/jazzy/ros2service/0.32.9-1
+    version: release/jazzy/ros2service/0.32.11-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-ros2test/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-ros2test/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-ros2test
 _pkgname=ros2test
-pkgver=0.6.0
+pkgver=0.6.1
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ros2test
     uri: https://github.com/ros2-gbp/ros_testing-release.git
-    version: release/jazzy/ros2test/0.6.0-3
+    version: release/jazzy/ros2test/0.6.1-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-ros2topic/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-ros2topic/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-ros2topic
 _pkgname=ros2topic
-pkgver=0.32.9
+pkgver=0.32.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: ros2topic
     uri: https://github.com/ros2-gbp/ros2cli-release.git
-    version: release/jazzy/ros2topic/0.32.9-1
+    version: release/jazzy/ros2topic/0.32.11-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-rosbag2-compression-zstd/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-rosbag2-compression-zstd/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rosbag2-compression-zstd
 _pkgname=rosbag2_compression_zstd
-pkgver=0.26.9
+pkgver=0.26.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rosbag2_compression_zstd
     uri: https://github.com/ros2-gbp/rosbag2-release.git
-    version: release/jazzy/rosbag2_compression_zstd/0.26.9-1
+    version: release/jazzy/rosbag2_compression_zstd/0.26.11-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-rosbag2-compression/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-rosbag2-compression/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rosbag2-compression
 _pkgname=rosbag2_compression
-pkgver=0.26.9
+pkgver=0.26.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rosbag2_compression
     uri: https://github.com/ros2-gbp/rosbag2-release.git
-    version: release/jazzy/rosbag2_compression/0.26.9-1
+    version: release/jazzy/rosbag2_compression/0.26.11-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-rosbag2-cpp/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-rosbag2-cpp/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rosbag2-cpp
 _pkgname=rosbag2_cpp
-pkgver=0.26.9
+pkgver=0.26.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rosbag2_cpp
     uri: https://github.com/ros2-gbp/rosbag2-release.git
-    version: release/jazzy/rosbag2_cpp/0.26.9-1
+    version: release/jazzy/rosbag2_cpp/0.26.11-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-rosbag2-interfaces/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-rosbag2-interfaces/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rosbag2-interfaces
 _pkgname=rosbag2_interfaces
-pkgver=0.26.9
+pkgver=0.26.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rosbag2_interfaces
     uri: https://github.com/ros2-gbp/rosbag2-release.git
-    version: release/jazzy/rosbag2_interfaces/0.26.9-1
+    version: release/jazzy/rosbag2_interfaces/0.26.11-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-rosbag2-py/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-rosbag2-py/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rosbag2-py
 _pkgname=rosbag2_py
-pkgver=0.26.9
+pkgver=0.26.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rosbag2_py
     uri: https://github.com/ros2-gbp/rosbag2-release.git
-    version: release/jazzy/rosbag2_py/0.26.9-1
+    version: release/jazzy/rosbag2_py/0.26.11-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-rosbag2-storage-default-plugins/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-rosbag2-storage-default-plugins/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rosbag2-storage-default-plugins
 _pkgname=rosbag2_storage_default_plugins
-pkgver=0.26.9
+pkgver=0.26.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rosbag2_storage_default_plugins
     uri: https://github.com/ros2-gbp/rosbag2-release.git
-    version: release/jazzy/rosbag2_storage_default_plugins/0.26.9-1
+    version: release/jazzy/rosbag2_storage_default_plugins/0.26.11-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-rosbag2-storage-mcap/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-rosbag2-storage-mcap/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rosbag2-storage-mcap
 _pkgname=rosbag2_storage_mcap
-pkgver=0.26.9
+pkgver=0.26.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rosbag2_storage_mcap
     uri: https://github.com/ros2-gbp/rosbag2-release.git
-    version: release/jazzy/rosbag2_storage_mcap/0.26.9-1
+    version: release/jazzy/rosbag2_storage_mcap/0.26.11-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-rosbag2-storage-sqlite3/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-rosbag2-storage-sqlite3/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rosbag2-storage-sqlite3
 _pkgname=rosbag2_storage_sqlite3
-pkgver=0.26.9
+pkgver=0.26.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rosbag2_storage_sqlite3
     uri: https://github.com/ros2-gbp/rosbag2-release.git
-    version: release/jazzy/rosbag2_storage_sqlite3/0.26.9-1
+    version: release/jazzy/rosbag2_storage_sqlite3/0.26.11-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-rosbag2-storage/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-rosbag2-storage/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rosbag2-storage
 _pkgname=rosbag2_storage
-pkgver=0.26.9
+pkgver=0.26.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rosbag2_storage
     uri: https://github.com/ros2-gbp/rosbag2-release.git
-    version: release/jazzy/rosbag2_storage/0.26.9-1
+    version: release/jazzy/rosbag2_storage/0.26.11-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-rosbag2-test-common/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-rosbag2-test-common/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rosbag2-test-common
 _pkgname=rosbag2_test_common
-pkgver=0.26.9
+pkgver=0.26.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rosbag2_test_common
     uri: https://github.com/ros2-gbp/rosbag2-release.git
-    version: release/jazzy/rosbag2_test_common/0.26.9-1
+    version: release/jazzy/rosbag2_test_common/0.26.11-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-rosbag2-test-msgdefs/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-rosbag2-test-msgdefs/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rosbag2-test-msgdefs
 _pkgname=rosbag2_test_msgdefs
-pkgver=0.26.9
+pkgver=0.26.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rosbag2_test_msgdefs
     uri: https://github.com/ros2-gbp/rosbag2-release.git
-    version: release/jazzy/rosbag2_test_msgdefs/0.26.9-1
+    version: release/jazzy/rosbag2_test_msgdefs/0.26.11-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-rosbag2-tests/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-rosbag2-tests/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rosbag2-tests
 _pkgname=rosbag2_tests
-pkgver=0.26.9
+pkgver=0.26.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rosbag2_tests
     uri: https://github.com/ros2-gbp/rosbag2-release.git
-    version: release/jazzy/rosbag2_tests/0.26.9-1
+    version: release/jazzy/rosbag2_tests/0.26.11-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-rosbag2-transport/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-rosbag2-transport/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rosbag2-transport
 _pkgname=rosbag2_transport
-pkgver=0.26.9
+pkgver=0.26.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rosbag2_transport
     uri: https://github.com/ros2-gbp/rosbag2-release.git
-    version: release/jazzy/rosbag2_transport/0.26.9-1
+    version: release/jazzy/rosbag2_transport/0.26.11-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-rosbag2/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-rosbag2/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rosbag2
 _pkgname=rosbag2
-pkgver=0.26.9
+pkgver=0.26.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rosbag2
     uri: https://github.com/ros2-gbp/rosbag2-release.git
-    version: release/jazzy/rosbag2/0.26.9-1
+    version: release/jazzy/rosbag2/0.26.11-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-rosgraph-msgs/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-rosgraph-msgs/APKBUILD
@@ -1,15 +1,15 @@
 pkgname=ros-jazzy-rosgraph-msgs
 _pkgname=rosgraph_msgs
-pkgver=2.0.3
+pkgver=2.0.4
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
 arch="all"
 license="Apache License 2.0"
 
-depends="ros-jazzy-builtin-interfaces ros-jazzy-ros-workspace ros-jazzy-rosidl-default-runtime"
-makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-jazzy-ament-cmake ros-jazzy-ament-cmake-dev ros-jazzy-ament-lint-common ros-jazzy-ament-lint-common-dev ros-jazzy-builtin-interfaces ros-jazzy-builtin-interfaces-dev ros-jazzy-ros-workspace-dev ros-jazzy-rosidl-default-generators ros-jazzy-rosidl-default-generators-dev ros-jazzy-rosidl-default-runtime-dev"
-depends_dev="ros-jazzy-builtin-interfaces-dev ros-jazzy-ros-workspace-dev ros-jazzy-rosidl-default-runtime-dev"
+depends="ros-jazzy-builtin-interfaces ros-jazzy-rcl-interfaces ros-jazzy-ros-workspace ros-jazzy-rosidl-default-runtime"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-jazzy-ament-cmake ros-jazzy-ament-cmake-dev ros-jazzy-ament-lint-common ros-jazzy-ament-lint-common-dev ros-jazzy-builtin-interfaces ros-jazzy-builtin-interfaces-dev ros-jazzy-rcl-interfaces ros-jazzy-rcl-interfaces-dev ros-jazzy-ros-workspace-dev ros-jazzy-rosidl-default-generators ros-jazzy-rosidl-default-generators-dev ros-jazzy-rosidl-default-runtime-dev"
+depends_dev="ros-jazzy-builtin-interfaces-dev ros-jazzy-rcl-interfaces-dev ros-jazzy-ros-workspace-dev ros-jazzy-rosidl-default-runtime-dev"
 
 subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rosgraph_msgs
     uri: https://github.com/ros2-gbp/rcl_interfaces-release.git
-    version: release/jazzy/rosgraph_msgs/2.0.3-1
+    version: release/jazzy/rosgraph_msgs/2.0.4-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-rosidl-adapter/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-rosidl-adapter/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rosidl-adapter
 _pkgname=rosidl_adapter
-pkgver=4.6.7
+pkgver=4.6.9
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rosidl_adapter
     uri: https://github.com/ros2-gbp/rosidl-release.git
-    version: release/jazzy/rosidl_adapter/4.6.7-1
+    version: release/jazzy/rosidl_adapter/4.6.9-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-rosidl-cli/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-rosidl-cli/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rosidl-cli
 _pkgname=rosidl_cli
-pkgver=4.6.7
+pkgver=4.6.9
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rosidl_cli
     uri: https://github.com/ros2-gbp/rosidl-release.git
-    version: release/jazzy/rosidl_cli/4.6.7-1
+    version: release/jazzy/rosidl_cli/4.6.9-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-rosidl-cmake/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-rosidl-cmake/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rosidl-cmake
 _pkgname=rosidl_cmake
-pkgver=4.6.7
+pkgver=4.6.9
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rosidl_cmake
     uri: https://github.com/ros2-gbp/rosidl-release.git
-    version: release/jazzy/rosidl_cmake/4.6.7-1
+    version: release/jazzy/rosidl_cmake/4.6.9-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-rosidl-default-generators/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-rosidl-default-generators/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rosidl-default-generators
 _pkgname=rosidl_default_generators
-pkgver=1.6.0
+pkgver=1.6.1
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rosidl_default_generators
     uri: https://github.com/ros2-gbp/rosidl_defaults-release.git
-    version: release/jazzy/rosidl_default_generators/1.6.0-3
+    version: release/jazzy/rosidl_default_generators/1.6.1-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-rosidl-default-runtime/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-rosidl-default-runtime/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rosidl-default-runtime
 _pkgname=rosidl_default_runtime
-pkgver=1.6.0
+pkgver=1.6.1
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rosidl_default_runtime
     uri: https://github.com/ros2-gbp/rosidl_defaults-release.git
-    version: release/jazzy/rosidl_default_runtime/1.6.0-3
+    version: release/jazzy/rosidl_default_runtime/1.6.1-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-rosidl-generator-c/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-rosidl-generator-c/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rosidl-generator-c
 _pkgname=rosidl_generator_c
-pkgver=4.6.7
+pkgver=4.6.9
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rosidl_generator_c
     uri: https://github.com/ros2-gbp/rosidl-release.git
-    version: release/jazzy/rosidl_generator_c/4.6.7-1
+    version: release/jazzy/rosidl_generator_c/4.6.9-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-rosidl-generator-cpp/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-rosidl-generator-cpp/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rosidl-generator-cpp
 _pkgname=rosidl_generator_cpp
-pkgver=4.6.7
+pkgver=4.6.9
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rosidl_generator_cpp
     uri: https://github.com/ros2-gbp/rosidl-release.git
-    version: release/jazzy/rosidl_generator_cpp/4.6.7-1
+    version: release/jazzy/rosidl_generator_cpp/4.6.9-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-rosidl-generator-rs/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-rosidl-generator-rs/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rosidl-generator-rs
 _pkgname=rosidl_generator_rs
-pkgver=0.4.11
+pkgver=0.4.12
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rosidl_generator_rs
     uri: https://github.com/ros2-gbp/rosidl_rust-release.git
-    version: release/jazzy/rosidl_generator_rs/0.4.11-1
+    version: release/jazzy/rosidl_generator_rs/0.4.12-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-rosidl-generator-type-description/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-rosidl-generator-type-description/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rosidl-generator-type-description
 _pkgname=rosidl_generator_type_description
-pkgver=4.6.7
+pkgver=4.6.9
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rosidl_generator_type_description
     uri: https://github.com/ros2-gbp/rosidl-release.git
-    version: release/jazzy/rosidl_generator_type_description/4.6.7-1
+    version: release/jazzy/rosidl_generator_type_description/4.6.9-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-rosidl-parser/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-rosidl-parser/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rosidl-parser
 _pkgname=rosidl_parser
-pkgver=4.6.7
+pkgver=4.6.9
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rosidl_parser
     uri: https://github.com/ros2-gbp/rosidl-release.git
-    version: release/jazzy/rosidl_parser/4.6.7-1
+    version: release/jazzy/rosidl_parser/4.6.9-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-rosidl-pycommon/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-rosidl-pycommon/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rosidl-pycommon
 _pkgname=rosidl_pycommon
-pkgver=4.6.7
+pkgver=4.6.9
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rosidl_pycommon
     uri: https://github.com/ros2-gbp/rosidl-release.git
-    version: release/jazzy/rosidl_pycommon/4.6.7-1
+    version: release/jazzy/rosidl_pycommon/4.6.9-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-rosidl-runtime-c/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-rosidl-runtime-c/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rosidl-runtime-c
 _pkgname=rosidl_runtime_c
-pkgver=4.6.7
+pkgver=4.6.9
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rosidl_runtime_c
     uri: https://github.com/ros2-gbp/rosidl-release.git
-    version: release/jazzy/rosidl_runtime_c/4.6.7-1
+    version: release/jazzy/rosidl_runtime_c/4.6.9-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-rosidl-runtime-cpp/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-rosidl-runtime-cpp/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rosidl-runtime-cpp
 _pkgname=rosidl_runtime_cpp
-pkgver=4.6.7
+pkgver=4.6.9
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rosidl_runtime_cpp
     uri: https://github.com/ros2-gbp/rosidl-release.git
-    version: release/jazzy/rosidl_runtime_cpp/4.6.7-1
+    version: release/jazzy/rosidl_runtime_cpp/4.6.9-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-rosidl-runtime-py/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-rosidl-runtime-py/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rosidl-runtime-py
 _pkgname=rosidl_runtime_py
-pkgver=0.13.1
+pkgver=0.13.2
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rosidl_runtime_py
     uri: https://github.com/ros2-gbp/rosidl_runtime_py-release.git
-    version: release/jazzy/rosidl_runtime_py/0.13.1-2
+    version: release/jazzy/rosidl_runtime_py/0.13.2-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-rosidl-typesupport-c/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-rosidl-typesupport-c/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rosidl-typesupport-c
 _pkgname=rosidl_typesupport_c
-pkgver=3.2.2
+pkgver=3.2.3
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rosidl_typesupport_c
     uri: https://github.com/ros2-gbp/rosidl_typesupport-release.git
-    version: release/jazzy/rosidl_typesupport_c/3.2.2-1
+    version: release/jazzy/rosidl_typesupport_c/3.2.3-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-rosidl-typesupport-cpp/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-rosidl-typesupport-cpp/APKBUILD
@@ -1,7 +1,7 @@
 pkgname=ros-jazzy-rosidl-typesupport-cpp
 _pkgname=rosidl_typesupport_cpp
-pkgver=3.2.2
-pkgrel=1
+pkgver=3.2.3
+pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
 arch="all"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rosidl_typesupport_cpp
     uri: https://github.com/ros2-gbp/rosidl_typesupport-release.git
-    version: release/jazzy/rosidl_typesupport_cpp/3.2.2-1
+    version: release/jazzy/rosidl_typesupport_cpp/3.2.3-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-rosidl-typesupport-fastrtps-c/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-rosidl-typesupport-fastrtps-c/APKBUILD
@@ -1,7 +1,7 @@
 pkgname=ros-jazzy-rosidl-typesupport-fastrtps-c
 _pkgname=rosidl_typesupport_fastrtps_c
-pkgver=3.6.3
-pkgrel=1
+pkgver=3.6.4
+pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
 arch="all"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rosidl_typesupport_fastrtps_c
     uri: https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release.git
-    version: release/jazzy/rosidl_typesupport_fastrtps_c/3.6.3-1
+    version: release/jazzy/rosidl_typesupport_fastrtps_c/3.6.4-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-rosidl-typesupport-fastrtps-cpp/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-rosidl-typesupport-fastrtps-cpp/APKBUILD
@@ -1,7 +1,7 @@
 pkgname=ros-jazzy-rosidl-typesupport-fastrtps-cpp
 _pkgname=rosidl_typesupport_fastrtps_cpp
-pkgver=3.6.3
-pkgrel=1
+pkgver=3.6.4
+pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
 arch="all"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rosidl_typesupport_fastrtps_cpp
     uri: https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release.git
-    version: release/jazzy/rosidl_typesupport_fastrtps_cpp/3.6.3-1
+    version: release/jazzy/rosidl_typesupport_fastrtps_cpp/3.6.4-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-rosidl-typesupport-interface/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-rosidl-typesupport-interface/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rosidl-typesupport-interface
 _pkgname=rosidl_typesupport_interface
-pkgver=4.6.7
+pkgver=4.6.9
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rosidl_typesupport_interface
     uri: https://github.com/ros2-gbp/rosidl-release.git
-    version: release/jazzy/rosidl_typesupport_interface/4.6.7-1
+    version: release/jazzy/rosidl_typesupport_interface/4.6.9-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-rosidl-typesupport-introspection-c/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-rosidl-typesupport-introspection-c/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rosidl-typesupport-introspection-c
 _pkgname=rosidl_typesupport_introspection_c
-pkgver=4.6.7
+pkgver=4.6.9
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rosidl_typesupport_introspection_c
     uri: https://github.com/ros2-gbp/rosidl-release.git
-    version: release/jazzy/rosidl_typesupport_introspection_c/4.6.7-1
+    version: release/jazzy/rosidl_typesupport_introspection_c/4.6.9-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-rosidl-typesupport-introspection-cpp/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-rosidl-typesupport-introspection-cpp/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rosidl-typesupport-introspection-cpp
 _pkgname=rosidl_typesupport_introspection_cpp
-pkgver=4.6.7
+pkgver=4.6.9
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rosidl_typesupport_introspection_cpp
     uri: https://github.com/ros2-gbp/rosidl-release.git
-    version: release/jazzy/rosidl_typesupport_introspection_cpp/4.6.7-1
+    version: release/jazzy/rosidl_typesupport_introspection_cpp/4.6.9-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-rqt-gui-cpp/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-rqt-gui-cpp/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rqt-gui-cpp
 _pkgname=rqt_gui_cpp
-pkgver=1.6.3
+pkgver=1.6.4
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="http://ros.org/wiki/rqt_gui_cpp"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rqt_gui_cpp
     uri: https://github.com/ros2-gbp/rqt-release.git
-    version: release/jazzy/rqt_gui_cpp/1.6.3-1
+    version: release/jazzy/rqt_gui_cpp/1.6.4-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-rqt-gui-py/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-rqt-gui-py/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rqt-gui-py
 _pkgname=rqt_gui_py
-pkgver=1.6.3
+pkgver=1.6.4
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="http://ros.org/wiki/rqt_gui_py"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rqt_gui_py
     uri: https://github.com/ros2-gbp/rqt-release.git
-    version: release/jazzy/rqt_gui_py/1.6.3-1
+    version: release/jazzy/rqt_gui_py/1.6.4-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-rqt-gui/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-rqt-gui/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rqt-gui
 _pkgname=rqt_gui
-pkgver=1.6.3
+pkgver=1.6.4
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="http://ros.org/wiki/rqt_gui"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rqt_gui
     uri: https://github.com/ros2-gbp/rqt-release.git
-    version: release/jazzy/rqt_gui/1.6.3-1
+    version: release/jazzy/rqt_gui/1.6.4-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-rqt-msg/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-rqt-msg/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rqt-msg
 _pkgname=rqt_msg
-pkgver=1.5.2
+pkgver=1.5.3
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="http://wiki.ros.org/rqt_msg"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rqt_msg
     uri: https://github.com/ros2-gbp/rqt_msg-release.git
-    version: release/jazzy/rqt_msg/1.5.2-1
+    version: release/jazzy/rqt_msg/1.5.3-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-rqt-py-common/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-rqt-py-common/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rqt-py-common
 _pkgname=rqt_py_common
-pkgver=1.6.3
+pkgver=1.6.4
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="http://ros.org/wiki/rqt_py_common"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rqt_py_common
     uri: https://github.com/ros2-gbp/rqt-release.git
-    version: release/jazzy/rqt_py_common/1.6.3-1
+    version: release/jazzy/rqt_py_common/1.6.4-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-rviz-assimp-vendor/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-rviz-assimp-vendor/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rviz-assimp-vendor
 _pkgname=rviz_assimp_vendor
-pkgver=14.1.20
+pkgver=14.1.23
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="http://assimp.sourceforge.net/index.html"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rviz_assimp_vendor
     uri: https://github.com/ros2-gbp/rviz-release.git
-    version: release/jazzy/rviz_assimp_vendor/14.1.20-2
+    version: release/jazzy/rviz_assimp_vendor/14.1.23-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-rviz-common/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-rviz-common/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rviz-common
 _pkgname=rviz_common
-pkgver=14.1.20
+pkgver=14.1.23
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://github.com/ros2/rviz/blob/ros2/README.md"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rviz_common
     uri: https://github.com/ros2-gbp/rviz-release.git
-    version: release/jazzy/rviz_common/14.1.20-2
+    version: release/jazzy/rviz_common/14.1.23-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-rviz-default-plugins/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-rviz-default-plugins/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rviz-default-plugins
 _pkgname=rviz_default_plugins
-pkgver=14.1.20
+pkgver=14.1.23
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://github.com/ros2/rviz/blob/ros2/README.md"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rviz_default_plugins
     uri: https://github.com/ros2-gbp/rviz-release.git
-    version: release/jazzy/rviz_default_plugins/14.1.20-2
+    version: release/jazzy/rviz_default_plugins/14.1.23-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-rviz-ogre-vendor/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-rviz-ogre-vendor/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rviz-ogre-vendor
 _pkgname=rviz_ogre_vendor
-pkgver=14.1.20
+pkgver=14.1.23
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://www.ogre3d.org/"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rviz_ogre_vendor
     uri: https://github.com/ros2-gbp/rviz-release.git
-    version: release/jazzy/rviz_ogre_vendor/14.1.20-2
+    version: release/jazzy/rviz_ogre_vendor/14.1.23-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-rviz-rendering-tests/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-rviz-rendering-tests/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rviz-rendering-tests
 _pkgname=rviz_rendering_tests
-pkgver=14.1.20
+pkgver=14.1.23
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://github.com/ros2/rviz"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rviz_rendering_tests
     uri: https://github.com/ros2-gbp/rviz-release.git
-    version: release/jazzy/rviz_rendering_tests/14.1.20-2
+    version: release/jazzy/rviz_rendering_tests/14.1.23-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-rviz-rendering/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-rviz-rendering/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rviz-rendering
 _pkgname=rviz_rendering
-pkgver=14.1.20
+pkgver=14.1.23
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://github.com/ros2/rviz/blob/ros2/README.md"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rviz_rendering
     uri: https://github.com/ros2-gbp/rviz-release.git
-    version: release/jazzy/rviz_rendering/14.1.20-2
+    version: release/jazzy/rviz_rendering/14.1.23-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-rviz-visual-testing-framework/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-rviz-visual-testing-framework/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rviz-visual-testing-framework
 _pkgname=rviz_visual_testing_framework
-pkgver=14.1.20
+pkgver=14.1.23
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="http://ros.org/wiki/rviz2"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rviz_visual_testing_framework
     uri: https://github.com/ros2-gbp/rviz-release.git
-    version: release/jazzy/rviz_visual_testing_framework/14.1.20-2
+    version: release/jazzy/rviz_visual_testing_framework/14.1.23-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-rviz2/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-rviz2/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rviz2
 _pkgname=rviz2
-pkgver=14.1.20
+pkgver=14.1.23
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://github.com/ros2/rviz/blob/ros2/README.md"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rviz2
     uri: https://github.com/ros2-gbp/rviz-release.git
-    version: release/jazzy/rviz2/14.1.20-2
+    version: release/jazzy/rviz2/14.1.23-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-sensor-msgs-py/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-sensor-msgs-py/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-sensor-msgs-py
 _pkgname=sensor_msgs_py
-pkgver=5.3.7
+pkgver=5.3.8
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: sensor_msgs_py
     uri: https://github.com/ros2-gbp/common_interfaces-release.git
-    version: release/jazzy/sensor_msgs_py/5.3.7-1
+    version: release/jazzy/sensor_msgs_py/5.3.8-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-sensor-msgs/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-sensor-msgs/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-sensor-msgs
 _pkgname=sensor_msgs
-pkgver=5.3.7
+pkgver=5.3.8
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: sensor_msgs
     uri: https://github.com/ros2-gbp/common_interfaces-release.git
-    version: release/jazzy/sensor_msgs/5.3.7-1
+    version: release/jazzy/sensor_msgs/5.3.8-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-service-msgs/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-service-msgs/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-service-msgs
 _pkgname=service_msgs
-pkgver=2.0.3
+pkgver=2.0.4
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: service_msgs
     uri: https://github.com/ros2-gbp/rcl_interfaces-release.git
-    version: release/jazzy/service_msgs/2.0.3-1
+    version: release/jazzy/service_msgs/2.0.4-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-shape-msgs/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-shape-msgs/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-shape-msgs
 _pkgname=shape_msgs
-pkgver=5.3.7
+pkgver=5.3.8
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: shape_msgs
     uri: https://github.com/ros2-gbp/common_interfaces-release.git
-    version: release/jazzy/shape_msgs/5.3.7-1
+    version: release/jazzy/shape_msgs/5.3.8-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-spdlog-vendor/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-spdlog-vendor/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-spdlog-vendor
 _pkgname=spdlog_vendor
-pkgver=1.6.1
+pkgver=1.6.2
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://github.com/gabime/spdlog"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: spdlog_vendor
     uri: https://github.com/ros2-gbp/spdlog_vendor-release.git
-    version: release/jazzy/spdlog_vendor/1.6.1-1
+    version: release/jazzy/spdlog_vendor/1.6.2-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-sqlite3-vendor/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-sqlite3-vendor/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-sqlite3-vendor
 _pkgname=sqlite3_vendor
-pkgver=0.26.9
+pkgver=0.26.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: sqlite3_vendor
     uri: https://github.com/ros2-gbp/rosbag2-release.git
-    version: release/jazzy/sqlite3_vendor/0.26.9-1
+    version: release/jazzy/sqlite3_vendor/0.26.11-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-statistics-msgs/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-statistics-msgs/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-statistics-msgs
 _pkgname=statistics_msgs
-pkgver=2.0.3
+pkgver=2.0.4
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: statistics_msgs
     uri: https://github.com/ros2-gbp/rcl_interfaces-release.git
-    version: release/jazzy/statistics_msgs/2.0.3-1
+    version: release/jazzy/statistics_msgs/2.0.4-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-std-msgs/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-std-msgs/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-std-msgs
 _pkgname=std_msgs
-pkgver=5.3.7
+pkgver=5.3.8
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: std_msgs
     uri: https://github.com/ros2-gbp/common_interfaces-release.git
-    version: release/jazzy/std_msgs/5.3.7-1
+    version: release/jazzy/std_msgs/5.3.8-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-std-srvs/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-std-srvs/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-std-srvs
 _pkgname=std_srvs
-pkgver=5.3.7
+pkgver=5.3.8
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: std_srvs
     uri: https://github.com/ros2-gbp/common_interfaces-release.git
-    version: release/jazzy/std_srvs/5.3.7-1
+    version: release/jazzy/std_srvs/5.3.8-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-stereo-image-proc/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-stereo-image-proc/APKBUILD
@@ -1,9 +1,9 @@
 pkgname=ros-jazzy-stereo-image-proc
 _pkgname=stereo_image_proc
-pkgver=5.0.11
+pkgver=5.0.13
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
-url="https://index.ros.org/p/stereo_image_proc/github-ros-perception-image_pipeline/"
+url="https://index.ros.org/p/stereo_image_proc/"
 arch="all"
 license="BSD"
 
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: stereo_image_proc
     uri: https://github.com/ros2-gbp/image_pipeline-release.git
-    version: release/jazzy/stereo_image_proc/5.0.11-1
+    version: release/jazzy/stereo_image_proc/5.0.13-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-stereo-msgs/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-stereo-msgs/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-stereo-msgs
 _pkgname=stereo_msgs
-pkgver=5.3.7
+pkgver=5.3.8
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: stereo_msgs
     uri: https://github.com/ros2-gbp/common_interfaces-release.git
-    version: release/jazzy/stereo_msgs/5.3.7-1
+    version: release/jazzy/stereo_msgs/5.3.8-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-test-interface-files/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-test-interface-files/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-test-interface-files
 _pkgname=test_interface_files
-pkgver=0.11.0
+pkgver=0.11.1
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: test_interface_files
     uri: https://github.com/ros2-gbp/test_interface_files-release.git
-    version: release/jazzy/test_interface_files/0.11.0-3
+    version: release/jazzy/test_interface_files/0.11.1-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-test-msgs/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-test-msgs/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-test-msgs
 _pkgname=test_msgs
-pkgver=2.0.3
+pkgver=2.0.4
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: test_msgs
     uri: https://github.com/ros2-gbp/rcl_interfaces-release.git
-    version: release/jazzy/test_msgs/2.0.3-1
+    version: release/jazzy/test_msgs/2.0.4-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-tf2-bullet/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-tf2-bullet/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-tf2-bullet
 _pkgname=tf2_bullet
-pkgver=0.36.19
+pkgver=0.36.22
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="http://www.ros.org/wiki/tf2_bullet"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: tf2_bullet
     uri: https://github.com/ros2-gbp/geometry2-release.git
-    version: release/jazzy/tf2_bullet/0.36.19-1
+    version: release/jazzy/tf2_bullet/0.36.22-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-tf2-eigen-kdl/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-tf2-eigen-kdl/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-tf2-eigen-kdl
 _pkgname=tf2_eigen_kdl
-pkgver=0.36.19
+pkgver=0.36.22
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: tf2_eigen_kdl
     uri: https://github.com/ros2-gbp/geometry2-release.git
-    version: release/jazzy/tf2_eigen_kdl/0.36.19-1
+    version: release/jazzy/tf2_eigen_kdl/0.36.22-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-tf2-eigen/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-tf2-eigen/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-tf2-eigen
 _pkgname=tf2_eigen
-pkgver=0.36.19
+pkgver=0.36.22
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: tf2_eigen
     uri: https://github.com/ros2-gbp/geometry2-release.git
-    version: release/jazzy/tf2_eigen/0.36.19-1
+    version: release/jazzy/tf2_eigen/0.36.22-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-tf2-geometry-msgs/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-tf2-geometry-msgs/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-tf2-geometry-msgs
 _pkgname=tf2_geometry_msgs
-pkgver=0.36.19
+pkgver=0.36.22
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="http://www.ros.org/wiki/tf2_ros"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: tf2_geometry_msgs
     uri: https://github.com/ros2-gbp/geometry2-release.git
-    version: release/jazzy/tf2_geometry_msgs/0.36.19-1
+    version: release/jazzy/tf2_geometry_msgs/0.36.22-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-tf2-kdl/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-tf2-kdl/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-tf2-kdl
 _pkgname=tf2_kdl
-pkgver=0.36.19
+pkgver=0.36.22
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="http://ros.org/wiki/tf2"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: tf2_kdl
     uri: https://github.com/ros2-gbp/geometry2-release.git
-    version: release/jazzy/tf2_kdl/0.36.19-1
+    version: release/jazzy/tf2_kdl/0.36.22-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-tf2-msgs/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-tf2-msgs/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-tf2-msgs
 _pkgname=tf2_msgs
-pkgver=0.36.19
+pkgver=0.36.22
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="http://www.ros.org/wiki/tf2_msgs"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: tf2_msgs
     uri: https://github.com/ros2-gbp/geometry2-release.git
-    version: release/jazzy/tf2_msgs/0.36.19-1
+    version: release/jazzy/tf2_msgs/0.36.22-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-tf2-py/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-tf2-py/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-tf2-py
 _pkgname=tf2_py
-pkgver=0.36.19
+pkgver=0.36.22
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="http://ros.org/wiki/tf2_py"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: tf2_py
     uri: https://github.com/ros2-gbp/geometry2-release.git
-    version: release/jazzy/tf2_py/0.36.19-1
+    version: release/jazzy/tf2_py/0.36.22-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-tf2-ros-py/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-tf2-ros-py/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-tf2-ros-py
 _pkgname=tf2_ros_py
-pkgver=0.36.19
+pkgver=0.36.22
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="http://www.ros.org/wiki/tf2_ros"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: tf2_ros_py
     uri: https://github.com/ros2-gbp/geometry2-release.git
-    version: release/jazzy/tf2_ros_py/0.36.19-1
+    version: release/jazzy/tf2_ros_py/0.36.22-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-tf2-ros/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-tf2-ros/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-tf2-ros
 _pkgname=tf2_ros
-pkgver=0.36.19
+pkgver=0.36.22
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="http://www.ros.org/wiki/tf2_ros"
@@ -8,7 +8,7 @@ arch="all"
 license="BSD"
 
 depends="ros-jazzy-builtin-interfaces ros-jazzy-geometry-msgs ros-jazzy-message-filters ros-jazzy-rcl-interfaces ros-jazzy-rclcpp ros-jazzy-rclcpp-action ros-jazzy-rclcpp-components ros-jazzy-ros-workspace ros-jazzy-tf2 ros-jazzy-tf2-msgs"
-makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-jazzy-ament-cmake ros-jazzy-ament-cmake-dev ros-jazzy-ament-cmake-gtest ros-jazzy-ament-cmake-gtest-dev ros-jazzy-ament-lint-auto ros-jazzy-ament-lint-auto-dev ros-jazzy-ament-lint-common ros-jazzy-ament-lint-common-dev ros-jazzy-builtin-interfaces ros-jazzy-builtin-interfaces-dev ros-jazzy-geometry-msgs ros-jazzy-geometry-msgs-dev ros-jazzy-message-filters ros-jazzy-message-filters-dev ros-jazzy-rcl-interfaces ros-jazzy-rcl-interfaces-dev ros-jazzy-rclcpp ros-jazzy-rclcpp-action ros-jazzy-rclcpp-action-dev ros-jazzy-rclcpp-components ros-jazzy-rclcpp-components-dev ros-jazzy-rclcpp-dev ros-jazzy-ros-workspace-dev ros-jazzy-rosgraph-msgs ros-jazzy-rosgraph-msgs-dev ros-jazzy-tf2 ros-jazzy-tf2-dev ros-jazzy-tf2-msgs ros-jazzy-tf2-msgs-dev"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-jazzy-ament-cmake ros-jazzy-ament-cmake-dev ros-jazzy-ament-cmake-gen-version-h ros-jazzy-ament-cmake-gen-version-h-dev ros-jazzy-ament-cmake-gtest ros-jazzy-ament-cmake-gtest-dev ros-jazzy-ament-lint-auto ros-jazzy-ament-lint-auto-dev ros-jazzy-ament-lint-common ros-jazzy-ament-lint-common-dev ros-jazzy-builtin-interfaces ros-jazzy-builtin-interfaces-dev ros-jazzy-geometry-msgs ros-jazzy-geometry-msgs-dev ros-jazzy-message-filters ros-jazzy-message-filters-dev ros-jazzy-rcl-interfaces ros-jazzy-rcl-interfaces-dev ros-jazzy-rclcpp ros-jazzy-rclcpp-action ros-jazzy-rclcpp-action-dev ros-jazzy-rclcpp-components ros-jazzy-rclcpp-components-dev ros-jazzy-rclcpp-dev ros-jazzy-ros-workspace-dev ros-jazzy-rosgraph-msgs ros-jazzy-rosgraph-msgs-dev ros-jazzy-tf2 ros-jazzy-tf2-dev ros-jazzy-tf2-msgs ros-jazzy-tf2-msgs-dev"
 depends_dev="ros-jazzy-builtin-interfaces ros-jazzy-builtin-interfaces-dev ros-jazzy-geometry-msgs ros-jazzy-geometry-msgs-dev ros-jazzy-message-filters ros-jazzy-message-filters-dev ros-jazzy-rcl-interfaces ros-jazzy-rcl-interfaces-dev ros-jazzy-rclcpp ros-jazzy-rclcpp-action ros-jazzy-rclcpp-action-dev ros-jazzy-rclcpp-components ros-jazzy-rclcpp-components-dev ros-jazzy-rclcpp-dev ros-jazzy-ros-workspace-dev ros-jazzy-tf2 ros-jazzy-tf2-dev ros-jazzy-tf2-msgs ros-jazzy-tf2-msgs-dev"
 
 subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: tf2_ros
     uri: https://github.com/ros2-gbp/geometry2-release.git
-    version: release/jazzy/tf2_ros/0.36.19-1
+    version: release/jazzy/tf2_ros/0.36.22-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-tf2-sensor-msgs/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-tf2-sensor-msgs/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-tf2-sensor-msgs
 _pkgname=tf2_sensor_msgs
-pkgver=0.36.19
+pkgver=0.36.22
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="http://www.ros.org/wiki/tf2_ros"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: tf2_sensor_msgs
     uri: https://github.com/ros2-gbp/geometry2-release.git
-    version: release/jazzy/tf2_sensor_msgs/0.36.19-1
+    version: release/jazzy/tf2_sensor_msgs/0.36.22-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-tf2-tools/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-tf2-tools/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-tf2-tools
 _pkgname=tf2_tools
-pkgver=0.36.19
+pkgver=0.36.22
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="http://www.ros.org/wiki/tf2_tools"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: tf2_tools
     uri: https://github.com/ros2-gbp/geometry2-release.git
-    version: release/jazzy/tf2_tools/0.36.19-1
+    version: release/jazzy/tf2_tools/0.36.22-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-tf2/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-tf2/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-tf2
 _pkgname=tf2
-pkgver=0.36.19
+pkgver=0.36.22
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="http://www.ros.org/wiki/tf2"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: tf2
     uri: https://github.com/ros2-gbp/geometry2-release.git
-    version: release/jazzy/tf2/0.36.19-1
+    version: release/jazzy/tf2/0.36.22-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-theora-image-transport/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-theora-image-transport/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-theora-image-transport
 _pkgname=theora_image_transport
-pkgver=4.0.6
+pkgver=4.0.7
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="http://www.ros.org/wiki/image_transport_plugins"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: theora_image_transport
     uri: https://github.com/ros2-gbp/image_transport_plugins-release.git
-    version: release/jazzy/theora_image_transport/4.0.6-1
+    version: release/jazzy/theora_image_transport/4.0.7-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-tlsf/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-tlsf/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-tlsf
 _pkgname=tlsf
-pkgver=0.9.0
+pkgver=0.9.1
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: tlsf
     uri: https://github.com/ros2-gbp/tlsf-release.git
-    version: release/jazzy/tlsf/0.9.0-3
+    version: release/jazzy/tlsf/0.9.1-2
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-topic-monitor/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-topic-monitor/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-topic-monitor
 _pkgname=topic_monitor
-pkgver=0.33.9
+pkgver=0.33.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: topic_monitor
     uri: https://github.com/ros2-gbp/demos-release.git
-    version: release/jazzy/topic_monitor/0.33.9-1
+    version: release/jazzy/topic_monitor/0.33.11-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-tracetools-image-pipeline/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-tracetools-image-pipeline/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-tracetools-image-pipeline
 _pkgname=tracetools_image_pipeline
-pkgver=5.0.11
+pkgver=5.0.13
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: tracetools_image_pipeline
     uri: https://github.com/ros2-gbp/image_pipeline-release.git
-    version: release/jazzy/tracetools_image_pipeline/5.0.11-1
+    version: release/jazzy/tracetools_image_pipeline/5.0.13-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-tracetools/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-tracetools/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-tracetools
 _pkgname=tracetools
-pkgver=8.2.5
+pkgver=8.2.6
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://docs.ros.org/en/rolling/p/tracetools/"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: tracetools
     uri: https://github.com/ros2-gbp/ros2_tracing-release.git
-    version: release/jazzy/tracetools/8.2.5-1
+    version: release/jazzy/tracetools/8.2.6-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-trajectory-msgs/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-trajectory-msgs/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-trajectory-msgs
 _pkgname=trajectory_msgs
-pkgver=5.3.7
+pkgver=5.3.8
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: trajectory_msgs
     uri: https://github.com/ros2-gbp/common_interfaces-release.git
-    version: release/jazzy/trajectory_msgs/5.3.7-1
+    version: release/jazzy/trajectory_msgs/5.3.8-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-turtlesim/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-turtlesim/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-turtlesim
 _pkgname=turtlesim
-pkgver=1.8.3
+pkgver=1.8.4
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="http://www.ros.org/wiki/turtlesim"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: turtlesim
     uri: https://github.com/ros2-gbp/ros_tutorials-release.git
-    version: release/jazzy/turtlesim/1.8.3-1
+    version: release/jazzy/turtlesim/1.8.4-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-type-description-interfaces/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-type-description-interfaces/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-type-description-interfaces
 _pkgname=type_description_interfaces
-pkgver=2.0.3
+pkgver=2.0.4
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: type_description_interfaces
     uri: https://github.com/ros2-gbp/rcl_interfaces-release.git
-    version: release/jazzy/type_description_interfaces/2.0.3-1
+    version: release/jazzy/type_description_interfaces/2.0.4-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-unique-identifier-msgs/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-unique-identifier-msgs/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-unique-identifier-msgs
 _pkgname=unique_identifier_msgs
-pkgver=2.5.0
+pkgver=2.5.1
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="http://ros.org/wiki/unique_identifier_msgs"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: unique_identifier_msgs
     uri: https://github.com/ros2-gbp/unique_identifier_msgs-release.git
-    version: release/jazzy/unique_identifier_msgs/2.5.0-3
+    version: release/jazzy/unique_identifier_msgs/2.5.1-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-urdf-parser-plugin/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-urdf-parser-plugin/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-urdf-parser-plugin
 _pkgname=urdf_parser_plugin
-pkgver=2.10.0
+pkgver=2.10.1
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://github.com/ros2/urdf"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: urdf_parser_plugin
     uri: https://github.com/ros2-gbp/urdf-release.git
-    version: release/jazzy/urdf_parser_plugin/2.10.0-3
+    version: release/jazzy/urdf_parser_plugin/2.10.1-2
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-urdf/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-urdf/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-urdf
 _pkgname=urdf
-pkgver=2.10.0
+pkgver=2.10.1
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://github.com/ros2/urdf"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: urdf
     uri: https://github.com/ros2-gbp/urdf-release.git
-    version: release/jazzy/urdf/2.10.0-3
+    version: release/jazzy/urdf/2.10.1-2
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-urdfdom-headers/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-urdfdom-headers/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-urdfdom-headers
 _pkgname=urdfdom_headers
-pkgver=1.1.2
+pkgver=1.1.3
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="http://ros.org/wiki/urdf"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: urdfdom_headers
     uri: https://github.com/ros2-gbp/urdfdom_headers-release.git
-    version: release/jazzy/urdfdom_headers/1.1.2-1
+    version: release/jazzy/urdfdom_headers/1.1.3-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-visualization-msgs/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-visualization-msgs/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-visualization-msgs
 _pkgname=visualization_msgs
-pkgver=5.3.7
+pkgver=5.3.8
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: visualization_msgs
     uri: https://github.com/ros2-gbp/common_interfaces-release.git
-    version: release/jazzy/visualization_msgs/5.3.7-1
+    version: release/jazzy/visualization_msgs/5.3.8-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-zstd-image-transport/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-zstd-image-transport/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-zstd-image-transport
 _pkgname=zstd_image_transport
-pkgver=4.0.6
+pkgver=4.0.7
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="http://www.ros.org/wiki/image_transport_plugins"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: zstd_image_transport
     uri: https://github.com/ros2-gbp/image_transport_plugins-release.git
-    version: release/jazzy/zstd_image_transport/4.0.6-1
+    version: release/jazzy/zstd_image_transport/4.0.7-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-zstd-vendor/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-zstd-vendor/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-zstd-vendor
 _pkgname=zstd_vendor
-pkgver=0.26.9
+pkgver=0.26.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://facebook.github.io/zstd/"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: zstd_vendor
     uri: https://github.com/ros2-gbp/rosbag2-release.git
-    version: release/jazzy/zstd_vendor/0.26.9-1
+    version: release/jazzy/zstd_vendor/0.26.11-1
 "
 
 prepare() {


### PR DESCRIPTION
Not for merge — this exists to run CI over #1280, #1281 and #1282 together, since none of them can go green on its own.

## Why

#1280 (jazzy-3.23) and #1281 (jazzy-3.20) both bump `launch_testing` to 3.4.11 and both fail at `prepare`, because `disable-failing-test.patch` deletes a file whose contents changed by one character upstream. #1282 refreshes that patch — but the refreshed patch only matches 3.4.11, so it cannot be verified against `master` (still 3.4.10) either. Each piece is unverifiable alone; together they are the state that would exist after all three merge.

## Contents

Merges of three branches, no conflicts:

| branch | |
|---|---|
| `auto-update/jazzy/3.23/20260812-102402` | #1280 |
| `auto-update/jazzy/3.20/20260812-102403` | #1281 |
| `fix/jazzy-launch-testing-3.4.11` | #1282 |

569 files changed. The `launch_testing` APKBUILD bump is identical in the auto-update branches and in #1282, so it merged without conflict; only #1282 touches the patch.

Consistency of the merged tree:

| | pkgver | patch |
|---|---|---|
| `v3.20/ros/jazzy/ros-jazzy-launch-testing` | 3.4.11 | refreshed |
| `v3.23/ros/jazzy/ros-jazzy-launch-testing` | 3.4.11 | refreshed |

Both refreshed copies apply cleanly to `release/jazzy/launch_testing/3.4.11-1` (`patch -p1 --dry-run`).

## What to watch in the CI result

- `jazzy-3.20` and `jazzy-3.23` should get past `ros-jazzy-launch-testing`.
- `ros-jazzy-performance-test-fixture*: libmemory_tools.so: path not found` appeared earlier in #1281's log. It did **not** fail that build — abuild carried on and only `launch_testing` reached `Failed to build` — but with `launch_testing` fixed, whether it stays a non-fatal complaint is now actually observable.
- humble is untouched here. #1278 (`ament_flake8` calling `python -m pytest` without pytest in makedepends) and #1279 (`ros2component` hitting `empty node name returned by the RMW layer`) are separate problems.

🤖 Generated with [Claude Code](https://claude.com/claude-code)