### PR TITLE
ros-jazzy-class-loader: immortalize global singletons to fix exit-time segfault on musl

### DIFF
--- a/v3.23/ros/jazzy/ros-jazzy-class-loader/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-class-loader/APKBUILD
@@ -1,7 +1,7 @@
 pkgname=ros-jazzy-class-loader
 _pkgname=class_loader
 pkgver=2.7.0
-pkgrel=0
+pkgrel=1
 pkgdesc="$_pkgname package for ROS jazzy"
 url="http://ros.org/wiki/class_loader"
 arch="all"

--- a/v3.23/ros/jazzy/ros-jazzy-class-loader/immortalize-global-singletons.patch
+++ b/v3.23/ros/jazzy/ros-jazzy-class-loader/immortalize-global-singletons.patch
@@ -1,0 +1,53 @@
+diff --git a/src/class_loader_core.cpp b/src/class_loader_core.cpp
+index 632f8c2..7605118 100644
+--- a/src/class_loader_core.cpp
++++ b/src/class_loader_core.cpp
+@@ -45,19 +45,22 @@ namespace impl
+ 
+ std::recursive_mutex & getLoadedLibraryVectorMutex()
+ {
+-  static std::recursive_mutex m;
++  // Leaked intentionally: on musl, dlclose() does not unload libraries, so
++  // static destructors of dlopen()ed plugin libraries run at process exit
++  // and may still call into these singletons after their normal destruction.
++  static std::recursive_mutex & m = *new std::recursive_mutex();
+   return m;
+ }
+ 
+ std::recursive_mutex & getPluginBaseToFactoryMapMapMutex()
+ {
+-  static std::recursive_mutex m;
++  static std::recursive_mutex & m = *new std::recursive_mutex();
+   return m;
+ }
+ 
+ BaseToFactoryMapMap & getGlobalPluginBaseToFactoryMapMap()
+ {
+-  static BaseToFactoryMapMap instance;
++  static BaseToFactoryMapMap & instance = *new BaseToFactoryMapMap();
+   return instance;
+ }
+ 
+@@ -74,19 +77,19 @@ FactoryMap & getFactoryMapForBaseClass(const std::string & typeid_base_class_nam
+ 
+ MetaObjectGraveyardVector & getMetaObjectGraveyard()
+ {
+-  static MetaObjectGraveyardVector instance;
++  static MetaObjectGraveyardVector & instance = *new MetaObjectGraveyardVector();
+   return instance;
+ }
+ 
+ LibraryVector & getLoadedLibraryVector()
+ {
+-  static LibraryVector instance;
++  static LibraryVector & instance = *new LibraryVector();
+   return instance;
+ }
+ 
+ std::string & getCurrentlyLoadingLibraryNameReference()
+ {
+-  static std::string library_name;
++  static std::string & library_name = *new std::string();
+   return library_name;
+ }
+ 


### PR DESCRIPTION
Second blocker for the jazzy-3.23 auto-update (after #1289): `rclcpp_components`' `test_component_manager_api` dies with SIGSEGV **after all of its tests pass**:

```
[  PASSED  ] 2 tests.
-- run_test.py: return code -11
```

## Root cause: a musl/glibc lifecycle difference in class_loader

Plugin libraries register their factories through static proxy objects whose destructors unregister from class_loader's global registry (the `unique_ptr` deleter in `class_loader_core.hpp`). The registry lives in function-local static singletons.

- **glibc**: `dlclose()` unloads the plugin library and runs the proxies' destructors at that moment, while the singletons are still alive. Fine.
- **musl**: `dlclose()` never unloads. The proxies' destructors are deferred to process exit — by which point the singletons (whose `atexit` registration happened *later* than the proxies', at first use) have already been destroyed. The destructor walks a destroyed map under a destroyed mutex.

gdb at the crash site:

```
#0  class_loader::impl::registerPlugin<...>::{lambda(AbstractMetaObjectBase*)#1}::operator()
        at class_loader/class_loader_core.hpp:280
...
#6  (anonymous namespace)::ProxyExec2::~ProxyExec2  at test/components/test_component.cpp:67
#7  __funcs_on_exit ()  at src/exit/atexit.c:34
#8  exit (code=0)
```

The failure is **independent of the rclcpp_components version**: 28.1.17 — currently published, built on an older toolchain — fails identically when rebuilt today. Same "rebuild it and it breaks" family as the fastrtps ABI skew and the GCC 15 assertion aborts.

## Change

Allocate the six global singletons with `new` and never destroy them — the standard immortal-singleton pattern. The OS reclaims the memory at exit; in exchange, every stage of shutdown, however late, sees valid state. `pkgrel` bump to rebuild and republish.

Fixing class_loader alone heals every plugin consumer (rclcpp_components, pluginlib users — nav2, image_transport, …) with no dependent rebuilds: the singletons live in `libclass_loader.so`.

## Verification

One dependency-ordered ros-abuild run on 3.23-jazzy with this patch plus the pending update's rcl/rclcpp/rclcpp_components:

```
ros-jazzy-class-loader        8/8 tests
ros-jazzy-rcl                78/78
ros-jazzy-rclcpp            124/124
ros-jazzy-rclcpp-components   7/7   (was 6/7: exit segfault)
```

## Rollout note

aports-ci builds the PR **head** SHA, so the open update PR #1292 cannot pick this fix up by re-running. After this merges: close #1292 and re-run the updater; the fresh jazzy-3.23 branch will carry this patch and rebuild class_loader (pkgrel diff) before rclcpp_components in the same run.

The same latent bug exists on every other tree (humble, 3.20) and will surface there on the next rebuild of any plugin-using package; the patch can be copied over when those trees are next touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
