### PR TITLE
ros-jazzy-nav2-behavior-tree: update to 1.3.12 and fix tests for BT.CPP 4.9 and an upstream off-by-one

### DIFF
--- a/v3.23/ros/jazzy/ros-jazzy-nav2-behavior-tree/APKBUILD
+++ b/v3.23/ros/jazzy/ros-jazzy-nav2-behavior-tree/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=ros-jazzy-nav2-behavior-tree
 _pkgname=nav2_behavior_tree
-pkgver=1.3.11
+pkgver=1.3.12
 pkgrel=0
 pkgdesc="$_pkgname package for ROS jazzy"
 url="https://index.ros.org/p/$_pkgname"
@@ -34,7 +34,7 @@ fi
 rosinstall="- git:
     local-name: nav2_behavior_tree
     uri: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/nav2_behavior_tree/1.3.11-1
+    version: release/jazzy/nav2_behavior_tree/1.3.12-1
 "
 
 prepare() {
@@ -88,7 +88,10 @@ check() {
   cd build
   make install DESTDIR="$builddir"/tmp/pkg
   if [ $(make -q test > /dev/null 2> /dev/null; echo $?) -eq 1 ]; then
-    make test 2>&1 | tee $checklog
+    # Run tests one at a time: ROS tests share the default DDS domain, and
+    # upstream only ever runs them sequentially. The -j1 is explicit because
+    # ctest otherwise picks up parallelism from MAKEFLAGS.
+    ctest -j1 2>&1 | tee $checklog
   fi
 }
 
@@ -159,6 +162,10 @@ package() {
       -iname "copying*" -or \
       -iname "gnu-*gpl*" \
     | while read file; do
+    if [ ! -f "$file" ]; then
+      # Omit directories named like a license file
+      continue
+    fi
     # Copy license files under the source
     if echo $file | grep -e '^\./\.'; then
       # Omit files under hidden directory

--- a/v3.23/ros/jazzy/ros-jazzy-nav2-behavior-tree/fix-tests-for-btcpp49-and-oob.patch
+++ b/v3.23/ros/jazzy/ros-jazzy-nav2-behavior-tree/fix-tests-for-btcpp49-and-oob.patch
@@ -1,0 +1,75 @@
+diff --git a/src/behavior_tree_engine.cpp b/src/behavior_tree_engine.cpp
+index a9b43c7..fbcca45 100644
+--- a/src/behavior_tree_engine.cpp
++++ b/src/behavior_tree_engine.cpp
+@@ -76,6 +76,14 @@ BehaviorTreeEngine::run(
+           1.0 / (loopRate.period().count() * 1.0e-9));
+       }
+     }
++  } catch (const BT::NodeExecutionError & ex) {
++    RCLCPP_ERROR(
++      rclcpp::get_logger("BehaviorTreeEngine"),
++      "BT Exception at Node: [%s] (Path: %s). Original error: %s. Exiting with failure.",
++      ex.failedNode().registration_name.c_str(),
++      ex.failedNode().node_path.c_str(),
++      ex.originalMessage().c_str());
++    return BtStatus::FAILED;
+   } catch (const std::exception & ex) {
+     RCLCPP_ERROR(
+       rclcpp::get_logger("BehaviorTreeEngine"),
+diff --git a/test/plugins/control/test_pipeline_sequence.cpp b/test/plugins/control/test_pipeline_sequence.cpp
+index 517ee1f..72edfde 100644
+--- a/test/plugins/control/test_pipeline_sequence.cpp
++++ b/test/plugins/control/test_pipeline_sequence.cpp
+@@ -62,7 +62,7 @@ PipelineSequenceTestFixture::third_child_ = nullptr;
+ TEST_F(PipelineSequenceTestFixture, test_failure_on_idle_child)
+ {
+   first_child_->changeStatus(BT::NodeStatus::IDLE);
+-  EXPECT_THROW(bt_node_->executeTick(), std::runtime_error);
++  EXPECT_THROW(bt_node_->executeTick(), BT::NodeExecutionError);
+ }
+ 
+ TEST_F(PipelineSequenceTestFixture, test_failure)
+diff --git a/test/plugins/control/test_recovery_node.cpp b/test/plugins/control/test_recovery_node.cpp
+index 8292703..dfe3265 100644
+--- a/test/plugins/control/test_recovery_node.cpp
++++ b/test/plugins/control/test_recovery_node.cpp
+@@ -103,10 +103,10 @@ TEST_F(RecoveryNodeTestFixture, test_running)
+ TEST_F(RecoveryNodeTestFixture, test_failure_on_idle_child)
+ {
+   first_child_->changeStatus(BT::NodeStatus::IDLE);
+-  EXPECT_THROW(bt_node_->executeTick(), BT::LogicError);
++  EXPECT_THROW(bt_node_->executeTick(), BT::NodeExecutionError);
+   first_child_->changeStatus(BT::NodeStatus::FAILURE);
+   second_child_->changeStatus(BT::NodeStatus::IDLE);
+-  EXPECT_THROW(bt_node_->executeTick(), BT::LogicError);
++  EXPECT_THROW(bt_node_->executeTick(), BT::NodeExecutionError);
+ }
+ 
+ TEST_F(RecoveryNodeTestFixture, test_success_one_retry)
+diff --git a/test/plugins/control/test_round_robin_node.cpp b/test/plugins/control/test_round_robin_node.cpp
+index 7daa91c..07ae0e3 100644
+--- a/test/plugins/control/test_round_robin_node.cpp
++++ b/test/plugins/control/test_round_robin_node.cpp
+@@ -58,7 +58,7 @@ std::shared_ptr<nav2_behavior_tree::DummyNode> RoundRobinNodeTestFixture::third_
+ TEST_F(RoundRobinNodeTestFixture, test_failure_on_idle_child)
+ {
+   first_child_->changeStatus(BT::NodeStatus::IDLE);
+-  EXPECT_THROW(bt_node_->executeTick(), BT::LogicError);
++  EXPECT_THROW(bt_node_->executeTick(), BT::NodeExecutionError);
+ }
+ 
+ TEST_F(RoundRobinNodeTestFixture, test_failure)
+diff --git a/test/plugins/decorator/test_path_longer_on_approach.cpp b/test/plugins/decorator/test_path_longer_on_approach.cpp
+index 5d521e2..1cc0f56 100644
+--- a/test/plugins/decorator/test_path_longer_on_approach.cpp
++++ b/test/plugins/decorator/test_path_longer_on_approach.cpp
+@@ -137,7 +137,7 @@ TEST_F(PathLongerOnApproachTestFixture, test_tick)
+ 
+   // set new path on blackboard
+   new_path.poses.resize(11);
+-  for (unsigned int i = 0; i <= new_path.poses.size(); i++) {
++  for (unsigned int i = 0; i < new_path.poses.size(); i++) {
+     // Assuming distance between waypoints to be 1.5m
+     new_path.poses[i].pose.position.x = 1.5 * i;
+   }


### PR DESCRIPTION
Third blocker for the jazzy-3.23 auto-update, behind #1289 and #1295. `nav2_behavior_tree` 1.3.12 fails 4 of 67 tests when built on 3.23, for two independent reasons:

## 1. behaviortree-cpp 4.9 changed an exception type (3 tests)

When a child node returns IDLE, BT.CPP now throws `BT::NodeExecutionError` instead of `BT::LogicError`:

```
Expected: bt_node_->executeTick() throws an exception of type BT::LogicError.
  Actual: it throws BT::NodeExecutionError with description
          "Exception in node '' []: A child node must never return IDLE".
```

Upstream already fixed this on the jazzy branch right after the 1.3.12 release ([`f3f5d1f6` "Backport #5987 to Jazzy"](https://github.com/ros-navigation/navigation2/commit/f3f5d1f6)). The patch backports it verbatim, including the `NodeExecutionError` catch added to `behavior_tree_engine.cpp`.

## 2. Off-by-one in test_path_longer_on_approach (1 test)

```cpp
new_path.poses.resize(11);
for (unsigned int i = 0; i <= new_path.poses.size(); i++) {  // writes poses[11]
```

GCC 15's libstdc++ hardening turns the out-of-bounds `operator[]` into an assertion abort (`return code -6`). On glibc the write lands in spare capacity or corrupts the heap silently, which is why upstream CI never notices. **The bug is still present on upstream main** — worth reporting upstream. The patch tightens the bound to `<`.

## Verification

Built on 3.23-jazzy with the complete package directory (all pre-existing patches included), together with nav2_common/nav2_msgs/nav2_util at the update's versions:

```
ros-jazzy-nav2-util           20/20 tests
ros-jazzy-nav2-behavior-tree  67/67   (was 63/67)
```

As with #1282/#1284/#1289, the version bump and the patch are inseparable: the exception-type hunks only match the 1.3.12 tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
