### PR TITLE
ros-jazzy-nav2-mppi-controller: fix racy first read in noise generator test (backport of nav2#4933)

### DIFF
--- a/v3.23/ros/jazzy/ros-jazzy-nav2-mppi-controller/fix-flaky-noise-generator-test.patch
+++ b/v3.23/ros/jazzy/ros-jazzy-nav2-mppi-controller/fix-flaky-noise-generator-test.patch
@@ -1,0 +1,72 @@
+diff --git a/test/noise_generator_test.cpp b/test/noise_generator_test.cpp
+index 485cc37..060ad10 100644
+--- a/test/noise_generator_test.cpp
++++ b/test/noise_generator_test.cpp
+@@ -79,21 +79,24 @@ TEST(NoiseGeneratorTest, NoiseGeneratorMain)
+   mppi::models::State state;
+   state.reset(settings.batch_size, settings.time_steps);
+ 
+-  // Request an update with no noise yet generated, should result in identical outputs
++  // reset() schedules the initial noise generation on the worker thread.
++  // There is no completion signal, so poll (bounded) until it lands.
+   generator.initialize(settings, false, "test_name", &handler);
+   generator.reset(settings, false);  // sets initial sizing and zeros out noises
+-  generator.setNoisedControls(state, control_sequence);
+-  EXPECT_EQ(state.cvx(0), 0);
+-  EXPECT_EQ(state.cvy(0), 0);
+-  EXPECT_EQ(state.cwz(0), 0);
+-  EXPECT_EQ(state.cvx(9), 9);
+-  EXPECT_EQ(state.cvy(9), 9);
+-  EXPECT_EQ(state.cwz(9), 9);
+-
+-  // Request an update with noise requested
+-  generator.generateNextNoises();
+-  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+-  generator.setNoisedControls(state, control_sequence);
++  for (int i = 0; i != 100; i++) {
++    std::this_thread::sleep_for(std::chrono::milliseconds(10));
++    generator.setNoisedControls(state, control_sequence);
++    if (state.cvx(0) != 0) {break;}
++  }
++
++  // save initial state
++  auto initial_cvx_0 = state.cvx(0);
++  auto initial_cvy_0 = state.cvy(0);
++  auto initial_cwz_0 = state.cwz(0);
++  auto initial_cvx_9 = state.cvx(9);
++  auto initial_cvy_9 = state.cvy(9);
++  auto initial_cwz_9 = state.cwz(9);
++
+   EXPECT_NE(state.cvx(0), 0);
+   EXPECT_EQ(state.cvy(0), 0);  // Not populated in non-holonomic
+   EXPECT_NE(state.cwz(0), 0);
+@@ -102,12 +105,27 @@ TEST(NoiseGeneratorTest, NoiseGeneratorMain)
+   EXPECT_NE(state.cwz(9), 9);
+ 
+   EXPECT_NEAR(state.cvx(0), 0, 0.3);
+-  EXPECT_NEAR(state.cvy(0), 0, 0.3);
+   EXPECT_NEAR(state.cwz(0), 0, 0.3);
+   EXPECT_NEAR(state.cvx(9), 9, 0.3);
+-  EXPECT_NEAR(state.cvy(9), 9, 0.3);
+   EXPECT_NEAR(state.cwz(9), 9, 0.3);
+ 
++  // Request an update with noise requested; poll until the regenerated
++  // noises replace the previous ones.
++  generator.generateNextNoises();
++  for (int i = 0; i != 100; i++) {
++    std::this_thread::sleep_for(std::chrono::milliseconds(10));
++    generator.setNoisedControls(state, control_sequence);
++    if (state.cvx(0) != initial_cvx_0) {break;}
++  }
++
++  // Ensure the state has changed after generating new noises
++  EXPECT_NE(state.cvx(0), initial_cvx_0);
++  EXPECT_EQ(state.cvy(0), initial_cvy_0);  // Not populated in non-holonomic
++  EXPECT_NE(state.cwz(0), initial_cwz_0);
++  EXPECT_NE(state.cvx(9), initial_cvx_9);
++  EXPECT_EQ(state.cvy(9), initial_cvy_9);  // Not populated in non-holonomic
++  EXPECT_NE(state.cwz(9), initial_cwz_9);
++
+   // Test holonomic setting
+   generator.reset(settings, true);  // Now holonomically
+   generator.generateNextNoises();


### PR DESCRIPTION
Follow-up to #1297: the jazzy-3.23 auto-update (#1303) now clears every deterministic blocker, but failed 2 of 3 otherwise-identical runs on `nav2_mppi_controller`'s `NoiseGeneratorTest.NoiseGeneratorMain`.

## The race

The test asserts that the noised controls are still zero right after `reset()`:

```cpp
generator.initialize(settings, false, "test_name", &handler);
generator.reset(settings, false);  // sets initial sizing and zeros out noises
generator.setNoisedControls(state, control_sequence);
EXPECT_EQ(state.cvx(0), 0);
```

But with `regenerate_noises=true` (which the test sets), `reset()` hands noise generation to the worker thread and notifies it — whether the first read sees zeros is a race between the reader and the worker. On the CI machine the worker usually wins (2/3 runs); on a slower local machine it never did across 7 full builds, which is why local verification missed it.

## Fix

Backport of [ros-navigation/navigation2#4933 "Fix flaky mppi test"](https://github.com/ros-navigation/navigation2/pull/4933), which fixed exactly this upstream: accept that `reset()` schedules generation, wait 100 ms, assert that noise **is** present, then assert the values **change** after the next `generateNextNoises()`. Adapted to the jazzy tree's indexing (`state.cvx(9)` instead of main's `state.cvx(0, 9)`).

## Patch-only, no version bump

Same pattern as #1297: the test file is identical at the current 1.3.11 and the pending 1.3.12 (the patch dry-runs clean on both), and no other patch touches it, so application order stays free. Nothing rebuilds until the update PR lands.

## Verification

- 1.3.12 package check on 3.23-jazzy: 16/16
- the rebuilt test binary: 20/20 consecutive standalone runs (the unfixed test loses the race roughly half the time on fast machines)

After this merges: close #1303 and re-run the updater; the remaining known flake is depth_image_proc's camera_info sync (1 of 3 runs), so the odds of a green run improve substantially.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
