### PR TITLE
jazzy-3.23: opt depth_image_proc and rcl into flaky-test retries (check_retries)

### DIFF
--- a/v3.23/ros/jazzy/ros-jazzy-depth-image-proc/apkbuild_hook.sh
+++ b/v3.23/ros/jazzy/ros-jazzy-depth-image-proc/apkbuild_hook.sh
@@ -1,0 +1,5 @@
+apkbuild_hook() {
+  # test_point_cloud_xyz waits a fixed window for camera_info delivery
+  # and loses that race on a loaded builder
+  check_retries=3
+}

--- a/v3.23/ros/jazzy/ros-jazzy-rcl/apkbuild_hook.sh
+++ b/v3.23/ros/jazzy/ros-jazzy-rcl/apkbuild_hook.sh
@@ -1,3 +1,6 @@
 apkbuild_hook() {
   depends_dev="${depends_dev} ros-jazzy-rmw-implementation-cmake ros-jazzy-rmw-implementation-cmake-dev"
+  # discovery-dependent tests (test_graph, test_subscription, ...) flake
+  # when other builder containers share the docker bridge
+  check_retries=3
 }


### PR DESCRIPTION
Now that alpine-ros/ros-abuild-docker#197 is merged, a package can mark its tests as flaky with `check_retries=N` in its `apkbuild_hook.sh` — failing tests get up to N attempts (`ctest --repeat until-pass:N`), and a test that never passes still fails the build. Opt in the two known offenders from the jazzy-3.23 update runs:

| package | flake | evidence |
|---|---|---|
| depth_image_proc | `test_point_cloud_xyz` waits a fixed window for camera_info synchronization and loses that race on a loaded builder | 1 of 3 otherwise-identical #1303 runs |
| rcl | discovery-dependent tests (`test_graph`, `test_subscription`, …) flake when other builder containers run concurrently on the shared docker bridge — `domain_coordinator` only coordinates within one container, and the isolate patches pin fixed domain ids | the concurrent-legs runs of #1285/#1286/#1288/#1292 |

(The third known flake, nav2_costmap_2d's `test_collision_checker`, stays disabled: it fired in 3 of 5 runs, so even three attempts would leak ~20 % — it needs an actual fix upstream.)

The retry-capable `check()` only exists in APKBUILDs generated with the new template. The next updater run regenerates everything with it, and hooks are read at build time, so this takes effect with the upcoming update PR. No version bumps — nothing rebuilds until then, and CI on this PR is setup-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
