### PR TITLE
ros-jazzy-rclpy: update to 7.1.11 and rebuild the jazzy-3.20 fastrtps stack

### DIFF
--- a/v3.20/ros/jazzy/ros-jazzy-fastrtps/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-fastrtps/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-fastrtps
 _pkgname=fastrtps
-pkgver=2.14.5
+pkgver=2.14.6
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://www.eprosima.com/"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: fastrtps
     uri: https://github.com/ros2-gbp/fastdds-release.git
-    version: release/jazzy/fastrtps/2.14.5-2
+    version: release/jazzy/fastrtps/2.14.6-1
 "
 
 prepare() {
@@ -81,7 +81,10 @@ check() {
   fi
   cd build
   if [ $(make -q test > /dev/null 2> /dev/null; echo $?) -eq 1 ]; then
-    make test 2>&1 | tee $checklog
+    # Run tests one at a time: ROS tests share the default DDS domain, and
+    # upstream only ever runs them sequentially. The -j1 is explicit because
+    # ctest otherwise picks up parallelism from MAKEFLAGS.
+    ctest -j1 2>&1 | tee $checklog
   fi
 }
 
@@ -152,6 +155,10 @@ package() {
       -iname "copying*" -or \
       -iname "gnu-*gpl*" \
     | while read file; do
+    if [ ! -f "$file" ]; then
+      # Omit directories named like a license file
+      continue
+    fi
     # Copy license files under the source
     if echo $file | grep -e '^\./\.'; then
       # Omit files under hidden directory

--- a/v3.20/ros/jazzy/ros-jazzy-rclpy/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-rclpy/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rclpy
 _pkgname=rclpy
-pkgver=7.1.9
+pkgver=7.1.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rclpy
     uri: https://github.com/ros2-gbp/rclpy-release.git
-    version: release/jazzy/rclpy/7.1.9-1
+    version: release/jazzy/rclpy/7.1.11-1
 "
 
 prepare() {

--- a/v3.20/ros/jazzy/ros-jazzy-rclpy/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-rclpy/APKBUILD
@@ -87,7 +87,10 @@ check() {
   cd build
   make install DESTDIR="$builddir"/tmp/pkg
   if [ $(make -q test > /dev/null 2> /dev/null; echo $?) -eq 1 ]; then
-    make test 2>&1 | tee $checklog
+    # Run tests one at a time: ROS tests share the default DDS domain, and
+    # upstream only ever runs them sequentially. The -j1 is explicit because
+    # ctest otherwise picks up parallelism from MAKEFLAGS.
+    ctest -j1 2>&1 | tee $checklog
   fi
 }
 
@@ -158,6 +161,10 @@ package() {
       -iname "copying*" -or \
       -iname "gnu-*gpl*" \
     | while read file; do
+    if [ ! -f "$file" ]; then
+      # Omit directories named like a license file
+      continue
+    fi
     # Copy license files under the source
     if echo $file | grep -e '^\./\.'; then
       # Omit files under hidden directory

--- a/v3.20/ros/jazzy/ros-jazzy-rclpy/disable-flaky-test.patch
+++ b/v3.20/ros/jazzy/ros-jazzy-rclpy/disable-flaky-test.patch
@@ -1,5 +1,5 @@
 diff --git a/test/test_timer.py b/test/test_timer.py
-index 394f750..dbe095c 100644
+index 9ca7363..3ff1326 100644
 --- a/test/test_timer.py
 +++ b/test/test_timer.py
 @@ -101,54 +101,54 @@ def test_number_callbacks(period):
@@ -39,7 +39,7 @@ index 394f750..dbe095c 100644
 -                        executor.spin_once(timeout_sec=period / 10)
 -                    assert [] == callbacks
 -
--                    # Reenable timer and make sure callbacks are received again
+-                    # Re-enable timer and make sure callbacks are received again
 -                    timer.reset()
 -                    assert not timer.is_canceled()
 -                    begin_time = time.time()
@@ -87,7 +87,7 @@ index 394f750..dbe095c 100644
 +#                         executor.spin_once(timeout_sec=period / 10)
 +#                     assert [] == callbacks
 +#
-+#                     # Reenable timer and make sure callbacks are received again
++#                     # Re-enable timer and make sure callbacks are received again
 +#                     timer.reset()
 +#                     assert not timer.is_canceled()
 +#                     begin_time = time.time()

--- a/v3.20/ros/jazzy/ros-jazzy-rmw-fastrtps-cpp/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-rmw-fastrtps-cpp/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rmw-fastrtps-cpp
 _pkgname=rmw_fastrtps_cpp
-pkgver=8.4.3
+pkgver=8.4.4
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -8,8 +8,8 @@ arch="all"
 license="Apache License 2.0"
 
 depends="ros-jazzy-rcpputils ros-jazzy-rcutils ros-jazzy-rmw ros-jazzy-rmw-fastrtps-shared-cpp ros-jazzy-ros-workspace ros-jazzy-rosidl-dynamic-typesupport ros-jazzy-rosidl-dynamic-typesupport-fastrtps ros-jazzy-tracetools"
-makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-jazzy-ament-cmake ros-jazzy-ament-cmake-dev ros-jazzy-ament-cmake-gtest ros-jazzy-ament-cmake-gtest-dev ros-jazzy-ament-cmake-ros ros-jazzy-ament-cmake-ros-dev ros-jazzy-ament-lint-auto ros-jazzy-ament-lint-auto-dev ros-jazzy-ament-lint-common ros-jazzy-ament-lint-common-dev ros-jazzy-fastcdr ros-jazzy-fastcdr-dev ros-jazzy-fastrtps ros-jazzy-fastrtps-cmake-module ros-jazzy-fastrtps-cmake-module-dev ros-jazzy-fastrtps-dev ros-jazzy-osrf-testing-tools-cpp ros-jazzy-osrf-testing-tools-cpp-dev ros-jazzy-rcpputils ros-jazzy-rcpputils-dev ros-jazzy-rcutils ros-jazzy-rcutils-dev ros-jazzy-rmw ros-jazzy-rmw-dds-common ros-jazzy-rmw-dds-common-dev ros-jazzy-rmw-dev ros-jazzy-rmw-fastrtps-shared-cpp ros-jazzy-rmw-fastrtps-shared-cpp-dev ros-jazzy-ros-workspace-dev ros-jazzy-rosidl-dynamic-typesupport ros-jazzy-rosidl-dynamic-typesupport-dev ros-jazzy-rosidl-dynamic-typesupport-fastrtps ros-jazzy-rosidl-dynamic-typesupport-fastrtps-dev ros-jazzy-rosidl-runtime-c ros-jazzy-rosidl-runtime-c-dev ros-jazzy-rosidl-runtime-cpp ros-jazzy-rosidl-runtime-cpp-dev ros-jazzy-rosidl-typesupport-fastrtps-c ros-jazzy-rosidl-typesupport-fastrtps-c-dev ros-jazzy-rosidl-typesupport-fastrtps-cpp ros-jazzy-rosidl-typesupport-fastrtps-cpp-dev ros-jazzy-test-msgs ros-jazzy-test-msgs-dev ros-jazzy-tracetools ros-jazzy-tracetools-dev"
-depends_dev="ros-jazzy-ament-cmake ros-jazzy-ament-cmake-dev ros-jazzy-fastcdr ros-jazzy-fastcdr-dev ros-jazzy-fastrtps ros-jazzy-fastrtps-cmake-module ros-jazzy-fastrtps-cmake-module-dev ros-jazzy-fastrtps-dev ros-jazzy-rcpputils-dev ros-jazzy-rcutils ros-jazzy-rcutils-dev ros-jazzy-rmw ros-jazzy-rmw-dds-common ros-jazzy-rmw-dds-common-dev ros-jazzy-rmw-dev ros-jazzy-rmw-fastrtps-shared-cpp ros-jazzy-rmw-fastrtps-shared-cpp-dev ros-jazzy-ros-workspace-dev ros-jazzy-rosidl-dynamic-typesupport ros-jazzy-rosidl-dynamic-typesupport-dev ros-jazzy-rosidl-dynamic-typesupport-fastrtps-dev ros-jazzy-rosidl-runtime-c ros-jazzy-rosidl-runtime-c-dev ros-jazzy-rosidl-runtime-cpp ros-jazzy-rosidl-runtime-cpp-dev ros-jazzy-rosidl-typesupport-fastrtps-c ros-jazzy-rosidl-typesupport-fastrtps-c-dev ros-jazzy-rosidl-typesupport-fastrtps-cpp ros-jazzy-rosidl-typesupport-fastrtps-cpp-dev ros-jazzy-tracetools ros-jazzy-tracetools-dev"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-jazzy-ament-cmake-gtest ros-jazzy-ament-cmake-gtest-dev ros-jazzy-ament-cmake-ros ros-jazzy-ament-cmake-ros-dev ros-jazzy-ament-lint-auto ros-jazzy-ament-lint-auto-dev ros-jazzy-ament-lint-common ros-jazzy-ament-lint-common-dev ros-jazzy-fastcdr ros-jazzy-fastcdr-dev ros-jazzy-fastrtps ros-jazzy-fastrtps-cmake-module ros-jazzy-fastrtps-cmake-module-dev ros-jazzy-fastrtps-dev ros-jazzy-osrf-testing-tools-cpp ros-jazzy-osrf-testing-tools-cpp-dev ros-jazzy-rcpputils ros-jazzy-rcpputils-dev ros-jazzy-rcutils ros-jazzy-rcutils-dev ros-jazzy-rmw ros-jazzy-rmw-dds-common ros-jazzy-rmw-dds-common-dev ros-jazzy-rmw-dev ros-jazzy-rmw-fastrtps-shared-cpp ros-jazzy-rmw-fastrtps-shared-cpp-dev ros-jazzy-ros-workspace-dev ros-jazzy-rosidl-dynamic-typesupport ros-jazzy-rosidl-dynamic-typesupport-dev ros-jazzy-rosidl-dynamic-typesupport-fastrtps ros-jazzy-rosidl-dynamic-typesupport-fastrtps-dev ros-jazzy-rosidl-runtime-c ros-jazzy-rosidl-runtime-c-dev ros-jazzy-rosidl-runtime-cpp ros-jazzy-rosidl-runtime-cpp-dev ros-jazzy-rosidl-typesupport-fastrtps-c ros-jazzy-rosidl-typesupport-fastrtps-c-dev ros-jazzy-rosidl-typesupport-fastrtps-cpp ros-jazzy-rosidl-typesupport-fastrtps-cpp-dev ros-jazzy-test-msgs ros-jazzy-test-msgs-dev ros-jazzy-tracetools ros-jazzy-tracetools-dev"
+depends_dev="ros-jazzy-fastcdr ros-jazzy-fastcdr-dev ros-jazzy-fastrtps ros-jazzy-fastrtps-cmake-module ros-jazzy-fastrtps-cmake-module-dev ros-jazzy-fastrtps-dev ros-jazzy-rcpputils-dev ros-jazzy-rcutils ros-jazzy-rcutils-dev ros-jazzy-rmw ros-jazzy-rmw-dds-common ros-jazzy-rmw-dds-common-dev ros-jazzy-rmw-dev ros-jazzy-rmw-fastrtps-shared-cpp ros-jazzy-rmw-fastrtps-shared-cpp-dev ros-jazzy-ros-workspace-dev ros-jazzy-rosidl-dynamic-typesupport ros-jazzy-rosidl-dynamic-typesupport-dev ros-jazzy-rosidl-dynamic-typesupport-fastrtps-dev ros-jazzy-rosidl-runtime-c ros-jazzy-rosidl-runtime-c-dev ros-jazzy-rosidl-runtime-cpp ros-jazzy-rosidl-runtime-cpp-dev ros-jazzy-rosidl-typesupport-fastrtps-c ros-jazzy-rosidl-typesupport-fastrtps-c-dev ros-jazzy-rosidl-typesupport-fastrtps-cpp ros-jazzy-rosidl-typesupport-fastrtps-cpp-dev ros-jazzy-tracetools ros-jazzy-tracetools-dev"
 
 subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rmw_fastrtps_cpp
     uri: https://github.com/ros2-gbp/rmw_fastrtps-release.git
-    version: release/jazzy/rmw_fastrtps_cpp/8.4.3-1
+    version: release/jazzy/rmw_fastrtps_cpp/8.4.4-1
 "
 
 prepare() {
@@ -87,7 +87,10 @@ check() {
   cd build
   make install DESTDIR="$builddir"/tmp/pkg
   if [ $(make -q test > /dev/null 2> /dev/null; echo $?) -eq 1 ]; then
-    make test 2>&1 | tee $checklog
+    # Run tests one at a time: ROS tests share the default DDS domain, and
+    # upstream only ever runs them sequentially. The -j1 is explicit because
+    # ctest otherwise picks up parallelism from MAKEFLAGS.
+    ctest -j1 2>&1 | tee $checklog
   fi
 }
 
@@ -158,6 +161,10 @@ package() {
       -iname "copying*" -or \
       -iname "gnu-*gpl*" \
     | while read file; do
+    if [ ! -f "$file" ]; then
+      # Omit directories named like a license file
+      continue
+    fi
     # Copy license files under the source
     if echo $file | grep -e '^\./\.'; then
       # Omit files under hidden directory

--- a/v3.20/ros/jazzy/ros-jazzy-rmw-fastrtps-dynamic-cpp/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-rmw-fastrtps-dynamic-cpp/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rmw-fastrtps-dynamic-cpp
 _pkgname=rmw_fastrtps_dynamic_cpp
-pkgver=8.4.3
+pkgver=8.4.4
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -8,8 +8,8 @@ arch="all"
 license="Apache License 2.0"
 
 depends="ros-jazzy-ros-workspace"
-makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-jazzy-ament-cmake ros-jazzy-ament-cmake-dev ros-jazzy-ament-cmake-gtest ros-jazzy-ament-cmake-gtest-dev ros-jazzy-ament-cmake-ros ros-jazzy-ament-cmake-ros-dev ros-jazzy-ament-lint-auto ros-jazzy-ament-lint-auto-dev ros-jazzy-ament-lint-common ros-jazzy-ament-lint-common-dev ros-jazzy-fastcdr ros-jazzy-fastcdr-dev ros-jazzy-fastrtps ros-jazzy-fastrtps-cmake-module ros-jazzy-fastrtps-cmake-module-dev ros-jazzy-fastrtps-dev ros-jazzy-osrf-testing-tools-cpp ros-jazzy-osrf-testing-tools-cpp-dev ros-jazzy-rcpputils ros-jazzy-rcpputils-dev ros-jazzy-rcutils ros-jazzy-rcutils-dev ros-jazzy-rmw ros-jazzy-rmw-dds-common ros-jazzy-rmw-dds-common-dev ros-jazzy-rmw-dev ros-jazzy-rmw-fastrtps-shared-cpp ros-jazzy-rmw-fastrtps-shared-cpp-dev ros-jazzy-ros-workspace-dev ros-jazzy-rosidl-runtime-c ros-jazzy-rosidl-runtime-c-dev ros-jazzy-rosidl-typesupport-introspection-c ros-jazzy-rosidl-typesupport-introspection-c-dev ros-jazzy-rosidl-typesupport-introspection-cpp ros-jazzy-rosidl-typesupport-introspection-cpp-dev ros-jazzy-test-msgs ros-jazzy-test-msgs-dev"
-depends_dev="ros-jazzy-ament-cmake ros-jazzy-ament-cmake-dev ros-jazzy-fastcdr ros-jazzy-fastcdr-dev ros-jazzy-fastrtps ros-jazzy-fastrtps-cmake-module ros-jazzy-fastrtps-cmake-module-dev ros-jazzy-fastrtps-dev ros-jazzy-rcpputils ros-jazzy-rcpputils-dev ros-jazzy-rcutils ros-jazzy-rcutils-dev ros-jazzy-rmw ros-jazzy-rmw-dds-common ros-jazzy-rmw-dds-common-dev ros-jazzy-rmw-dev ros-jazzy-rmw-fastrtps-shared-cpp ros-jazzy-rmw-fastrtps-shared-cpp-dev ros-jazzy-ros-workspace-dev ros-jazzy-rosidl-runtime-c ros-jazzy-rosidl-runtime-c-dev ros-jazzy-rosidl-typesupport-introspection-c ros-jazzy-rosidl-typesupport-introspection-c-dev ros-jazzy-rosidl-typesupport-introspection-cpp ros-jazzy-rosidl-typesupport-introspection-cpp-dev"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-jazzy-ament-cmake-gtest ros-jazzy-ament-cmake-gtest-dev ros-jazzy-ament-cmake-ros ros-jazzy-ament-cmake-ros-dev ros-jazzy-ament-lint-auto ros-jazzy-ament-lint-auto-dev ros-jazzy-ament-lint-common ros-jazzy-ament-lint-common-dev ros-jazzy-fastcdr ros-jazzy-fastcdr-dev ros-jazzy-fastrtps ros-jazzy-fastrtps-cmake-module ros-jazzy-fastrtps-cmake-module-dev ros-jazzy-fastrtps-dev ros-jazzy-osrf-testing-tools-cpp ros-jazzy-osrf-testing-tools-cpp-dev ros-jazzy-rcpputils ros-jazzy-rcpputils-dev ros-jazzy-rcutils ros-jazzy-rcutils-dev ros-jazzy-rmw ros-jazzy-rmw-dds-common ros-jazzy-rmw-dds-common-dev ros-jazzy-rmw-dev ros-jazzy-rmw-fastrtps-shared-cpp ros-jazzy-rmw-fastrtps-shared-cpp-dev ros-jazzy-ros-workspace-dev ros-jazzy-rosidl-runtime-c ros-jazzy-rosidl-runtime-c-dev ros-jazzy-rosidl-typesupport-introspection-c ros-jazzy-rosidl-typesupport-introspection-c-dev ros-jazzy-rosidl-typesupport-introspection-cpp ros-jazzy-rosidl-typesupport-introspection-cpp-dev ros-jazzy-test-msgs ros-jazzy-test-msgs-dev"
+depends_dev="ros-jazzy-fastcdr ros-jazzy-fastcdr-dev ros-jazzy-fastrtps ros-jazzy-fastrtps-cmake-module ros-jazzy-fastrtps-cmake-module-dev ros-jazzy-fastrtps-dev ros-jazzy-rcpputils ros-jazzy-rcpputils-dev ros-jazzy-rcutils ros-jazzy-rcutils-dev ros-jazzy-rmw ros-jazzy-rmw-dds-common ros-jazzy-rmw-dds-common-dev ros-jazzy-rmw-dev ros-jazzy-rmw-fastrtps-shared-cpp ros-jazzy-rmw-fastrtps-shared-cpp-dev ros-jazzy-ros-workspace-dev ros-jazzy-rosidl-runtime-c ros-jazzy-rosidl-runtime-c-dev ros-jazzy-rosidl-typesupport-introspection-c ros-jazzy-rosidl-typesupport-introspection-c-dev ros-jazzy-rosidl-typesupport-introspection-cpp ros-jazzy-rosidl-typesupport-introspection-cpp-dev"
 
 subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rmw_fastrtps_dynamic_cpp
     uri: https://github.com/ros2-gbp/rmw_fastrtps-release.git
-    version: release/jazzy/rmw_fastrtps_dynamic_cpp/8.4.3-1
+    version: release/jazzy/rmw_fastrtps_dynamic_cpp/8.4.4-1
 "
 
 prepare() {
@@ -87,7 +87,10 @@ check() {
   cd build
   make install DESTDIR="$builddir"/tmp/pkg
   if [ $(make -q test > /dev/null 2> /dev/null; echo $?) -eq 1 ]; then
-    make test 2>&1 | tee $checklog
+    # Run tests one at a time: ROS tests share the default DDS domain, and
+    # upstream only ever runs them sequentially. The -j1 is explicit because
+    # ctest otherwise picks up parallelism from MAKEFLAGS.
+    ctest -j1 2>&1 | tee $checklog
   fi
 }
 
@@ -158,6 +161,10 @@ package() {
       -iname "copying*" -or \
       -iname "gnu-*gpl*" \
     | while read file; do
+    if [ ! -f "$file" ]; then
+      # Omit directories named like a license file
+      continue
+    fi
     # Copy license files under the source
     if echo $file | grep -e '^\./\.'; then
       # Omit files under hidden directory

--- a/v3.20/ros/jazzy/ros-jazzy-rmw-fastrtps-shared-cpp/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-rmw-fastrtps-shared-cpp/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rmw-fastrtps-shared-cpp
 _pkgname=rmw_fastrtps_shared_cpp
-pkgver=8.4.3
+pkgver=8.4.4
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -8,8 +8,8 @@ arch="all"
 license="Apache License 2.0"
 
 depends="ros-jazzy-ros-workspace"
-makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-jazzy-ament-cmake ros-jazzy-ament-cmake-dev ros-jazzy-ament-cmake-ros ros-jazzy-ament-cmake-ros-dev ros-jazzy-ament-lint-auto ros-jazzy-ament-lint-auto-dev ros-jazzy-ament-lint-common ros-jazzy-ament-lint-common-dev ros-jazzy-fastcdr ros-jazzy-fastcdr-dev ros-jazzy-fastrtps ros-jazzy-fastrtps-cmake-module ros-jazzy-fastrtps-cmake-module-dev ros-jazzy-fastrtps-dev ros-jazzy-osrf-testing-tools-cpp ros-jazzy-osrf-testing-tools-cpp-dev ros-jazzy-rcpputils ros-jazzy-rcpputils-dev ros-jazzy-rcutils ros-jazzy-rcutils-dev ros-jazzy-rmw ros-jazzy-rmw-dds-common ros-jazzy-rmw-dds-common-dev ros-jazzy-rmw-dev ros-jazzy-ros-workspace-dev ros-jazzy-rosidl-dynamic-typesupport ros-jazzy-rosidl-dynamic-typesupport-dev ros-jazzy-rosidl-runtime-c ros-jazzy-rosidl-runtime-c-dev ros-jazzy-rosidl-typesupport-introspection-c ros-jazzy-rosidl-typesupport-introspection-c-dev ros-jazzy-rosidl-typesupport-introspection-cpp ros-jazzy-rosidl-typesupport-introspection-cpp-dev ros-jazzy-tracetools ros-jazzy-tracetools-dev"
-depends_dev="ros-jazzy-ament-cmake ros-jazzy-ament-cmake-dev ros-jazzy-fastcdr ros-jazzy-fastcdr-dev ros-jazzy-fastrtps ros-jazzy-fastrtps-cmake-module ros-jazzy-fastrtps-cmake-module-dev ros-jazzy-fastrtps-dev ros-jazzy-rcpputils ros-jazzy-rcpputils-dev ros-jazzy-rcutils ros-jazzy-rcutils-dev ros-jazzy-rmw ros-jazzy-rmw-dds-common ros-jazzy-rmw-dds-common-dev ros-jazzy-rmw-dev ros-jazzy-ros-workspace-dev ros-jazzy-rosidl-dynamic-typesupport ros-jazzy-rosidl-dynamic-typesupport-dev ros-jazzy-rosidl-typesupport-introspection-c ros-jazzy-rosidl-typesupport-introspection-c-dev ros-jazzy-rosidl-typesupport-introspection-cpp ros-jazzy-rosidl-typesupport-introspection-cpp-dev ros-jazzy-tracetools ros-jazzy-tracetools-dev"
+makedepends="chrpath py3-rosdep py3-rosinstall-generator py3-setuptools py3-vcstool ros-jazzy-ament-cmake-ros ros-jazzy-ament-cmake-ros-dev ros-jazzy-ament-lint-auto ros-jazzy-ament-lint-auto-dev ros-jazzy-ament-lint-common ros-jazzy-ament-lint-common-dev ros-jazzy-fastcdr ros-jazzy-fastcdr-dev ros-jazzy-fastrtps ros-jazzy-fastrtps-cmake-module ros-jazzy-fastrtps-cmake-module-dev ros-jazzy-fastrtps-dev ros-jazzy-osrf-testing-tools-cpp ros-jazzy-osrf-testing-tools-cpp-dev ros-jazzy-rcpputils ros-jazzy-rcpputils-dev ros-jazzy-rcutils ros-jazzy-rcutils-dev ros-jazzy-rmw ros-jazzy-rmw-dds-common ros-jazzy-rmw-dds-common-dev ros-jazzy-rmw-dev ros-jazzy-ros-workspace-dev ros-jazzy-rosidl-dynamic-typesupport ros-jazzy-rosidl-dynamic-typesupport-dev ros-jazzy-rosidl-runtime-c ros-jazzy-rosidl-runtime-c-dev ros-jazzy-rosidl-typesupport-introspection-c ros-jazzy-rosidl-typesupport-introspection-c-dev ros-jazzy-rosidl-typesupport-introspection-cpp ros-jazzy-rosidl-typesupport-introspection-cpp-dev ros-jazzy-tracetools ros-jazzy-tracetools-dev"
+depends_dev="ros-jazzy-fastcdr ros-jazzy-fastcdr-dev ros-jazzy-fastrtps ros-jazzy-fastrtps-cmake-module ros-jazzy-fastrtps-cmake-module-dev ros-jazzy-fastrtps-dev ros-jazzy-rcpputils ros-jazzy-rcpputils-dev ros-jazzy-rcutils ros-jazzy-rcutils-dev ros-jazzy-rmw ros-jazzy-rmw-dds-common ros-jazzy-rmw-dds-common-dev ros-jazzy-rmw-dev ros-jazzy-ros-workspace-dev ros-jazzy-rosidl-dynamic-typesupport ros-jazzy-rosidl-dynamic-typesupport-dev ros-jazzy-rosidl-typesupport-introspection-c ros-jazzy-rosidl-typesupport-introspection-c-dev ros-jazzy-rosidl-typesupport-introspection-cpp ros-jazzy-rosidl-typesupport-introspection-cpp-dev ros-jazzy-tracetools ros-jazzy-tracetools-dev"
 
 subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rmw_fastrtps_shared_cpp
     uri: https://github.com/ros2-gbp/rmw_fastrtps-release.git
-    version: release/jazzy/rmw_fastrtps_shared_cpp/8.4.3-1
+    version: release/jazzy/rmw_fastrtps_shared_cpp/8.4.4-1
 "
 
 prepare() {
@@ -87,7 +87,10 @@ check() {
   cd build
   make install DESTDIR="$builddir"/tmp/pkg
   if [ $(make -q test > /dev/null 2> /dev/null; echo $?) -eq 1 ]; then
-    make test 2>&1 | tee $checklog
+    # Run tests one at a time: ROS tests share the default DDS domain, and
+    # upstream only ever runs them sequentially. The -j1 is explicit because
+    # ctest otherwise picks up parallelism from MAKEFLAGS.
+    ctest -j1 2>&1 | tee $checklog
   fi
 }
 
@@ -158,6 +161,10 @@ package() {
       -iname "copying*" -or \
       -iname "gnu-*gpl*" \
     | while read file; do
+    if [ ! -f "$file" ]; then
+      # Omit directories named like a license file
+      continue
+    fi
     # Copy license files under the source
     if echo $file | grep -e '^\./\.'; then
       # Omit files under hidden directory

--- a/v3.20/ros/jazzy/ros-jazzy-rosidl-dynamic-typesupport-fastrtps/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-rosidl-dynamic-typesupport-fastrtps/APKBUILD
@@ -1,7 +1,7 @@
 pkgname=ros-jazzy-rosidl-dynamic-typesupport-fastrtps
 _pkgname=rosidl_dynamic_typesupport_fastrtps
 pkgver=0.1.0
-pkgrel=1
+pkgrel=2
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
 arch="all"
@@ -87,7 +87,10 @@ check() {
   cd build
   make install DESTDIR="$builddir"/tmp/pkg
   if [ $(make -q test > /dev/null 2> /dev/null; echo $?) -eq 1 ]; then
-    make test 2>&1 | tee $checklog
+    # Run tests one at a time: ROS tests share the default DDS domain, and
+    # upstream only ever runs them sequentially. The -j1 is explicit because
+    # ctest otherwise picks up parallelism from MAKEFLAGS.
+    ctest -j1 2>&1 | tee $checklog
   fi
 }
 
@@ -158,6 +161,10 @@ package() {
       -iname "copying*" -or \
       -iname "gnu-*gpl*" \
     | while read file; do
+    if [ ! -f "$file" ]; then
+      # Omit directories named like a license file
+      continue
+    fi
     # Copy license files under the source
     if echo $file | grep -e '^\./\.'; then
       # Omit files under hidden directory

--- a/v3.20/ros/jazzy/ros-jazzy-rosidl-dynamic-typesupport/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-rosidl-dynamic-typesupport/APKBUILD
@@ -1,7 +1,7 @@
 pkgname=ros-jazzy-rosidl-dynamic-typesupport
 _pkgname=rosidl_dynamic_typesupport
 pkgver=0.1.2
-pkgrel=1
+pkgrel=2
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
 arch="all"
@@ -87,7 +87,10 @@ check() {
   cd build
   make install DESTDIR="$builddir"/tmp/pkg
   if [ $(make -q test > /dev/null 2> /dev/null; echo $?) -eq 1 ]; then
-    make test 2>&1 | tee $checklog
+    # Run tests one at a time: ROS tests share the default DDS domain, and
+    # upstream only ever runs them sequentially. The -j1 is explicit because
+    # ctest otherwise picks up parallelism from MAKEFLAGS.
+    ctest -j1 2>&1 | tee $checklog
   fi
 }
 
@@ -158,6 +161,10 @@ package() {
       -iname "copying*" -or \
       -iname "gnu-*gpl*" \
     | while read file; do
+    if [ ! -f "$file" ]; then
+      # Omit directories named like a license file
+      continue
+    fi
     # Copy license files under the source
     if echo $file | grep -e '^\./\.'; then
       # Omit files under hidden directory

--- a/v3.20/ros/jazzy/ros-jazzy-rosidl-typesupport-fastrtps-c/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-rosidl-typesupport-fastrtps-c/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rosidl-typesupport-fastrtps-c
 _pkgname=rosidl_typesupport_fastrtps_c
-pkgver=3.6.3
+pkgver=3.6.4
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rosidl_typesupport_fastrtps_c
     uri: https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release.git
-    version: release/jazzy/rosidl_typesupport_fastrtps_c/3.6.3-1
+    version: release/jazzy/rosidl_typesupport_fastrtps_c/3.6.4-1
 "
 
 prepare() {
@@ -87,7 +87,10 @@ check() {
   cd build
   make install DESTDIR="$builddir"/tmp/pkg
   if [ $(make -q test > /dev/null 2> /dev/null; echo $?) -eq 1 ]; then
-    make test 2>&1 | tee $checklog
+    # Run tests one at a time: ROS tests share the default DDS domain, and
+    # upstream only ever runs them sequentially. The -j1 is explicit because
+    # ctest otherwise picks up parallelism from MAKEFLAGS.
+    ctest -j1 2>&1 | tee $checklog
   fi
 }
 
@@ -158,6 +161,10 @@ package() {
       -iname "copying*" -or \
       -iname "gnu-*gpl*" \
     | while read file; do
+    if [ ! -f "$file" ]; then
+      # Omit directories named like a license file
+      continue
+    fi
     # Copy license files under the source
     if echo $file | grep -e '^\./\.'; then
       # Omit files under hidden directory

--- a/v3.20/ros/jazzy/ros-jazzy-rosidl-typesupport-fastrtps-cpp/APKBUILD
+++ b/v3.20/ros/jazzy/ros-jazzy-rosidl-typesupport-fastrtps-cpp/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rosidl-typesupport-fastrtps-cpp
 _pkgname=rosidl_typesupport_fastrtps_cpp
-pkgver=3.6.3
+pkgver=3.6.4
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rosidl_typesupport_fastrtps_cpp
     uri: https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release.git
-    version: release/jazzy/rosidl_typesupport_fastrtps_cpp/3.6.3-1
+    version: release/jazzy/rosidl_typesupport_fastrtps_cpp/3.6.4-1
 "
 
 prepare() {
@@ -87,7 +87,10 @@ check() {
   cd build
   make install DESTDIR="$builddir"/tmp/pkg
   if [ $(make -q test > /dev/null 2> /dev/null; echo $?) -eq 1 ]; then
-    make test 2>&1 | tee $checklog
+    # Run tests one at a time: ROS tests share the default DDS domain, and
+    # upstream only ever runs them sequentially. The -j1 is explicit because
+    # ctest otherwise picks up parallelism from MAKEFLAGS.
+    ctest -j1 2>&1 | tee $checklog
   fi
 }
 
@@ -158,6 +161,10 @@ package() {
       -iname "copying*" -or \
       -iname "gnu-*gpl*" \
     | while read file; do
+    if [ ! -f "$file" ]; then
+      # Omit directories named like a license file
+      continue
+    fi
     # Copy license files under the source
     if echo $file | grep -e '^\./\.'; then
       # Omit files under hidden directory

--- a/v3.23/ros/jazzy/ros-jazzy-rclpy/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-rclpy/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-rclpy
 _pkgname=rclpy
-pkgver=7.1.10
+pkgver=7.1.11
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: rclpy
     uri: https://github.com/ros2-gbp/rclpy-release.git
-    version: release/jazzy/rclpy/7.1.10-1
+    version: release/jazzy/rclpy/7.1.11-1
 "
 
 prepare() {

--- a/v3.23/ros/jazzy/ros-jazzy-rclpy/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-rclpy/APKBUILD
@@ -88,7 +88,10 @@ check() {
   cd build
   make install DESTDIR="$builddir"/tmp/pkg
   if [ $(make -q test > /dev/null 2> /dev/null; echo $?) -eq 1 ]; then
-    make test 2>&1 | tee $checklog
+    # Run tests one at a time: ROS tests share the default DDS domain, and
+    # upstream only ever runs them sequentially. The -j1 is explicit because
+    # ctest otherwise picks up parallelism from MAKEFLAGS.
+    ctest -j1 2>&1 | tee $checklog
   fi
 }
 
@@ -159,6 +162,10 @@ package() {
       -iname "copying*" -or \
       -iname "gnu-*gpl*" \
     | while read file; do
+    if [ ! -f "$file" ]; then
+      # Omit directories named like a license file
+      continue
+    fi
     # Copy license files under the source
     if echo $file | grep -e '^\./\.'; then
       # Omit files under hidden directory

--- a/v3.23/ros/jazzy/ros-jazzy-rclpy/disable-flaky-test.patch
+++ b/v3.23/ros/jazzy/ros-jazzy-rclpy/disable-flaky-test.patch
@@ -1,5 +1,5 @@
 diff --git a/test/test_timer.py b/test/test_timer.py
-index 394f750..dbe095c 100644
+index 9ca7363..3ff1326 100644
 --- a/test/test_timer.py
 +++ b/test/test_timer.py
 @@ -101,54 +101,54 @@ def test_number_callbacks(period):
@@ -39,7 +39,7 @@ index 394f750..dbe095c 100644
 -                        executor.spin_once(timeout_sec=period / 10)
 -                    assert [] == callbacks
 -
--                    # Reenable timer and make sure callbacks are received again
+-                    # Re-enable timer and make sure callbacks are received again
 -                    timer.reset()
 -                    assert not timer.is_canceled()
 -                    begin_time = time.time()
@@ -87,7 +87,7 @@ index 394f750..dbe095c 100644
 +#                         executor.spin_once(timeout_sec=period / 10)
 +#                     assert [] == callbacks
 +#
-+#                     # Reenable timer and make sure callbacks are received again
++#                     # Re-enable timer and make sure callbacks are received again
 +#                     timer.reset()
 +#                     assert not timer.is_canceled()
 +#                     begin_time = time.time()


### PR DESCRIPTION
Started as the second instance of the pattern in #1282 — a stale patch blocking the jazzy auto-update PRs at `prepare` — but fixing that exposed a deeper problem: the published jazzy-3.20 repository ships an ABI-inconsistent fastrtps stack, which is what has actually been failing rclpy's `check()` all along (and breaks the published packages for end users, too). This PR fixes both.

## Part 1: refresh `disable-flaky-test.patch` for rclpy 7.1.11

rclpy 7.1.11 changes one line of `test/test_timer.py`, and it lands inside the very function this patch comments out:

```diff
-                    # Reenable timer and make sure callbacks are received again
+                    # Re-enable timer and make sure callbacks are received again
```

`disable-flaky-test.patch` comments out `test_cancel_reset` by rewriting all 54 of its lines, so that line appears in the hunk both as removed context and as replacement. One upstream character breaks the match:

```
Hunk #1 FAILED at 101.
>>> ERROR: ros-jazzy-rclpy: prepare failed
```

The patch is regenerated against the 7.1.11 tree (`patch -p1 --dry-run` verified: old fails, new applies, `fix-test.patch` still applies). The version bump rides along for the same reason as #1282: the refreshed patch matches 7.1.11 only. Both jazzy trees move to 7.1.11; their APKBUILDs are regenerated with current ros-abuild-docker, so `check()` runs `ctest -j1` (alpine-ros/ros-abuild-docker#196) and `package()` survives directories in the license sweep (alpine-ros/ros-abuild-docker#194).

## Part 2: rebuild the jazzy-3.20 fastrtps consumer stack

With the patch fixed, `check()` on jazzy-3.20 still failed 32 of 56 tests, every one dying at node creation with Fast DDS's

```
RuntimeError: This member is not been selected
```

This is not a CI-only problem. The same error reproduces with nothing but published packages — `apk add ros-jazzy-rclpy` (7.1.9) and `rclpy.create_node()` dies. The 3.20 repository is internally inconsistent: `rmw-fastrtps-*` 8.4.3-r0 were built against fastrtps 2.14.6 headers, but the fastrtps 2.14.6 build itself kept failing on the license-directory bug (alpine-ros/ros-abuild-docker#194), so the repository still serves 2.14.5. Fast DDS is not ABI compatible across that patch release for its consumers.

Swap experiments with locally rebuilt packages pin it down — what matters is that the consumers were built against the fastrtps they run with:

| runtime fastrtps | rmw-fastrtps | result |
|---|---|---|
| 2.14.5 (published) | 8.4.3-r0 (published) | `create_node` fails |
| 2.14.6 | 8.4.3-r0 (published) | `create_node` fails |
| 2.14.5 (published) | 8.4.4 (rebuilt vs 2.14.6) | `create_node` fails |
| 2.14.6 | 8.4.4 (rebuilt vs 2.14.6) | `create_node` OK |

fastrtps + rmw alone is still not enough: rclpy's full test suite then segfaults in `serialize_message` (2/56), because the typesupport packages are still from the 2.14.5 era. So the whole set of packages linking fastrtps moves together:

| package | change |
|---|---|
| fastrtps | 2.14.5 → 2.14.6 (buildable now that `package()` skips the license directory) |
| rmw-fastrtps-shared-cpp / -cpp / -dynamic-cpp | 8.4.3 → 8.4.4 (released upstream meanwhile) |
| rosidl-typesupport-fastrtps-c / -cpp | → 3.6.4 |
| rosidl-dynamic-typesupport / -fastrtps | same version, `pkgrel` bump to force the rebuild |

## Verification

A dependency-ordered ros-abuild run of all eight stack packages plus rclpy 7.1.11 on 3.20-jazzy, using the current ros-abuild image:

```
ros-jazzy-fastrtps                       package() OK (license dir skipped)
ros-jazzy-rmw-fastrtps-shared-cpp        13/13 tests
ros-jazzy-rmw-fastrtps-cpp                6/6
ros-jazzy-rmw-fastrtps-dynamic-cpp        6/6
ros-jazzy-rosidl-typesupport-fastrtps-c  10/10
ros-jazzy-rosidl-typesupport-fastrtps-cpp 10/10
ros-jazzy-rclpy                          56/56  (was 32 failures)
```

With a healthy stack the serialized (`ctest -j1`) rclpy check finishes in 3m35s — the 40-minute runs seen before were inflated by the mass failures and timeouts.

The same ABI rule explains why the previous 3.23 healing needed the manual `pkgrel` bumps of fastrtps and rmw-fastrtps in #1215.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
